### PR TITLE
Update to match changes in casper-node due to fast-sync feature

### DIFF
--- a/.github/workflows/ci-casper-client-rs.yml
+++ b/.github/workflows/ci-casper-client-rs.yml
@@ -27,7 +27,6 @@ jobs:
           toolchain: stable
           profile: minimal
           components: rustfmt, clippy
-      # Add some needed dependencies
 
       - name: Fmt
         uses: actions-rs/cargo@v1
@@ -46,6 +45,12 @@ jobs:
         with:
           command: clippy
           args: --all-targets
+
+      - name: Doc
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --no-deps
 
       - name: Test
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ casper-hashing = "*"
 casper-types = "*"
 clap = "2"
 humantime = "2"
+itertools = "0.10.3"
 jsonrpc-lite = "0.5.0"
 once_cell = "1"
 rand = "0.8.4"
@@ -54,15 +55,14 @@ warp = "0.3.2"
 warp-json-rpc = "0.3.0"
 
 [features]
-default = ["ffi", "casper-mainnet"]
+default = ["ffi"]
 ffi = ["cbindgen"]
-casper-mainnet = ["casper-node/casper-mainnet"]
 
 [patch.crates-io]
-casper-execution-engine = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
-casper-node = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
-casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
-casper-types = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
+casper-execution-engine = { git = "https://github.com/casper-network/casper-node", branch = "feat-fast-sync" }
+casper-node = { git = "https://github.com/casper-network/casper-node", branch = "feat-fast-sync" }
+casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "feat-fast-sync" }
+casper-types = { git = "https://github.com/casper-network/casper-node", branch = "feat-fast-sync" }
 
 [package.metadata.deb]
 features = ["vendored-openssl"]

