### PR TITLE
CI: add os in slack title to differentiate 

### DIFF
--- a/.github/workflows/nightly-scheduled-test.yml
+++ b/.github/workflows/nightly-scheduled-test.yml
@@ -32,7 +32,7 @@ jobs:
         if: always()
         with:
           status: ${{ job.status }}
-          notification_title: "*{repo}*"
+          notification_title: "*{repo}:* ${{ matrix.os }}"
           message_format: "{emoji} *{workflow}:* *{status_message}* in <{repo_url}|{repo}@{branch}> on <{commit_url}|{commit_sha}>"
           footer: "<{run_url}|View Run>"
         env:


### PR DESCRIPTION
Adds:
- change slack notification title to call out OS.