### PR TITLE
Make selected helper structs public

### DIFF
--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -21,7 +21,8 @@
 //!   [`Block`] height or empty.  If empty, the latest `Block` known on the server will be used.
 
 mod cl_type;
-mod deploy;
+/// Deploy module.
+pub mod deploy;
 mod deploy_str_params;
 mod dictionary_item_str_params;
 mod error;

--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -6,7 +6,8 @@ use crate::{
     TransferTarget,
 };
 
-pub(super) fn with_payment_and_session(
+/// Creates new Deploy with specified payment and session data.
+pub fn with_payment_and_session(
     deploy_params: DeployStrParams,
     payment_params: PaymentStrParams,
     session_params: SessionStrParams,
@@ -31,7 +32,8 @@ pub(super) fn with_payment_and_session(
     Ok(deploy)
 }
 
-pub(super) fn new_transfer(
+/// Creates new Transfer with specified data.
+pub fn new_transfer(
     amount: &str,
     source_purse: Option<URef>,
     target_account: &str,

--- a/lib/crypto.rs
+++ b/lib/crypto.rs
@@ -2,7 +2,8 @@
 
 mod asymmetric_key;
 mod asymmetric_key_ext;
-mod error;
+/// Cryptographic error.
+pub mod error;
 
 pub(crate) use asymmetric_key::sign;
 pub use asymmetric_key_ext::AsymmetricKeyExt;

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -36,7 +36,7 @@
 )]
 
 pub mod cli;
-pub(crate) mod crypto;
+pub mod crypto;
 mod error;
 mod json_rpc;
 pub mod keygen;


### PR DESCRIPTION
This PR makes selected helper structs public so that they are available to use in other crates.