### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/ci-casper-client-rs.yml
+++ b/.github/workflows/ci-casper-client-rs.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: audit
-          args: --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2022-0013
+          args: --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2020-0159
 
       - name: Clippy
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "casper-client"
 version = "1.4.3" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
-edition = "2018"
+edition = "2021"
 description = "A client library and binary for interacting with the Casper network"
 documentation = "https://docs.rs/casper-client"
 readme = "README.md"
@@ -20,33 +20,34 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-async-trait = "0.1.51"
+async-trait = "0.1.52"
 base16 = "0.2.1"
 base64 = "0.13.0"
 casper-execution-engine = "*"
 casper-node = "*"
 casper-hashing = "*"
 casper-types = "*"
-clap = "2"
+clap = { version = "3", features = ["cargo"] }
+clap_complete = "3"
 humantime = "2"
 itertools = "0.10.3"
 jsonrpc-lite = "0.5.0"
 once_cell = "1"
-rand = "0.8.4"
-reqwest = { version = "0.11.6", features = ["json"] }
+rand = "0.8.5"
+reqwest = { version = "0.11.9", features = ["json"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
 thiserror = "1"
-tokio = { version = "1.14", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.17", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 
 [dev-dependencies]
 anyhow = "1"
-futures = "0.3.18"
-hyper = "0.14.15"
+futures = "0.3.21"
+hyper = "0.14.17"
 semver = "1"
 serde = "1"
-tower = "0.4.11"
+tower = "0.4.12"
 warp = "0.3.2"
 warp-json-rpc = "0.3.0"
 

--- a/src/account_address.rs
+++ b/src/account_address.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use std::str;
 
-use clap::{App, ArgMatches, SubCommand};
+use clap::{ArgMatches, Command};
 
 use casper_client::Error;
 use casper_types::{AsymmetricType, PublicKey};
@@ -17,19 +17,19 @@ enum DisplayOrder {
 pub struct GenerateAccountHash {}
 
 #[async_trait]
-impl<'a, 'b> ClientCommand<'a, 'b> for GenerateAccountHash {
+impl ClientCommand for GenerateAccountHash {
     const NAME: &'static str = "account-address";
     const ABOUT: &'static str = "Generates an account hash from a given public key";
 
-    fn build(display_order: usize) -> App<'a, 'b> {
-        SubCommand::with_name(Self::NAME)
+    fn build(display_order: usize) -> Command<'static> {
+        Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)
             .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
             .arg(common::public_key::arg(DisplayOrder::PublicKey as usize))
     }
 
-    async fn run(matches: &ArgMatches<'a>) -> Result<Success, Error> {
+    async fn run(matches: &ArgMatches) -> Result<Success, Error> {
         let hex_public_key = common::public_key::get(matches)?;
         let public_key = PublicKey::from_hex(&hex_public_key).map_err(|error| {
             eprintln!("Can't parse {} as a public key: {}", hex_public_key, error);

--- a/src/block/get.rs
+++ b/src/block/get.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use std::str;
 
-use clap::{App, ArgMatches, SubCommand};
+use clap::{ArgMatches, Command};
 
 use casper_client::Error;
 use casper_node::rpcs::chain::GetBlock;
@@ -17,12 +17,12 @@ enum DisplayOrder {
 }
 
 #[async_trait]
-impl<'a, 'b> ClientCommand<'a, 'b> for GetBlock {
+impl ClientCommand for GetBlock {
     const NAME: &'static str = "get-block";
     const ABOUT: &'static str = "Retrieves a block from the network";
 
-    fn build(display_order: usize) -> App<'a, 'b> {
-        SubCommand::with_name(Self::NAME)
+    fn build(display_order: usize) -> Command<'static> {
+        Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)
             .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
@@ -35,7 +35,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetBlock {
             ))
     }
 
-    async fn run(matches: &ArgMatches<'a>) -> Result<Success, Error> {
+    async fn run(matches: &ArgMatches) -> Result<Success, Error> {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);

--- a/src/block/transfers.rs
+++ b/src/block/transfers.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use std::str;
 
-use clap::{App, ArgMatches, SubCommand};
+use clap::{ArgMatches, Command};
 
 use casper_client::Error;
 use casper_node::rpcs::chain::GetBlockTransfers;
@@ -17,12 +17,12 @@ enum DisplayOrder {
 }
 
 #[async_trait]
-impl<'a, 'b> ClientCommand<'a, 'b> for GetBlockTransfers {
+impl ClientCommand for GetBlockTransfers {
     const NAME: &'static str = "get-block-transfers";
     const ABOUT: &'static str = "Retrieves all transfers for a block from the network";
 
-    fn build(display_order: usize) -> App<'a, 'b> {
-        SubCommand::with_name(Self::NAME)
+    fn build(display_order: usize) -> Command<'static> {
+        Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)
             .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
@@ -35,7 +35,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetBlockTransfers {
             ))
     }
 
-    async fn run(matches: &ArgMatches<'a>) -> Result<Success, Error> {
+    async fn run(matches: &ArgMatches) -> Result<Success, Error> {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use clap::{App, ArgMatches};
+use clap::{ArgMatches, Command};
 use jsonrpc_lite::JsonRpc;
 
 use casper_client::Error;
@@ -19,12 +19,12 @@ impl From<JsonRpc> for Success {
 }
 
 #[async_trait]
-pub trait ClientCommand<'a, 'b> {
+pub trait ClientCommand {
     const NAME: &'static str;
     const ABOUT: &'static str;
-    /// Constructs the clap `SubCommand` and returns the clap `App`.
-    fn build(display_order: usize) -> App<'a, 'b>;
+    /// Constructs the clap subcommand.
+    fn build(display_order: usize) -> Command<'static>;
 
     /// Parses the arg matches and runs the subcommand.
-    async fn run(matches: &ArgMatches<'a>) -> Result<Success, Error>;
+    async fn run(matches: &ArgMatches) -> Result<Success, Error>;
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -15,22 +15,26 @@ pub mod verbose {
     use super::*;
 
     pub const ARG_NAME: &str = "verbose";
-    const ARG_NAME_SHORT: &str = "v";
+    const ARG_NAME_SHORT: char = 'v';
     const ARG_HELP: &str =
         "Generates verbose output, e.g. prints the RPC request.  If repeated by using '-vv' then \
         all output will be extra verbose, meaning that large JSON strings will be shown in full";
 
-    pub fn arg(order: usize) -> Arg<'static, 'static> {
-        Arg::with_name(ARG_NAME)
+    pub fn arg(order: usize) -> Arg<'static> {
+        Arg::new(ARG_NAME)
             .short(ARG_NAME_SHORT)
             .required(false)
-            .multiple(true)
+            .multiple_occurrences(true)
             .help(ARG_HELP)
             .display_order(order)
     }
 
     pub fn get(matches: &ArgMatches) -> u64 {
-        matches.occurrences_of(ARG_NAME)
+        if matches.is_valid_arg(ARG_NAME) {
+            matches.occurrences_of(ARG_NAME)
+        } else {
+            0
+        }
     }
 }
 
@@ -39,23 +43,23 @@ pub mod node_address {
     use super::*;
 
     const ARG_NAME: &str = "node-address";
-    const ARG_SHORT: &str = "n";
+    const ARG_SHORT: char = 'n';
     const ARG_VALUE_NAME: &str = "HOST:PORT";
     const ARG_DEFAULT: &str = "http://localhost:7777";
     const ARG_HELP: &str = "Hostname or IP and port of node on which HTTP service is running";
 
-    pub fn arg(order: usize) -> Arg<'static, 'static> {
-        Arg::with_name(ARG_NAME)
+    pub fn arg(order: usize) -> Arg<'static> {
+        Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
-            .required(true)
+            .required(false)
             .default_value(ARG_DEFAULT)
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
             .display_order(order)
     }
 
-    pub fn get<'a>(matches: &'a ArgMatches) -> &'a str {
+    pub fn get(matches: &ArgMatches) -> &str {
         matches
             .value_of(ARG_NAME)
             .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME))
@@ -72,8 +76,8 @@ pub mod rpc_id {
         "JSON-RPC identifier, applied to the request and returned in the response. If not \
         provided, a random integer will be assigned";
 
-    pub fn arg(order: usize) -> Arg<'static, 'static> {
-        Arg::with_name(ARG_NAME)
+    pub fn arg(order: usize) -> Arg<'static> {
+        Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .required(false)
             .value_name(ARG_VALUE_NAME)
@@ -81,7 +85,7 @@ pub mod rpc_id {
             .display_order(order)
     }
 
-    pub fn get<'a>(matches: &'a ArgMatches) -> &'a str {
+    pub fn get(matches: &ArgMatches) -> &str {
         matches.value_of(ARG_NAME).unwrap_or_default()
     }
 }
@@ -91,21 +95,20 @@ pub mod secret_key {
     use super::*;
 
     const ARG_NAME: &str = "secret-key";
-    const ARG_SHORT: &str = "k";
+    const ARG_SHORT: char = 'k';
     const ARG_VALUE_NAME: &str = super::ARG_PATH;
     const ARG_HELP: &str = "Path to secret key file";
 
-    pub fn arg(order: usize) -> Arg<'static, 'static> {
-        Arg::with_name(ARG_NAME)
+    pub fn arg(order: usize) -> Arg<'static> {
+        Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
-            .required(true)
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
             .display_order(order)
     }
 
-    pub fn get<'a>(matches: &'a ArgMatches) -> &'a str {
+    pub fn get(matches: &ArgMatches) -> &str {
         matches
             .value_of(ARG_NAME)
             .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME))
@@ -117,7 +120,7 @@ pub mod force {
     use super::*;
 
     pub const ARG_NAME: &str = "force";
-    const ARG_NAME_SHORT: &str = "f";
+    const ARG_SHORT: char = 'f';
     const ARG_HELP_SINGULAR: &str =
         "If this flag is passed and the output file already exists, it will be overwritten. \
         Without this flag, if the output file already exists, the command will fail";
@@ -125,10 +128,10 @@ pub mod force {
         "If this flag is passed, any existing output files will be overwritten. Without this flag, \
         if any output file exists, no output files will be generated and the command will fail";
 
-    pub fn arg(order: usize, singular: bool) -> Arg<'static, 'static> {
-        Arg::with_name(ARG_NAME)
+    pub fn arg(order: usize, singular: bool) -> Arg<'static> {
+        Arg::new(ARG_NAME)
             .long(ARG_NAME)
-            .short(ARG_NAME_SHORT)
+            .short(ARG_SHORT)
             .required(false)
             .help(if singular {
                 ARG_HELP_SINGULAR
@@ -148,12 +151,12 @@ pub mod state_root_hash {
     use super::*;
 
     const ARG_NAME: &str = "state-root-hash";
-    const ARG_SHORT: &str = "s";
+    const ARG_SHORT: char = 's';
     const ARG_VALUE_NAME: &str = super::ARG_HEX_STRING;
     const ARG_HELP: &str = "Hex-encoded hash of the state root";
 
-    pub(crate) fn arg(order: usize) -> Arg<'static, 'static> {
-        Arg::with_name(ARG_NAME)
+    pub(crate) fn arg(order: usize) -> Arg<'static> {
+        Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
             .required(true)
@@ -162,7 +165,7 @@ pub mod state_root_hash {
             .display_order(order)
     }
 
-    pub(crate) fn get<'a>(matches: &'a ArgMatches) -> &'a str {
+    pub(crate) fn get(matches: &ArgMatches) -> &str {
         matches
             .value_of(ARG_NAME)
             .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME))
@@ -174,14 +177,14 @@ pub mod block_identifier {
     use super::*;
 
     const ARG_NAME: &str = "block-identifier";
-    const ARG_SHORT: &str = "b";
+    const ARG_SHORT: char = 'b';
     const ARG_VALUE_NAME: &str = "HEX STRING OR INTEGER";
     const ARG_HELP: &str =
         "Hex-encoded block hash or height of the block. If not given, the last block added to the \
         chain as known at the given node will be used";
 
-    pub(crate) fn arg(order: usize) -> Arg<'static, 'static> {
-        Arg::with_name(ARG_NAME)
+    pub(crate) fn arg(order: usize) -> Arg<'static> {
+        Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
             .required(false)
@@ -190,7 +193,7 @@ pub mod block_identifier {
             .display_order(order)
     }
 
-    pub(crate) fn get<'a>(matches: &'a ArgMatches) -> &'a str {
+    pub(crate) fn get(matches: &ArgMatches) -> &str {
         matches.value_of(ARG_NAME).unwrap_or_default()
     }
 }
@@ -210,8 +213,8 @@ mod sealed_public_key {
         arg_name: &'static str,
         arg_help: &'static str,
         required: bool,
-    ) -> Arg<'static, 'static> {
-        Arg::with_name(arg_name)
+    ) -> Arg<'static> {
+        Arg::new(arg_name)
             .long(arg_name)
             .required(required)
             .value_name(ARG_VALUE_NAME)
@@ -258,7 +261,7 @@ pub(super) mod public_key {
     use super::*;
 
     const ARG_NAME: &str = "public-key";
-    const ARG_SHORT: &str = "p";
+    const ARG_SHORT: char = 'p';
     const IS_REQUIRED: bool = true;
     const ARG_HELP: &str =
         "This must be a properly formatted public key. The public key may instead be read in from \
@@ -266,7 +269,7 @@ pub(super) mod public_key {
         should be one of the two public key files generated via the `keygen` subcommand; \
         \"public_key_hex\" or \"public_key.pem\"";
 
-    pub fn arg(order: usize) -> Arg<'static, 'static> {
+    pub fn arg(order: usize) -> Arg<'static> {
         sealed_public_key::arg(order, ARG_NAME, ARG_HELP, IS_REQUIRED).short(ARG_SHORT)
     }
 
@@ -289,7 +292,7 @@ pub(super) mod session_account {
         argument. The file should be one of the two public key files generated via the `keygen`
         subcommand; \"public_key_hex\" or \"public_key.pem\"";
 
-    pub fn arg(display_order: usize) -> Arg<'static, 'static> {
+    pub fn arg(display_order: usize) -> Arg<'static> {
         sealed_public_key::arg(display_order, ARG_NAME, ARG_HELP, IS_REQUIRED)
     }
 

--- a/src/deploy/get.rs
+++ b/src/deploy/get.rs
@@ -1,7 +1,7 @@
 use std::str;
 
 use async_trait::async_trait;
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{Arg, ArgMatches, Command};
 
 use casper_client::Error;
 use casper_node::rpcs::info::GetDeploy;
@@ -24,15 +24,15 @@ mod deploy_hash {
     const ARG_VALUE_NAME: &str = "HEX STRING";
     const ARG_HELP: &str = "Hex-encoded deploy hash";
 
-    pub(super) fn arg() -> Arg<'static, 'static> {
-        Arg::with_name(ARG_NAME)
+    pub(super) fn arg() -> Arg<'static> {
+        Arg::new(ARG_NAME)
             .required(true)
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
             .display_order(DisplayOrder::DeployHash as usize)
     }
 
-    pub(super) fn get<'a>(matches: &'a ArgMatches) -> &'a str {
+    pub(super) fn get(matches: &ArgMatches) -> &str {
         matches
             .value_of(ARG_NAME)
             .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME))
@@ -40,12 +40,12 @@ mod deploy_hash {
 }
 
 #[async_trait]
-impl<'a, 'b> ClientCommand<'a, 'b> for GetDeploy {
+impl ClientCommand for GetDeploy {
     const NAME: &'static str = "get-deploy";
     const ABOUT: &'static str = "Retrieves a deploy from the network";
 
-    fn build(display_order: usize) -> App<'a, 'b> {
-        SubCommand::with_name(Self::NAME)
+    fn build(display_order: usize) -> Command<'static> {
+        Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)
             .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
@@ -56,7 +56,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetDeploy {
             .arg(deploy_hash::arg())
     }
 
-    async fn run(matches: &ArgMatches<'a>) -> Result<Success, Error> {
+    async fn run(matches: &ArgMatches) -> Result<Success, Error> {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);

--- a/src/deploy/list.rs
+++ b/src/deploy/list.rs
@@ -1,7 +1,7 @@
 use std::str;
 
 use async_trait::async_trait;
-use clap::{App, ArgMatches, SubCommand};
+use clap::{ArgMatches, Command};
 
 use casper_client::{Error, ListDeploysResult};
 use casper_node::rpcs::chain::GetBlockResult;
@@ -19,12 +19,12 @@ enum DisplayOrder {
 pub struct ListDeploys;
 
 #[async_trait]
-impl<'a, 'b> ClientCommand<'a, 'b> for ListDeploys {
+impl ClientCommand for ListDeploys {
     const NAME: &'static str = "list-deploys";
     const ABOUT: &'static str = "Retrieves the list of all deploy hashes in a given block";
 
-    fn build(display_order: usize) -> App<'a, 'b> {
-        SubCommand::with_name(Self::NAME)
+    fn build(display_order: usize) -> Command<'static> {
+        Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)
             .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
@@ -37,7 +37,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for ListDeploys {
             ))
     }
 
-    async fn run(matches: &ArgMatches<'a>) -> Result<Success, Error> {
+    async fn run(matches: &ArgMatches) -> Result<Success, Error> {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);

--- a/src/deploy/make.rs
+++ b/src/deploy/make.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use clap::{App, ArgMatches, SubCommand};
+use clap::{ArgMatches, Command};
 
 use casper_client::{DeployStrParams, Error};
 
@@ -9,15 +9,15 @@ use crate::{command::ClientCommand, common, Success};
 pub struct MakeDeploy;
 
 #[async_trait]
-impl<'a, 'b> ClientCommand<'a, 'b> for MakeDeploy {
+impl ClientCommand for MakeDeploy {
     const NAME: &'static str = "make-deploy";
     const ABOUT: &'static str =
         "Creates a deploy and outputs it to a file or stdout. As a file, the deploy can \
         subsequently be signed by other parties using the 'sign-deploy' subcommand and then sent \
         to the network for execution using the 'send-deploy' subcommand";
 
-    fn build(display_order: usize) -> App<'a, 'b> {
-        let subcommand = SubCommand::with_name(Self::NAME)
+    fn build(display_order: usize) -> Command<'static> {
+        let subcommand = Command::new(Self::NAME)
             .about(Self::ABOUT)
             .arg(creation_common::output::arg())
             .arg(common::force::arg(
@@ -30,7 +30,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for MakeDeploy {
         creation_common::apply_common_creation_options(subcommand, false)
     }
 
-    async fn run(matches: &ArgMatches<'a>) -> Result<Success, Error> {
+    async fn run(matches: &ArgMatches) -> Result<Success, Error> {
         creation_common::show_arg_examples_and_exit_if_required(matches);
 
         let secret_key = common::secret_key::get(matches);

--- a/src/deploy/make_transfer.rs
+++ b/src/deploy/make_transfer.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use clap::{App, ArgMatches, SubCommand};
+use clap::{ArgMatches, Command};
 
 use casper_client::{DeployStrParams, Error};
 
@@ -9,15 +9,15 @@ use crate::{command::ClientCommand, common, Success};
 pub struct MakeTransfer;
 
 #[async_trait]
-impl<'a, 'b> ClientCommand<'a, 'b> for MakeTransfer {
+impl ClientCommand for MakeTransfer {
     const NAME: &'static str = "make-transfer";
     const ABOUT: &'static str =
         "Creates a transfer deploy and outputs it to a file or stdout. As a file, the deploy can \
         subsequently be signed by other parties using the 'sign-deploy' subcommand and then sent \
         to the network for execution using the 'send-deploy' subcommand";
 
-    fn build(display_order: usize) -> App<'a, 'b> {
-        let subcommand = SubCommand::with_name(Self::NAME)
+    fn build(display_order: usize) -> Command<'static> {
+        let subcommand = Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)
             .arg(creation_common::output::arg())
@@ -32,7 +32,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for MakeTransfer {
         creation_common::apply_common_creation_options(subcommand, false)
     }
 
-    async fn run(matches: &ArgMatches<'a>) -> Result<Success, Error> {
+    async fn run(matches: &ArgMatches) -> Result<Success, Error> {
         creation_common::show_arg_examples_and_exit_if_required(matches);
 
         let amount = transfer::amount::get(matches);

--- a/src/deploy/put.rs
+++ b/src/deploy/put.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use clap::{App, ArgMatches, SubCommand};
+use clap::{ArgMatches, Command};
 
 use casper_client::{DeployStrParams, Error};
 use casper_node::rpcs::account::PutDeploy;
@@ -8,12 +8,12 @@ use super::creation_common::{self, DisplayOrder};
 use crate::{command::ClientCommand, common, Success};
 
 #[async_trait]
-impl<'a, 'b> ClientCommand<'a, 'b> for PutDeploy {
+impl ClientCommand for PutDeploy {
     const NAME: &'static str = "put-deploy";
     const ABOUT: &'static str = "Creates a deploy and sends it to the network for execution";
 
-    fn build(display_order: usize) -> App<'a, 'b> {
-        let subcommand = SubCommand::with_name(Self::NAME)
+    fn build(display_order: usize) -> Command<'static> {
+        let subcommand = Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)
             .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
@@ -23,7 +23,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for PutDeploy {
         creation_common::apply_common_creation_options(subcommand, true)
     }
 
-    async fn run(matches: &ArgMatches<'a>) -> Result<Success, Error> {
+    async fn run(matches: &ArgMatches) -> Result<Success, Error> {
         creation_common::show_arg_examples_and_exit_if_required(matches);
 
         let maybe_rpc_id = common::rpc_id::get(matches);

--- a/src/deploy/send.rs
+++ b/src/deploy/send.rs
@@ -1,4 +1,4 @@
-use clap::{App, ArgMatches, SubCommand};
+use clap::{ArgMatches, Command};
 
 use async_trait::async_trait;
 use casper_client::Error;
@@ -9,13 +9,13 @@ use crate::{command::ClientCommand, common, Success};
 pub struct SendDeploy;
 
 #[async_trait]
-impl<'a, 'b> ClientCommand<'a, 'b> for SendDeploy {
+impl ClientCommand for SendDeploy {
     const NAME: &'static str = "send-deploy";
     const ABOUT: &'static str =
         "Reads a previously-saved deploy from a file and sends it to the network for execution";
 
-    fn build(display_order: usize) -> App<'a, 'b> {
-        SubCommand::with_name(Self::NAME)
+    fn build(display_order: usize) -> Command<'static> {
+        Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)
             .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
@@ -26,7 +26,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for SendDeploy {
             .arg(creation_common::input::arg())
     }
 
-    async fn run(matches: &ArgMatches<'a>) -> Result<Success, Error> {
+    async fn run(matches: &ArgMatches) -> Result<Success, Error> {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);

--- a/src/deploy/sign.rs
+++ b/src/deploy/sign.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use clap::{App, ArgMatches, SubCommand};
+use clap::{ArgMatches, Command};
 
 use casper_client::Error;
 
@@ -9,19 +9,20 @@ use crate::{command::ClientCommand, common, Success};
 pub struct SignDeploy;
 
 #[async_trait]
-impl<'a, 'b> ClientCommand<'a, 'b> for SignDeploy {
+impl ClientCommand for SignDeploy {
     const NAME: &'static str = "sign-deploy";
     const ABOUT: &'static str =
         "Reads a previously-saved deploy from a file, cryptographically signs it, and outputs it \
         to a file or stdout";
 
-    fn build(display_order: usize) -> App<'a, 'b> {
-        SubCommand::with_name(Self::NAME)
+    fn build(display_order: usize) -> Command<'static> {
+        Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)
-            .arg(common::secret_key::arg(
-                creation_common::DisplayOrder::SecretKey as usize,
-            ))
+            .arg(
+                common::secret_key::arg(creation_common::DisplayOrder::SecretKey as usize)
+                    .required(true),
+            )
             .arg(creation_common::input::arg())
             .arg(creation_common::output::arg())
             .arg(common::force::arg(
@@ -30,7 +31,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for SignDeploy {
             ))
     }
 
-    async fn run(matches: &ArgMatches<'a>) -> Result<Success, Error> {
+    async fn run(matches: &ArgMatches) -> Result<Success, Error> {
         let input_path = creation_common::input::get(matches);
         let secret_key = common::secret_key::get(matches);
         let maybe_output_path = creation_common::output::get(matches).unwrap_or_default();

--- a/src/deploy/transfer.rs
+++ b/src/deploy/transfer.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{Arg, ArgMatches, Command};
 
 use casper_client::{DeployStrParams, Error};
 
@@ -11,21 +11,21 @@ pub(super) mod amount {
     use super::*;
 
     const ARG_NAME: &str = "amount";
-    const ARG_SHORT: &str = "a";
+    const ARG_SHORT: char = 'a';
     const ARG_VALUE_NAME: &str = "512-BIT INTEGER";
     const ARG_HELP: &str = "The number of motes to transfer";
 
-    pub(in crate::deploy) fn arg() -> Arg<'static, 'static> {
-        Arg::with_name(ARG_NAME)
+    pub(in crate::deploy) fn arg() -> Arg<'static> {
+        Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
-            .required_unless(creation_common::show_arg_examples::ARG_NAME)
+            .required_unless_present(creation_common::show_arg_examples::ARG_NAME)
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
             .display_order(DisplayOrder::TransferAmount as usize)
     }
 
-    pub(in crate::deploy) fn get<'a>(matches: &'a ArgMatches) -> &'a str {
+    pub(in crate::deploy) fn get(matches: &ArgMatches) -> &str {
         matches
             .value_of(ARG_NAME)
             .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME))
@@ -37,7 +37,7 @@ pub(super) mod target_account {
     use super::*;
 
     pub(in crate::deploy) const ARG_NAME: &str = "target-account";
-    const ARG_SHORT: &str = "t";
+    const ARG_SHORT: char = 't';
     const ARG_VALUE_NAME: &str = "FORMATTED STRING";
     const ARG_HELP: &str =
         "Account hash, uref or hex-encoded public key of the account from which the main purse will be used as the \
@@ -45,17 +45,17 @@ pub(super) mod target_account {
 
     // Conflicts with --target-purse, but that's handled via an `ArgGroup` in the subcommand. Don't
     // add a `conflicts_with()` to the arg or the `ArgGroup` fails to work correctly.
-    pub(in crate::deploy) fn arg() -> Arg<'static, 'static> {
-        Arg::with_name(ARG_NAME)
+    pub(in crate::deploy) fn arg() -> Arg<'static> {
+        Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
-            .required_unless(creation_common::show_arg_examples::ARG_NAME)
+            .required_unless_present(creation_common::show_arg_examples::ARG_NAME)
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
             .display_order(DisplayOrder::TransferTargetAccount as usize)
     }
 
-    pub(in crate::deploy) fn get<'a>(matches: &'a ArgMatches) -> &'a str {
+    pub(in crate::deploy) fn get(matches: &ArgMatches) -> &str {
         matches.value_of(ARG_NAME).unwrap_or_default()
     }
 }
@@ -65,21 +65,21 @@ pub(super) mod transfer_id {
     use super::*;
 
     pub(in crate::deploy) const ARG_NAME: &str = "transfer-id";
-    const ARG_SHORT: &str = "i";
+    const ARG_SHORT: char = 'i';
     const ARG_VALUE_NAME: &str = "64-BIT INTEGER";
     const ARG_HELP: &str = "User-defined identifier, permanently associated with the transfer";
 
-    pub(in crate::deploy) fn arg() -> Arg<'static, 'static> {
-        Arg::with_name(ARG_NAME)
+    pub(in crate::deploy) fn arg() -> Arg<'static> {
+        Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
-            .required_unless(creation_common::show_arg_examples::ARG_NAME)
+            .required_unless_present(creation_common::show_arg_examples::ARG_NAME)
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
             .display_order(DisplayOrder::TransferId as usize)
     }
 
-    pub(in crate::deploy) fn get<'a>(matches: &'a ArgMatches) -> &'a str {
+    pub(in crate::deploy) fn get(matches: &ArgMatches) -> &str {
         matches.value_of(ARG_NAME).unwrap_or_default()
     }
 }
@@ -87,12 +87,12 @@ pub(super) mod transfer_id {
 pub struct Transfer {}
 
 #[async_trait]
-impl<'a, 'b> ClientCommand<'a, 'b> for Transfer {
+impl ClientCommand for Transfer {
     const NAME: &'static str = "transfer";
     const ABOUT: &'static str = "Transfers funds between purses";
 
-    fn build(display_order: usize) -> App<'a, 'b> {
-        let subcommand = SubCommand::with_name(Self::NAME)
+    fn build(display_order: usize) -> Command<'static> {
+        let subcommand = Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)
             .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
@@ -104,7 +104,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for Transfer {
         creation_common::apply_common_creation_options(subcommand, true)
     }
 
-    async fn run(matches: &ArgMatches<'a>) -> Result<Success, Error> {
+    async fn run(matches: &ArgMatches) -> Result<Success, Error> {
         creation_common::show_arg_examples_and_exit_if_required(matches);
 
         let amount = amount::get(matches);

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -1,7 +1,7 @@
 use std::str;
 
 use async_trait::async_trait;
-use clap::{App, ArgMatches, SubCommand};
+use clap::{ArgMatches, Command};
 
 use casper_client::Error;
 use casper_node::rpcs::docs::ListRpcs;
@@ -16,12 +16,12 @@ enum DisplayOrder {
 }
 
 #[async_trait]
-impl<'a, 'b> ClientCommand<'a, 'b> for ListRpcs {
+impl ClientCommand for ListRpcs {
     const NAME: &'static str = "list-rpcs";
     const ABOUT: &'static str = "List all currently supported RPCs";
 
-    fn build(display_order: usize) -> App<'a, 'b> {
-        SubCommand::with_name(Self::NAME)
+    fn build(display_order: usize) -> Command<'static> {
+        Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)
             .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
@@ -31,7 +31,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for ListRpcs {
             .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
     }
 
-    async fn run(matches: &ArgMatches<'a>) -> Result<Success, Error> {
+    async fn run(matches: &ArgMatches) -> Result<Success, Error> {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);

--- a/src/get_account_info.rs
+++ b/src/get_account_info.rs
@@ -1,7 +1,7 @@
 use std::str;
 
 use async_trait::async_trait;
-use clap::{App, ArgMatches, SubCommand};
+use clap::{ArgMatches, Command};
 
 use casper_client::Error;
 
@@ -18,12 +18,12 @@ enum DisplayOrder {
 }
 
 #[async_trait]
-impl<'a, 'b> ClientCommand<'a, 'b> for GetAccountInfo {
+impl ClientCommand for GetAccountInfo {
     const NAME: &'static str = "get-account-info";
     const ABOUT: &'static str = "Retrieve account information from the network";
 
-    fn build(display_order: usize) -> App<'a, 'b> {
-        SubCommand::with_name(Self::NAME)
+    fn build(display_order: usize) -> Command<'static> {
+        Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)
             .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
@@ -37,7 +37,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetAccountInfo {
             ))
     }
 
-    async fn run(matches: &ArgMatches<'a>) -> Result<Success, Error> {
+    async fn run(matches: &ArgMatches) -> Result<Success, Error> {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);

--- a/src/get_auction_info.rs
+++ b/src/get_auction_info.rs
@@ -1,7 +1,7 @@
 use std::str;
 
 use async_trait::async_trait;
-use clap::{App, ArgMatches, SubCommand};
+use clap::{ArgMatches, Command};
 
 use casper_client::Error;
 use casper_node::rpcs::state::GetAuctionInfo;
@@ -17,13 +17,13 @@ enum DisplayOrder {
 }
 
 #[async_trait]
-impl<'a, 'b> ClientCommand<'a, 'b> for GetAuctionInfo {
+impl ClientCommand for GetAuctionInfo {
     const NAME: &'static str = "get-auction-info";
     const ABOUT: &'static str =
         "Returns the bids and validators as of either a specific block (by height or hash), or the most recently added block";
 
-    fn build(display_order: usize) -> App<'a, 'b> {
-        SubCommand::with_name(Self::NAME)
+    fn build(display_order: usize) -> Command<'static> {
+        Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)
             .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
@@ -36,7 +36,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetAuctionInfo {
             ))
     }
 
-    async fn run(matches: &ArgMatches<'a>) -> Result<Success, Error> {
+    async fn run(matches: &ArgMatches) -> Result<Success, Error> {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);

--- a/src/get_balance.rs
+++ b/src/get_balance.rs
@@ -1,7 +1,7 @@
 use std::str;
 
 use async_trait::async_trait;
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{Arg, ArgMatches, Command};
 
 use casper_client::Error;
 use casper_node::rpcs::state::GetBalance;
@@ -22,14 +22,14 @@ mod purse_uref {
     use super::*;
 
     const ARG_NAME: &str = "purse-uref";
-    const ARG_SHORT: &str = "p";
+    const ARG_SHORT: char = 'p';
     const ARG_VALUE_NAME: &str = "FORMATTED STRING";
     const ARG_HELP: &str =
         "The URef under which the purse is stored. This must be a properly formatted URef \
         \"uref-<HEX STRING>-<THREE DIGIT INTEGER>\"";
 
-    pub(super) fn arg() -> Arg<'static, 'static> {
-        Arg::with_name(ARG_NAME)
+    pub(super) fn arg() -> Arg<'static> {
+        Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
             .required(true)
@@ -38,7 +38,7 @@ mod purse_uref {
             .display_order(DisplayOrder::PurseURef as usize)
     }
 
-    pub(super) fn get<'a>(matches: &'a ArgMatches) -> &'a str {
+    pub(super) fn get(matches: &ArgMatches) -> &str {
         matches
             .value_of(ARG_NAME)
             .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME))
@@ -46,12 +46,12 @@ mod purse_uref {
 }
 
 #[async_trait]
-impl<'a, 'b> ClientCommand<'a, 'b> for GetBalance {
+impl ClientCommand for GetBalance {
     const NAME: &'static str = "get-balance";
     const ABOUT: &'static str = "Retrieves a purse's balance from the network";
 
-    fn build(display_order: usize) -> App<'a, 'b> {
-        SubCommand::with_name(Self::NAME)
+    fn build(display_order: usize) -> Command<'static> {
+        Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)
             .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
@@ -65,7 +65,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetBalance {
             .arg(purse_uref::arg())
     }
 
-    async fn run(matches: &ArgMatches<'a>) -> Result<Success, Error> {
+    async fn run(matches: &ArgMatches) -> Result<Success, Error> {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);

--- a/src/get_era_info_by_switch_block.rs
+++ b/src/get_era_info_by_switch_block.rs
@@ -1,7 +1,7 @@
 use std::str;
 
 use async_trait::async_trait;
-use clap::{App, ArgMatches, SubCommand};
+use clap::{ArgMatches, Command};
 
 use casper_client::Error;
 use casper_node::rpcs::chain::GetEraInfoBySwitchBlock;
@@ -17,12 +17,12 @@ enum DisplayOrder {
 }
 
 #[async_trait]
-impl<'a, 'b> ClientCommand<'a, 'b> for GetEraInfoBySwitchBlock {
+impl ClientCommand for GetEraInfoBySwitchBlock {
     const NAME: &'static str = "get-era-info-by-switch-block";
     const ABOUT: &'static str = "Retrieves era information from the network";
 
-    fn build(display_order: usize) -> App<'a, 'b> {
-        SubCommand::with_name(Self::NAME)
+    fn build(display_order: usize) -> Command<'static> {
+        Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)
             .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
@@ -35,7 +35,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetEraInfoBySwitchBlock {
             ))
     }
 
-    async fn run(matches: &ArgMatches<'a>) -> Result<Success, Error> {
+    async fn run(matches: &ArgMatches) -> Result<Success, Error> {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);

--- a/src/get_state_hash.rs
+++ b/src/get_state_hash.rs
@@ -1,7 +1,7 @@
 use std::str;
 
 use async_trait::async_trait;
-use clap::{App, ArgMatches, SubCommand};
+use clap::{ArgMatches, Command};
 
 use casper_client::Error;
 use casper_node::rpcs::chain::GetStateRootHash;
@@ -17,12 +17,12 @@ enum DisplayOrder {
 }
 
 #[async_trait]
-impl<'a, 'b> ClientCommand<'a, 'b> for GetStateRootHash {
+impl ClientCommand for GetStateRootHash {
     const NAME: &'static str = "get-state-root-hash";
     const ABOUT: &'static str = "Retrieves a state root hash at a given block";
 
-    fn build(display_order: usize) -> App<'a, 'b> {
-        SubCommand::with_name(Self::NAME)
+    fn build(display_order: usize) -> Command<'static> {
+        Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)
             .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
@@ -35,7 +35,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetStateRootHash {
             ))
     }
 
-    async fn run(matches: &ArgMatches<'a>) -> Result<Success, Error> {
+    async fn run(matches: &ArgMatches) -> Result<Success, Error> {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);

--- a/src/get_validator_changes.rs
+++ b/src/get_validator_changes.rs
@@ -1,7 +1,7 @@
 use std::str;
 
 use async_trait::async_trait;
-use clap::{App, ArgMatches, SubCommand};
+use clap::{ArgMatches, Command};
 
 use casper_client::Error;
 use casper_node::rpcs::info::GetValidatorChanges;
@@ -16,12 +16,12 @@ enum DisplayOrder {
 }
 
 #[async_trait]
-impl<'a, 'b> ClientCommand<'a, 'b> for GetValidatorChanges {
+impl ClientCommand for GetValidatorChanges {
     const NAME: &'static str = "get-validator-changes";
     const ABOUT: &'static str = "Retrieves status changes of active validators";
 
-    fn build(display_order: usize) -> App<'a, 'b> {
-        SubCommand::with_name(Self::NAME)
+    fn build(display_order: usize) -> Command<'static> {
+        Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)
             .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
@@ -31,7 +31,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetValidatorChanges {
             .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
     }
 
-    async fn run(matches: &ArgMatches<'a>) -> Result<Success, Error> {
+    async fn run(matches: &ArgMatches) -> Result<Success, Error> {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{Arg, ArgMatches, Command};
 use once_cell::sync::Lazy;
 
 use casper_client::{
@@ -36,8 +36,8 @@ mod output_dir {
         "Path to output directory where key files will be created. If the path doesn't exist, it \
         will be created. If not set, the current working directory will be used";
 
-    pub(super) fn arg() -> Arg<'static, 'static> {
-        Arg::with_name(ARG_NAME)
+    pub(super) fn arg() -> Arg<'static> {
+        Arg::new(ARG_NAME)
             .required(false)
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
@@ -54,12 +54,12 @@ mod algorithm {
     use super::*;
 
     const ARG_NAME: &str = "algorithm";
-    const ARG_SHORT: &str = "a";
+    const ARG_SHORT: char = 'a';
     const ARG_VALUE_NAME: &str = common::ARG_STRING;
     const ARG_HELP: &str = "The type of keys to generate";
 
-    pub fn arg() -> Arg<'static, 'static> {
-        Arg::with_name(ARG_NAME)
+    pub fn arg() -> Arg<'static> {
+        Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
             .required(false)
@@ -71,7 +71,7 @@ mod algorithm {
             .display_order(DisplayOrder::Algorithm as usize)
     }
 
-    pub fn get<'a>(matches: &'a ArgMatches) -> &'a str {
+    pub fn get(matches: &ArgMatches) -> &str {
         matches
             .value_of(ARG_NAME)
             .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME))
@@ -81,12 +81,12 @@ mod algorithm {
 pub struct Keygen {}
 
 #[async_trait]
-impl<'a, 'b> ClientCommand<'a, 'b> for Keygen {
+impl ClientCommand for Keygen {
     const NAME: &'static str = "keygen";
     const ABOUT: &'static str = "Generates account key files in the given directory";
 
-    fn build(display_order: usize) -> App<'a, 'b> {
-        SubCommand::with_name(Self::NAME)
+    fn build(display_order: usize) -> Command<'static> {
+        Command::new(Self::NAME)
             .about(Self::ABOUT)
             .long_about(MORE_ABOUT.as_str())
             .display_order(display_order)
@@ -95,7 +95,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for Keygen {
             .arg(algorithm::arg())
     }
 
-    async fn run(matches: &ArgMatches<'a>) -> Result<Success, Error> {
+    async fn run(matches: &ArgMatches) -> Result<Success, Error> {
         let output_dir = output_dir::get(matches);
         let algorithm = algorithm::get(matches);
         let force = common::force::get(matches);

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ mod query_global_state;
 
 use std::process;
 
-use clap::{crate_version, App};
+use clap::{crate_version, Command};
 
 use casper_client::Error;
 use casper_node::rpcs::{
@@ -62,8 +62,8 @@ enum DisplayOrder {
     AccountAddress,
 }
 
-fn cli<'a, 'b>() -> App<'a, 'b> {
-    App::new(APP_NAME)
+fn cli() -> Command<'static> {
+    Command::new(APP_NAME)
         .version(crate_version!())
         .about("A client for interacting with the Casper network")
         .subcommand(PutDeploy::build(DisplayOrder::PutDeploy as usize))
@@ -108,38 +108,38 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
 async fn main() {
     let arg_matches = cli().get_matches();
     let (result, matches) = match arg_matches.subcommand() {
-        (PutDeploy::NAME, Some(matches)) => (PutDeploy::run(matches).await, matches),
-        (MakeDeploy::NAME, Some(matches)) => (MakeDeploy::run(matches).await, matches),
-        (SignDeploy::NAME, Some(matches)) => (SignDeploy::run(matches).await, matches),
-        (SendDeploy::NAME, Some(matches)) => (SendDeploy::run(matches).await, matches),
-        (Transfer::NAME, Some(matches)) => (Transfer::run(matches).await, matches),
-        (MakeTransfer::NAME, Some(matches)) => (MakeTransfer::run(matches).await, matches),
-        (GetDeploy::NAME, Some(matches)) => (GetDeploy::run(matches).await, matches),
-        (GetBlock::NAME, Some(matches)) => (GetBlock::run(matches).await, matches),
-        (GetBlockTransfers::NAME, Some(matches)) => {
+        Some((PutDeploy::NAME, matches)) => (PutDeploy::run(matches).await, matches),
+        Some((MakeDeploy::NAME, matches)) => (MakeDeploy::run(matches).await, matches),
+        Some((SignDeploy::NAME, matches)) => (SignDeploy::run(matches).await, matches),
+        Some((SendDeploy::NAME, matches)) => (SendDeploy::run(matches).await, matches),
+        Some((Transfer::NAME, matches)) => (Transfer::run(matches).await, matches),
+        Some((MakeTransfer::NAME, matches)) => (MakeTransfer::run(matches).await, matches),
+        Some((GetDeploy::NAME, matches)) => (GetDeploy::run(matches).await, matches),
+        Some((GetBlock::NAME, matches)) => (GetBlock::run(matches).await, matches),
+        Some((GetBlockTransfers::NAME, matches)) => {
             (GetBlockTransfers::run(matches).await, matches)
         }
-        (ListDeploys::NAME, Some(matches)) => (ListDeploys::run(matches).await, matches),
-        (GetBalance::NAME, Some(matches)) => (GetBalance::run(matches).await, matches),
-        (GetAccountInfo::NAME, Some(matches)) => (GetAccountInfo::run(matches).await, matches),
-        (GetStateRootHash::NAME, Some(matches)) => (GetStateRootHash::run(matches).await, matches),
-        (GetEraInfoBySwitchBlock::NAME, Some(matches)) => {
+        Some((ListDeploys::NAME, matches)) => (ListDeploys::run(matches).await, matches),
+        Some((GetBalance::NAME, matches)) => (GetBalance::run(matches).await, matches),
+        Some((GetAccountInfo::NAME, matches)) => (GetAccountInfo::run(matches).await, matches),
+        Some((GetStateRootHash::NAME, matches)) => (GetStateRootHash::run(matches).await, matches),
+        Some((GetEraInfoBySwitchBlock::NAME, matches)) => {
             (GetEraInfoBySwitchBlock::run(matches).await, matches)
         }
-        (GetAuctionInfo::NAME, Some(matches)) => (GetAuctionInfo::run(matches).await, matches),
-        (GetValidatorChanges::NAME, Some(matches)) => {
+        Some((GetAuctionInfo::NAME, matches)) => (GetAuctionInfo::run(matches).await, matches),
+        Some((GetValidatorChanges::NAME, matches)) => {
             (GetValidatorChanges::run(matches).await, matches)
         }
-        (Keygen::NAME, Some(matches)) => (Keygen::run(matches).await, matches),
-        (GenerateCompletion::NAME, Some(matches)) => {
+        Some((Keygen::NAME, matches)) => (Keygen::run(matches).await, matches),
+        Some((GenerateCompletion::NAME, matches)) => {
             (GenerateCompletion::run(matches).await, matches)
         }
-        (ListRpcs::NAME, Some(matches)) => (ListRpcs::run(matches).await, matches),
-        (AccountAddress::NAME, Some(matches)) => (AccountAddress::run(matches).await, matches),
-        (GetDictionaryItem::NAME, Some(matches)) => {
+        Some((ListRpcs::NAME, matches)) => (ListRpcs::run(matches).await, matches),
+        Some((AccountAddress::NAME, matches)) => (AccountAddress::run(matches).await, matches),
+        Some((GetDictionaryItem::NAME, matches)) => {
             (GetDictionaryItem::run(matches).await, matches)
         }
-        (QueryGlobalState::NAME, Some(matches)) => (QueryGlobalState::run(matches).await, matches),
+        Some((QueryGlobalState::NAME, matches)) => (QueryGlobalState::run(matches).await, matches),
 
         _ => {
             let _ = cli().print_long_help();


### PR DESCRIPTION
This PR updates all third party dependencies, with the bulk of the changes being around clap v3.

It is built on top of #14 so only the second commit is relevant to this PR.

Closes [#2770](https://github.com/casper-network/casper-node/issues/2770).