--- a/lib/deploy.rs
+++ b/lib/deploy.rs
@@ -526,7 +526,7 @@ mod tests {
     #[test]
     fn should_sign_deploy() {
         let bytes = SAMPLE_DEPLOY.as_bytes();
-        let mut deploy = Deploy::read_deploy(bytes).unwrap();
+        let deploy = Deploy::read_deploy(bytes).unwrap();
         deploy
             .is_valid()
             .unwrap_or_else(|error| panic!("{} - {:#?}", error, deploy));

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -20,6 +20,7 @@ pub mod ffi;
 pub mod keygen;
 mod parsing;
 mod rpc;
+pub mod types;
 mod validation;
 
 use std::{convert::TryInto, fs, io::Cursor};

--- a/lib/types.rs
+++ b/lib/types.rs
@@ -1,0 +1,14 @@
+//! Various data types of the Casper network.
+
+mod block;
+mod era_end;
+mod proof;
+mod timestamp;
+
+pub use block::{
+    v1::validate_hashes as validate_block_hashes_v1,
+    v2::validate_hashes as validate_block_hashes_v2, Block, BlockBody, BlockHash, BlockHeader,
+};
+pub use era_end::{EraEnd, EraReport, Reward, ValidatorWeight};
+pub use proof::Proof;
+pub use timestamp::Timestamp;

--- a/lib/types/block.rs
+++ b/lib/types/block.rs
@@ -1,0 +1,327 @@
+pub mod v1;
+pub mod v2;
+
+use std::fmt::{self, Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+use casper_hashing::Digest;
+use casper_types::{
+    bytesrepr::{self, ToBytes},
+    crypto::PublicKey,
+    EraId, ProtocolVersion,
+};
+
+#[cfg(doc)]
+use crate::types::{validate_block_hashes_v1, validate_block_hashes_v2};
+use crate::types::{EraEnd, Proof, Timestamp};
+
+/// A cryptographic hash uniquely identifying a [`Block`].
+///
+/// # Note
+///
+/// The type of this field is currently the same for all versions of blocks, and furthermore it is
+/// always a hash over the block's header.  However, *how* the hash is calculated can be different.
+///
+/// There are two separate functions to allow for validation of the block given the different
+/// hash mechanisms: [`validate_block_hashes_v1`] and [`validate_block_hashes_v2`].
+#[derive(
+    Copy, Clone, Default, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize, Debug,
+)]
+#[serde(deny_unknown_fields)]
+pub struct BlockHash(Digest);
+
+impl BlockHash {
+    /// Returns a new `BlockHash`.
+    pub fn new(digest: Digest) -> Self {
+        BlockHash(digest)
+    }
+
+    /// Returns a copy of the wrapped `Digest`.
+    pub fn inner(&self) -> Digest {
+        self.0
+    }
+}
+
+impl Display for BlockHash {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "{}", self.0)
+    }
+}
+
+impl ToBytes for BlockHash {
+    fn write_bytes(&self, buffer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.0.write_bytes(buffer)
+    }
+
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        self.0.to_bytes()
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.0.serialized_length()
+    }
+}
+
+/// The header portion of a block.
+#[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct BlockHeader {
+    parent_hash: BlockHash,
+    state_root_hash: Digest,
+    body_hash: Digest,
+    random_bit: bool,
+    accumulated_seed: Digest,
+    era_end: Option<EraEnd>,
+    timestamp: Timestamp,
+    era_id: EraId,
+    height: u64,
+    protocol_version: ProtocolVersion,
+}
+
+impl BlockHeader {
+    /// Returns the parent block's hash.
+    pub fn parent_hash(&self) -> BlockHash {
+        self.parent_hash
+    }
+
+    /// Returns the root hash of global state after executing the deploys in this block.
+    pub fn state_root_hash(&self) -> Digest {
+        self.state_root_hash
+    }
+
+    /// Returns the hash of the body of this block.
+    ///
+    /// # Note
+    ///
+    /// See [`validate_block_hashes_v1`] and [`validate_block_hashes_v2`] for further details on the
+    /// different ways in which this hash can be calculated.
+    pub fn body_hash(&self) -> Digest {
+        self.body_hash
+    }
+
+    /// Returns the random bit held in this block.
+    pub fn random_bit(&self) -> bool {
+        self.random_bit
+    }
+
+    /// Returns the accumulated seed held in this block.
+    pub fn accumulated_seed(&self) -> Digest {
+        self.accumulated_seed
+    }
+
+    /// Returns the `EraEnd`, where `Some` means this is a "switch block", i.e. the final block of
+    /// the specified era.
+    pub fn era_end(&self) -> Option<&EraEnd> {
+        self.era_end.as_ref()
+    }
+
+    /// Returns the creation timestamp of this block.
+    pub fn timestamp(&self) -> Timestamp {
+        self.timestamp
+    }
+
+    /// Returns the ID of the era in which this block belongs.
+    pub fn era_id(&self) -> EraId {
+        self.era_id
+    }
+
+    /// Returns the height of the block in the blockchain.
+    pub fn height(&self) -> u64 {
+        self.height
+    }
+
+    /// Returns the protocol version of the network at the time this block was created.
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.protocol_version
+    }
+}
+
+impl Display for BlockHeader {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(
+            formatter,
+            "block header parent hash {}, post-state hash {}, body hash {}, \
+            random bit {}, accumulated seed {}, timestamp {}",
+            self.parent_hash.0,
+            self.state_root_hash,
+            self.body_hash,
+            self.random_bit,
+            self.accumulated_seed,
+            self.timestamp,
+        )?;
+        if let Some(era_end) = &self.era_end {
+            write!(formatter, ", era_end {}", era_end)?;
+        }
+        Ok(())
+    }
+}
+
+impl ToBytes for BlockHeader {
+    fn write_bytes(&self, buffer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.parent_hash.write_bytes(buffer)?;
+        self.state_root_hash.write_bytes(buffer)?;
+        self.body_hash.write_bytes(buffer)?;
+        self.random_bit.write_bytes(buffer)?;
+        self.accumulated_seed.write_bytes(buffer)?;
+        self.era_end.write_bytes(buffer)?;
+        self.timestamp.write_bytes(buffer)?;
+        self.era_id.write_bytes(buffer)?;
+        self.height.write_bytes(buffer)?;
+        self.protocol_version.write_bytes(buffer)
+    }
+
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = vec![];
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.parent_hash.serialized_length()
+            + self.state_root_hash.serialized_length()
+            + self.body_hash.serialized_length()
+            + self.random_bit.serialized_length()
+            + self.accumulated_seed.serialized_length()
+            + self.era_end.serialized_length()
+            + self.timestamp.serialized_length()
+            + self.era_id.serialized_length()
+            + self.height.serialized_length()
+            + self.protocol_version.serialized_length()
+    }
+}
+
+/// The body portion of a block.
+#[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct BlockBody {
+    proposer: PublicKey,
+    // TODO: make this a `DeployHash`.
+    deploy_hashes: Vec<Digest>,
+    // TODO: make this a `DeployHash`.
+    transfer_hashes: Vec<Digest>,
+}
+
+impl BlockBody {
+    /// Returns the public key of the validator which proposed this block.
+    pub fn proposer(&self) -> &PublicKey {
+        &self.proposer
+    }
+
+    /// Returns the hashes of all non-transfer deploys included in this block.
+    pub fn deploy_hashes(&self) -> &Vec<Digest> {
+        &self.deploy_hashes
+    }
+
+    /// Returns the hashes of all transfers included in this block.
+    pub fn transfer_hashes(&self) -> &Vec<Digest> {
+        &self.transfer_hashes
+    }
+}
+
+impl Display for BlockBody {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "{:?}", self)
+    }
+}
+
+impl ToBytes for BlockBody {
+    fn write_bytes(&self, buffer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.proposer.write_bytes(buffer)?;
+        self.deploy_hashes.write_bytes(buffer)?;
+        self.transfer_hashes.write_bytes(buffer)
+    }
+
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = vec![];
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.proposer.serialized_length()
+            + self.deploy_hashes.serialized_length()
+            + self.transfer_hashes.serialized_length()
+    }
+}
+
+/// A block; the core component of the Casper linear blockchain.
+#[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct Block {
+    hash: BlockHash,
+    header: BlockHeader,
+    body: BlockBody,
+    proofs: Vec<Proof>,
+}
+
+impl Block {
+    /// Returns the hash uniquely identifying this block.
+    ///
+    /// # Note
+    ///
+    /// See [`validate_block_hashes_v1`] and [`validate_block_hashes_v2`] for further details on the
+    /// different ways in which this hash can be calculated.
+    pub fn hash(&self) -> &BlockHash {
+        &self.hash
+    }
+
+    /// Returns the header portion of the block.
+    pub fn header(&self) -> &BlockHeader {
+        &self.header
+    }
+
+    /// Returns the body portion of the block.
+    pub fn body(&self) -> &BlockBody {
+        &self.body
+    }
+
+    /// Returns the proofs; the public keys and signatures of the validators which signed the block.
+    pub fn proofs(&self) -> &Vec<Proof> {
+        &self.proofs
+    }
+}
+
+impl Display for Block {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "executed block {}, parent hash {}, post-state hash {}, body hash {}, \
+             random bit {}, timestamp {}, {}, height {}, protocol version: {}",
+            self.hash,
+            self.header.parent_hash,
+            self.header.state_root_hash,
+            self.header.body_hash,
+            self.header.random_bit,
+            self.header.timestamp,
+            self.header.era_id,
+            self.header.height,
+            self.header.protocol_version
+        )?;
+        if let Some(era_end) = &self.header.era_end {
+            write!(formatter, ", era-end: {}", era_end)?;
+        }
+        Ok(())
+    }
+}
+
+impl ToBytes for Block {
+    fn write_bytes(&self, buffer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        // Note: the proofs are deliberately not part of the bytesrepr serialized block.
+        self.hash.write_bytes(buffer)?;
+        self.header.write_bytes(buffer)?;
+        self.body.write_bytes(buffer)
+    }
+
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = vec![];
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.hash.serialized_length()
+            + self.header.serialized_length()
+            + self.body.serialized_length()
+    }
+}

