### PR TITLE
CI: initial commit of ci and publish piplines

### DIFF
--- a/.github/workflows/ci-casper-client-rs.yml
+++ b/.github/workflows/ci-casper-client-rs.yml
@@ -1,0 +1,53 @@
+---
+name: ci-casper-client-rs
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build_and_test:
+    strategy:
+      matrix:
+        #https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+        os: [ubuntu-18.04, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: rustfmt, clippy
+      # Add some needed dependencies
+
+      - name: Fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check
+
+      - name: Audit
+        uses: actions-rs/cargo@v1
+        with:
+          command: audit
+          args: --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2020-0159
+
+      - name: Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-targets
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/.github/workflows/publish-casper-client-rs.yml
+++ b/.github/workflows/publish-casper-client-rs.yml
@@ -1,0 +1,24 @@
+---
+name: publish-casper-client-rs
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+
+      - name: Crate Publish
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --token ${{ secrets.crates_io_token }}


### PR DESCRIPTION
Adds:
- `ci-casper-client-rs.yml`
    - utilizes matrix build for ubuntu 18.04/20.04
- `publish-casper-client-rs.yml`
    - will publish to crates.io

Notes: There's more to come for publishing but will need to be worked out incrementally. See Epic: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/233

Tickets for this PR:
- https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/234
- https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/235