### PR TITLE
ZH-SRE-I250: initial commit of nightly scheduled test 

### DIFF
--- a/.github/workflows/ci-casper-client-rs.yml
+++ b/.github/workflows/ci-casper-client-rs.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         #https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-        os: [ubuntu-18.04, ubuntu-latest]
+        os: [ubuntu-18.04, ubuntu-20.04]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/nightly-scheduled-test.yml
+++ b/.github/workflows/nightly-scheduled-test.yml
@@ -1,0 +1,35 @@
+---
+name: nightly-scheduled-test
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # runs every day at midnight
+    - cron: "0 0 * * *"
+
+jobs:
+  nightly-cargo-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+      - name: Slack Notification
+        uses: ravsamhq/notify-slack-action@v1
+        if: always()
+        with:
+          status: ${{ job.status }}
+          notification_title: "*{repo}*"
+          message_format: "{emoji} *{workflow}:* *{status_message}* in <{repo_url}|{repo}@{branch}> on <{commit_url}|{commit_sha}>"
+          footer: "<{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nightly-scheduled-test.yml
+++ b/.github/workflows/nightly-scheduled-test.yml
@@ -9,7 +9,11 @@ on:
 
 jobs:
   nightly-cargo-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
+    runs-on: ${{ matrix.os }}
+
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Adds:
- `.github/workflows/nightly-scheduled-test.yml`
    - runs `cargo test` nightly at `midnight` on both `18.04` and `20.04`
    - status of job written to slack

Non-related change:
- switch `.github/workflows/ci-casper-client-rs.yml` to `20.04` directly instead of `latest`

Ticket: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/250
Epic: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/casper-network/sre/233