--- a/lib/types/block/v1.rs
+++ b/lib/types/block/v1.rs
@@ -1,0 +1,42 @@
+use casper_hashing::Digest;
+use casper_types::bytesrepr::ToBytes;
+
+#[cfg(doc)]
+use crate::types::BlockHeader;
+use crate::{
+    types::{Block, BlockHash},
+    validation::ValidateResponseError,
+};
+
+/// Cryptographically validates the hashes of the given block, using the initial version of hashing.
+///
+/// The validation involves hashing the serialized header to ensure it matches the claimed
+/// [`Block::hash`] value, and then hashing the serialized body to ensure it matches the claimed
+/// [`BlockHeader::body_hash`] value.
+///
+/// For this version of hashing, a simple Blake2b hash of the serialized data is performed.
+///
+/// # Note
+///
+/// No validation of the proofs is performed in this function.
+pub fn validate_hashes(block: &Block) -> Result<(), ValidateResponseError> {
+    let serialized_header = block.header.to_bytes()?;
+    let actual_block_header_hash = BlockHash::new(Digest::hash(&serialized_header));
+    if block.hash != actual_block_header_hash {
+        return Err(ValidateResponseError::BlockHashMismatch {
+            block: Box::new(block.clone()),
+            actual_block_header_hash,
+        });
+    }
+
+    let serialized_body = block.body.to_bytes()?;
+    let actual_block_body_hash = Digest::hash(&serialized_body);
+    if block.header.body_hash != actual_block_body_hash {
+        return Err(ValidateResponseError::BodyHashMismatch {
+            block: Box::new(block.clone()),
+            actual_block_body_hash,
+        });
+    }
+
+    Ok(())
+}

