### PR TITLE
ZH-SRE-I239: Upload client debs to github release

### DIFF
--- a/.github/workflows/publish-casper-client-deb.yml
+++ b/.github/workflows/publish-casper-client-deb.yml
@@ -1,0 +1,47 @@
+---
+name: publish-casper-client-deb
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build_deb:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-18.04
+            code_name: bionic
+          - os: ubuntu-20.04
+            code_name: focal
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: rustfmt, clippy
+
+      - name: Cargo Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+
+      - name: Cargo Deb
+        uses: actions-rs/cargo@v1
+        with:
+          command: deb
+          args: -p casper-client --no-build --variant ${{ matrix.code_name }}
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/debian/casper-client*
+          tag: ${{ github.ref }}
+          file_glob: true

--- a/.github/workflows/publish-casper-client-deb.yml
+++ b/.github/workflows/publish-casper-client-deb.yml
@@ -26,13 +26,19 @@ jobs:
           profile: minimal
           components: rustfmt, clippy
 
-      - name: Cargo Build
+      - name: Install cargo deb
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-deb
+
+      - name: Cargo build
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release
 
-      - name: Cargo Deb
+      - name: Cargo deb
         uses: actions-rs/cargo@v1
         with:
           command: deb

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,13 +62,21 @@ casper-mainnet = ["casper-node/casper-mainnet"]
 features = ["vendored-openssl"]
 revision = "0"
 assets = [
-    ["../target/release/casper-client", "/usr/bin/casper-client", "755"],
+    ["./target/release/casper-client", "/usr/bin/casper-client", "755"],
 ]
 extended-description = """
 Package for Casper Client to connect to Casper Node.
 
 For information on using package, see https://github.com/CasperLabs/casper-node
 """
+
+[package.metadata.deb.variants.bionic]
+name = "casper-client"
+revision = "0+bionic"
+
+[package.metadata.deb.variants.focal]
+name = "casper-client"
+revision = "0+focal"
 
 [package.metadata.rpm]
 package = "casper-client"


### PR DESCRIPTION
Adds:
- `.github/workflows/publish-casper-client-deb.yml`
    - Builds and uploads client debian packages for `18.04` and `20.04` to github release
    
Tested in my fork:
- Release: https://github.com/TomVasile/casper-client-rs/releases/tag/v9.9.9
- Run: https://github.com/TomVasile/casper-client-rs/actions/runs/1546245790

Ticket: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/239
Epic: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/233