--- a/lib/types/block/v2.rs
+++ b/lib/types/block/v2.rs
@@ -1,0 +1,165 @@
+use std::{cmp::Reverse, collections::BTreeMap};
+
+use itertools::Itertools;
+
+use casper_hashing::Digest;
+use casper_types::{bytesrepr::ToBytes, crypto::PublicKey};
+
+use crate::{
+    types::{Block, BlockBody, BlockHash, BlockHeader, EraEnd, EraReport},
+    validation::ValidateResponseError,
+};
+
+/// Cryptographically validates the hashes of the given block, using the second version of hashing.
+///
+/// The validation involves hashing the header to ensure it matches the claimed [`Block::hash`]
+/// value, and then hashing the body to ensure it matches the claimed [`BlockHeader::body_hash`]
+/// value.
+///
+/// For this version of hashing, the block's header and body are notionally split into chunks
+/// (for the purpose of accommodating Merkle Proofs of the chunks) and the resulting hash of the
+/// header and body are thus Merkle root hashes, with Blake2b hashing used throughout.
+///
+/// # Note
+///
+/// No validation of the proofs is performed in this function.
+pub fn validate_hashes(block: &Block) -> Result<(), ValidateResponseError> {
+    let actual_block_header_hash = hash_header(&block.header)?;
+    if block.hash != actual_block_header_hash {
+        return Err(ValidateResponseError::BlockHashMismatch {
+            block: Box::new(block.clone()),
+            actual_block_header_hash,
+        });
+    }
+
+    let actual_block_body_hash = hash_body(&block.body)?;
+    if block.header.body_hash != actual_block_body_hash {
+        return Err(ValidateResponseError::BodyHashMismatch {
+            block: Box::new(block.clone()),
+            actual_block_body_hash,
+        });
+    }
+
+    Ok(())
+}
+
+fn hash_header(
+    BlockHeader {
+        parent_hash,
+        era_id,
+        body_hash,
+        state_root_hash,
+        era_end,
+        height,
+        timestamp,
+        protocol_version,
+        random_bit,
+        accumulated_seed,
+    }: &BlockHeader,
+) -> Result<BlockHash, ValidateResponseError> {
+    let hashed_era_end = match era_end {
+        None => Digest::SENTINEL_NONE,
+        Some(era_end) => hash_era_end(era_end)?,
+    };
+
+    let hashed_era_id = Digest::hash(era_id.to_bytes()?);
+    let hashed_height = Digest::hash(height.to_bytes()?);
+    let hashed_timestamp = Digest::hash(timestamp.to_bytes()?);
+    let hashed_protocol_version = Digest::hash(protocol_version.to_bytes()?);
+    let hashed_random_bit = Digest::hash(random_bit.to_bytes()?);
+
+    let digest = Digest::hash_slice_rfold(&[
+        hashed_protocol_version,
+        parent_hash.0,
+        hashed_era_end,
+        *body_hash,
+        hashed_era_id,
+        *state_root_hash,
+        hashed_height,
+        hashed_timestamp,
+        hashed_random_bit,
+        *accumulated_seed,
+    ]);
+    Ok(BlockHash::new(digest))
+}
+
+fn hash_era_end(
+    EraEnd {
+        next_era_validator_weights,
+        era_report,
+    }: &EraEnd,
+) -> Result<Digest, ValidateResponseError> {
+    let mut descending_validator_weight_hashed_pairs = vec![];
+    for validator_weight in next_era_validator_weights
+        .iter()
+        .sorted_by_key(|validator_weight| Reverse(validator_weight.weight()))
+    {
+        let validator_hash = Digest::hash(validator_weight.validator().to_bytes()?);
+        let weight_hash = Digest::hash(validator_weight.weight().to_bytes()?);
+        descending_validator_weight_hashed_pairs
+            .push(Digest::hash_pair(&validator_hash, &weight_hash));
+    }
+    let hashed_next_era_validator_weights =
+        Digest::hash_merkle_tree(descending_validator_weight_hashed_pairs);
+    let hashed_era_report = hash_era_report(era_report)?;
+    Ok(Digest::hash_slice_rfold(&[
+        hashed_next_era_validator_weights,
+        hashed_era_report,
+    ]))
+}
+
+fn hash_era_report(
+    EraReport {
+        equivocators,
+        inactive_validators,
+        rewards,
+    }: &EraReport,
+) -> Result<Digest, ValidateResponseError> {
+    let hashed_equivocators = hash_slice_of_public_keys(equivocators)?;
+    let hashed_inactive_validators = hash_slice_of_public_keys(inactive_validators)?;
+    let rewards: BTreeMap<PublicKey, u64> = rewards
+        .iter()
+        .map(|reward| (reward.validator().clone(), reward.amount()))
+        .collect();
+
+    let hashed_rewards = Digest::hash_btree_map(&rewards)?;
+
+    Ok(Digest::hash_slice_rfold(&[
+        hashed_equivocators,
+        hashed_rewards,
+        hashed_inactive_validators,
+    ]))
+}
+
+fn hash_slice_of_public_keys(public_keys: &[PublicKey]) -> Result<Digest, ValidateResponseError> {
+    let serialized_public_keys = public_keys
+        .iter()
+        .map(|validator| validator.to_bytes())
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Digest::hash_merkle_tree(
+        serialized_public_keys.iter().map(Digest::hash),
+    ))
+}
+
+fn hash_body(
+    BlockBody {
+        deploy_hashes,
+        transfer_hashes,
+        proposer,
+    }: &BlockBody,
+) -> Result<Digest, ValidateResponseError> {
+    let proposer_digest =
+        Digest::hash_pair(Digest::hash(&proposer.to_bytes()?), Digest::SENTINEL_RFOLD);
+
+    let transfer_hashes_digest = Digest::hash_pair(
+        Digest::hash_merkle_tree(transfer_hashes.iter().cloned().map(Digest::from)),
+        proposer_digest,
+    );
+
+    let deploy_hashes_digest = Digest::hash_pair(
+        Digest::hash_merkle_tree(deploy_hashes.iter().cloned().map(Digest::from)),
+        transfer_hashes_digest,
+    );
+
+    Ok(deploy_hashes_digest)
+}

--- a/lib/types/era_end.rs
+++ b/lib/types/era_end.rs
@@ -1,0 +1,165 @@
+use std::{
+    collections::BTreeMap,
+    fmt::{self, Display, Formatter},
+};
+
+use serde::{Deserialize, Serialize};
+
+use casper_types::{
+    bytesrepr::{self, ToBytes},
+    crypto::PublicKey,
+    U512,
+};
+
+/// A reward to be given to the specified validator.
+#[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct Reward {
+    validator: PublicKey,
+    amount: u64,
+}
+
+impl Reward {
+    /// Returns the validator's public key.
+    pub fn validator(&self) -> &PublicKey {
+        &self.validator
+    }
+
+    /// Returns the number of rewarded motes.
+    pub fn amount(&self) -> u64 {
+        self.amount
+    }
+}
+
+/// Equivocation and reward information included in switch blocks.
+#[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct EraReport {
+    pub(super) equivocators: Vec<PublicKey>,
+    pub(super) rewards: Vec<Reward>,
+    pub(super) inactive_validators: Vec<PublicKey>,
+}
+
+impl EraReport {
+    /// Returns the collection of validators which have equivocated in this era.
+    pub fn equivocators(&self) -> &Vec<PublicKey> {
+        &self.equivocators
+    }
+
+    /// Returns the collection of rewards due.
+    pub fn rewards(&self) -> &Vec<Reward> {
+        &self.rewards
+    }
+
+    /// Returns the collection of validators which were marked inactive in this era.
+    pub fn inactive_validators(&self) -> &Vec<PublicKey> {
+        &self.inactive_validators
+    }
+}
+
+impl ToBytes for EraReport {
+    fn write_bytes(&self, buffer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        let rewards: BTreeMap<PublicKey, u64> = self
+            .rewards
+            .iter()
+            .map(|reward| (reward.validator.clone(), reward.amount))
+            .collect();
+
+        self.equivocators.write_bytes(buffer)?;
+        rewards.write_bytes(buffer)?;
+        self.inactive_validators.write_bytes(buffer)
+    }
+
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = vec![];
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        let rewards: BTreeMap<PublicKey, u64> = self
+            .rewards
+            .iter()
+            .map(|reward| (reward.validator.clone(), reward.amount))
+            .collect();
+        self.equivocators.serialized_length()
+            + rewards.serialized_length()
+            + self.inactive_validators.serialized_length()
+    }
+}
+
+/// The amount of weight a given validator has.
+#[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct ValidatorWeight {
+    validator: PublicKey,
+    weight: U512,
+}
+
+impl ValidatorWeight {
+    /// Returns the validator's public key.
+    pub fn validator(&self) -> &PublicKey {
+        &self.validator
+    }
+
+    /// Returns the validator's weight.
+    pub fn weight(&self) -> U512 {
+        self.weight
+    }
+}
+
+/// Information included in switch blocks about the era the block concludes and the subsequent era.
+#[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct EraEnd {
+    /// The report on the era just concluded.
+    pub(super) era_report: EraReport,
+    /// The validator weights for the subsequent era.
+    pub(super) next_era_validator_weights: Vec<ValidatorWeight>,
+}
+
+impl EraEnd {
+    /// Returns the report on the era just concluded.
+    pub fn era_report(&self) -> &EraReport {
+        &self.era_report
+    }
+
+    /// Returns the validator weights for the subsequent era.
+    pub fn next_era_validator_weights(&self) -> &Vec<ValidatorWeight> {
+        &self.next_era_validator_weights
+    }
+}
+
+impl Display for EraEnd {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "{:?}", self.era_report)
+    }
+}
+
+impl ToBytes for EraEnd {
+    fn write_bytes(&self, buffer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        let next_era_validator_weights: BTreeMap<PublicKey, U512> = self
+            .next_era_validator_weights
+            .iter()
+            .map(|validator_weight| (validator_weight.validator.clone(), validator_weight.weight))
+            .collect();
+
+        self.era_report.write_bytes(buffer)?;
+        next_era_validator_weights.write_bytes(buffer)
+    }
+
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = vec![];
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        let next_era_validator_weights: BTreeMap<PublicKey, U512> = self
+            .next_era_validator_weights
+            .iter()
+            .map(|validator_weight| (validator_weight.validator.clone(), validator_weight.weight))
+            .collect();
+        self.era_report.serialized_length() + next_era_validator_weights.serialized_length()
+    }
+}

--- a/lib/types/proof.rs
+++ b/lib/types/proof.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Serialize};
+
+use casper_types::crypto::{PublicKey, Signature};
+
+#[cfg(doc)]
+use crate::types::Block;
+
+/// A pair of public key and signature, representing proof of having signed a given piece of data,
+/// generally a [`Block`].
+#[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct Proof {
+    public_key: PublicKey,
+    signature: Signature,
+}
+
+impl Proof {
+    /// Returns the public key.
+    pub fn public_key(&self) -> &PublicKey {
+        &self.public_key
+    }
+
+    /// Returns the signature.
+    pub fn signature(&self) -> &Signature {
+        &self.signature
+    }
+}

--- a/lib/types/timestamp.rs
+++ b/lib/types/timestamp.rs
@@ -1,0 +1,80 @@
+use std::{
+    fmt::{self, Display, Formatter},
+    str::FromStr,
+    time::{Duration, SystemTime},
+};
+
+use humantime::TimestampError;
+use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Serializer};
+
+use casper_types::bytesrepr::{self, ToBytes};
+
+/// A timestamp newtype, representing a specific moment in time.
+#[derive(Copy, Clone, Default, PartialOrd, Ord, PartialEq, Eq, Hash, Debug)]
+pub struct Timestamp(u64);
+
+impl Display for Timestamp {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        match SystemTime::UNIX_EPOCH.checked_add(Duration::from_millis(self.0)) {
+            Some(system_time) => write!(
+                formatter,
+                "{}",
+                humantime::format_rfc3339_millis(system_time)
+            ),
+            None => write!(
+                formatter,
+                "invalid Timestamp: {} ms after the Unix epoch",
+                self.0
+            ),
+        }
+    }
+}
+
+impl FromStr for Timestamp {
+    type Err = TimestampError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let system_time = humantime::parse_rfc3339_weak(value)?;
+        let inner = system_time
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map_err(|_| TimestampError::OutOfRange)?
+            .as_millis() as u64;
+        Ok(Timestamp(inner))
+    }
+}
+
+impl Serialize for Timestamp {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        if serializer.is_human_readable() {
+            self.to_string().serialize(serializer)
+        } else {
+            self.0.serialize(serializer)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Timestamp {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        if deserializer.is_human_readable() {
+            let value_as_string = String::deserialize(deserializer)?;
+            Timestamp::from_str(&value_as_string).map_err(SerdeError::custom)
+        } else {
+            let inner = u64::deserialize(deserializer)?;
+            Ok(Timestamp(inner))
+        }
+    }
+}
+
+impl ToBytes for Timestamp {
+    fn write_bytes(&self, buffer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.0.write_bytes(buffer)
+    }
+
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        self.0.to_bytes()
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.0.serialized_length()
+    }
+}


### PR DESCRIPTION
This PR makes the `feat-fast-sync` branch compatible with the same branch of `casper-node`.

Many of the JSON-specific types have been copied here as the first step to breaking the dependency of the client on the node library.

In the near future, an approach should be settled to allow testing that the copied types stay in sync.