### PR TITLE
Add `query_balance` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add support for new node RPC method `info_get_chainspec`, used in the binary's new `get-chainspec` subcommand.
 * Add support for new node RPC method `info_get_status`, used in the binary's new `get-node-status` subcommand.
 * Add support for new node RPC method `info_get_peers`, used in the binary's new `get-peers` subcommand.
+* Add support for new node RPC method `query_balance`, used in the binary's new `query-balance` subcommand.
 
 ### Changed
 * Update dependencies.

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -43,13 +43,15 @@ use casper_types::{AsymmetricType, PublicKey, URef};
 
 use crate::{
     rpcs::{
+        common::GlobalStateIdentifier,
         results::{
             GetAccountResult, GetAuctionInfoResult, GetBalanceResult, GetBlockResult,
             GetBlockTransfersResult, GetChainspecResult, GetDeployResult, GetDictionaryItemResult,
             GetEraInfoResult, GetNodeStatusResult, GetPeersResult, GetStateRootHashResult,
-            GetValidatorChangesResult, ListRpcsResult, PutDeployResult, QueryGlobalStateResult, QueryBalanceResult
+            GetValidatorChangesResult, ListRpcsResult, PutDeployResult, QueryBalanceResult,
+            QueryGlobalStateResult,
         },
-        DictionaryItemIdentifier, common::GlobalStateIdentifier, PurseIdentifier
+        DictionaryItemIdentifier, PurseIdentifier,
     },
     SuccessResponse,
 };

--- a/lib/cli/error.rs
+++ b/lib/cli/error.rs
@@ -9,7 +9,7 @@ use casper_types::{Key, PublicKey, URef};
 
 #[cfg(doc)]
 use crate::{
-    rpcs::{DictionaryItemIdentifier, GlobalStateIdentifier},
+    rpcs::{DictionaryItemIdentifier, common::GlobalStateIdentifier},
     types::{TimeDiff, Timestamp},
 };
 

--- a/lib/cli/error.rs
+++ b/lib/cli/error.rs
@@ -9,7 +9,7 @@ use casper_types::{Key, PublicKey, URef};
 
 #[cfg(doc)]
 use crate::{
-    rpcs::{DictionaryItemIdentifier, common::GlobalStateIdentifier},
+    rpcs::{common::GlobalStateIdentifier, DictionaryItemIdentifier},
     types::{TimeDiff, Timestamp},
 };
 

--- a/lib/cli/global_state_str_params.rs
+++ b/lib/cli/global_state_str_params.rs
@@ -1,30 +1,56 @@
 use casper_hashing::Digest;
 
-use crate::{cli::CliError, rpcs::GlobalStateIdentifier, types::BlockHash};
+use crate::{cli::CliError, rpcs::common::GlobalStateIdentifier, types::BlockHash};
 
-/// The two ways to construct a query to global state.
-#[derive(Default, Debug)]
+#[derive(Debug)]
+/// The ways to identify the string value.
+pub enum GlobalStateStrIdentifier {
+    /// The global state identifier is either a state root hash or a block hash.
+    Hash {
+        /// Whether the hash is a block hash or state root hash.
+        is_block_hash: bool,
+    },
+    /// The global state identifier is the block height.
+    Height,
+}
+
+/// The ways to construct a query to global state.
+#[derive(Debug)]
 pub struct GlobalStateStrParams<'a> {
-    /// Whether the hash is a block hash or state root hash.
-    pub is_block_hash: bool,
-    /// The hex-encoded hash value.
-    pub hash_value: &'a str,
+    /// Whether the identifier is the block height, block hash or the state root hash.
+    pub str_identifier: GlobalStateStrIdentifier,
+    /// The identifier value.
+    pub identifier_value: &'a str,
 }
 
 impl<'a> TryFrom<GlobalStateStrParams<'a>> for GlobalStateIdentifier {
     type Error = CliError;
 
     fn try_from(params: GlobalStateStrParams<'a>) -> Result<GlobalStateIdentifier, Self::Error> {
-        let hash =
-            Digest::from_hex(params.hash_value).map_err(|error| CliError::FailedToParseDigest {
-                context: "global_state_identifier",
-                error,
-            })?;
+        match params.str_identifier {
+            GlobalStateStrIdentifier::Hash { is_block_hash } => {
+                let hash = Digest::from_hex(params.identifier_value).map_err(|error| {
+                    CliError::FailedToParseDigest {
+                        context: "global_state_identifier",
+                        error,
+                    }
+                })?;
 
-        if params.is_block_hash {
-            Ok(GlobalStateIdentifier::BlockHash(BlockHash::new(hash)))
-        } else {
-            Ok(GlobalStateIdentifier::StateRootHash(hash))
+                if is_block_hash {
+                    Ok(GlobalStateIdentifier::BlockHash(BlockHash::new(hash)))
+                } else {
+                    Ok(GlobalStateIdentifier::StateRootHash(hash))
+                }
+            }
+            GlobalStateStrIdentifier::Height => {
+                let height = params.identifier_value.parse().map_err(|error| {
+                    CliError::FailedToParseInt {
+                        context: "global_state_identifier",
+                        error,
+                    }
+                })?;
+                Ok(GlobalStateIdentifier::BlockHeight(height))
+            }
         }
     }
 }

--- a/lib/cli/purse_identifier_str_params.rs
+++ b/lib/cli/purse_identifier_str_params.rs
@@ -1,0 +1,61 @@
+use crate::cli::CliError;
+use crate::rpcs::v1_4_5::query_balance::PurseIdentifier;
+use casper_types::account::AccountHash;
+use casper_types::{AsymmetricType, PublicKey, URef};
+
+#[derive(Debug)]
+/// The ways to construct a PurseIdentifier from a string.
+pub enum PurseStrIdentifier {
+    /// The string value is to be parsed as a PublicKey.
+    PublicKey,
+    /// The string value is to be parsed as an AccountHash.
+    AccountHash,
+    /// The string value is to be parsed as an URef.
+    PurseURef,
+}
+
+/// The ways to construct a balance query.
+#[derive(Debug)]
+pub struct PurseStrParams {
+    /// The identifier for the string value.
+    pub purse_str_identifier: PurseStrIdentifier,
+    /// The identifier value to parsed.
+    pub identifier_value: String,
+}
+
+impl TryFrom<PurseStrParams> for PurseIdentifier {
+    type Error = CliError;
+
+    fn try_from(params: PurseStrParams) -> Result<PurseIdentifier, Self::Error> {
+        match params.purse_str_identifier {
+            PurseStrIdentifier::PublicKey => {
+                let account_public_key =
+                    PublicKey::from_hex(params.identifier_value).map_err(|error| {
+                        CliError::FailedToParsePublicKey {
+                            context: "purse_identifier",
+                            error,
+                        }
+                    })?;
+                Ok(PurseIdentifier::MainPurseUnderPublicKey(account_public_key))
+            }
+            PurseStrIdentifier::AccountHash => {
+                let account_hash = AccountHash::from_formatted_str(&*params.identifier_value)
+                    .map_err(|error| CliError::FailedToParseKey {
+                        context: "purse_identifier",
+                        error: error.into(),
+                    })?;
+                Ok(PurseIdentifier::MainPurseUnderAccountHash(account_hash))
+            }
+            PurseStrIdentifier::PurseURef => {
+                let uref =
+                    URef::from_formatted_str(&*params.identifier_value).map_err(|error| {
+                        CliError::FailedToParseURef {
+                            context: "purse_identifier",
+                            error,
+                        }
+                    })?;
+                Ok(PurseIdentifier::PurseUref(uref))
+            }
+        }
+    }
+}

--- a/lib/cli/purse_identifier_str_params.rs
+++ b/lib/cli/purse_identifier_str_params.rs
@@ -1,7 +1,6 @@
-use crate::cli::CliError;
-use crate::rpcs::v1_4_5::query_balance::PurseIdentifier;
-use casper_types::account::AccountHash;
-use casper_types::{AsymmetricType, PublicKey, URef};
+use casper_types::{account::AccountHash, AsymmetricType, PublicKey, URef};
+
+use crate::{cli::CliError, rpcs::v1_4_5::query_balance::PurseIdentifier};
 
 #[derive(Debug)]
 /// The ways to construct a PurseIdentifier from a string.

--- a/lib/crypto/error.rs
+++ b/lib/crypto/error.rs
@@ -80,6 +80,7 @@ impl From<crypto::Error> for Error {
             crypto::Error::FromHex(error) => Error::FromHex(error),
             crypto::Error::FromBase64(error) => Error::FromBase64(error),
             crypto::Error::SignatureError(error) => Error::Signature(error),
+            crypto::Error::System(error) => Error::System(error),
         }
     }
 }

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -60,13 +60,17 @@ use casper_hashing::Digest;
 use casper_types::Transfer;
 use casper_types::{Key, PublicKey, SecretKey, URef};
 
+use crate::rpcs::results::QueryBalanceResult;
+use crate::rpcs::v1_4_5::query_balance::{
+    PurseIdentifier, QueryBalanceParams, QUERY_BALANCE_METHOD,
+};
 pub use crypto::{AsymmetricKeyExt, CryptoError};
 pub use error::Error;
 use json_rpc::JsonRpcCall;
 pub use json_rpc::{JsonRpcId, SuccessResponse};
 pub use output_kind::OutputKind;
 use rpcs::{
-    common::BlockIdentifier,
+    common::{BlockIdentifier, GlobalStateIdentifier},
     results::{
         GetAccountResult, GetAuctionInfoResult, GetBalanceResult, GetBlockResult,
         GetBlockTransfersResult, GetChainspecResult, GetDeployResult, GetDictionaryItemResult,
@@ -91,7 +95,7 @@ use rpcs::{
         put_deploy::{PutDeployParams, PUT_DEPLOY_METHOD},
         query_global_state::{QueryGlobalStateParams, QUERY_GLOBAL_STATE_METHOD},
     },
-    DictionaryItemIdentifier, GlobalStateIdentifier,
+    DictionaryItemIdentifier,
 };
 pub use transfer_target::TransferTarget;
 #[cfg(doc)]
@@ -282,6 +286,24 @@ pub async fn query_global_state(
     let params = QueryGlobalStateParams::new(global_state_identifier, key, path);
     JsonRpcCall::new(rpc_id, node_address, verbosity)
         .send_request(QUERY_GLOBAL_STATE_METHOD, Some(params))
+        .await
+}
+
+/// Retrieves a purse's balance at a given state root hash.
+///
+/// Sends a JSON-RPC `query_balance` request to the specified node.
+///
+/// For details of the parameters, see [the module docs](crate#common-parameters).
+pub async fn query_balance(
+    rpc_id: JsonRpcId,
+    node_address: &str,
+    verbosity: Verbosity,
+    maybe_global_state_identifier: Option<GlobalStateIdentifier>,
+    purse_identifier: PurseIdentifier,
+) -> Result<SuccessResponse<QueryBalanceResult>, Error> {
+    let params = QueryBalanceParams::new(maybe_global_state_identifier, purse_identifier);
+    JsonRpcCall::new(rpc_id, node_address, verbosity)
+        .send_request(QUERY_BALANCE_METHOD, Some(params))
         .await
 }
 

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -60,10 +60,6 @@ use casper_hashing::Digest;
 use casper_types::Transfer;
 use casper_types::{Key, PublicKey, SecretKey, URef};
 
-use crate::rpcs::results::QueryBalanceResult;
-use crate::rpcs::v1_4_5::query_balance::{
-    PurseIdentifier, QueryBalanceParams, QUERY_BALANCE_METHOD,
-};
 pub use crypto::{AsymmetricKeyExt, CryptoError};
 pub use error::Error;
 use json_rpc::JsonRpcCall;
@@ -75,7 +71,8 @@ use rpcs::{
         GetAccountResult, GetAuctionInfoResult, GetBalanceResult, GetBlockResult,
         GetBlockTransfersResult, GetChainspecResult, GetDeployResult, GetDictionaryItemResult,
         GetEraInfoResult, GetNodeStatusResult, GetPeersResult, GetStateRootHashResult,
-        GetValidatorChangesResult, ListRpcsResult, PutDeployResult, QueryGlobalStateResult,
+        GetValidatorChangesResult, ListRpcsResult, PutDeployResult, QueryBalanceResult,
+        QueryGlobalStateResult,
     },
     v1_4_5::{
         get_account::{GetAccountParams, GET_ACCOUNT_METHOD},
@@ -93,6 +90,7 @@ use rpcs::{
         get_validator_changes::GET_VALIDATOR_CHANGES_METHOD,
         list_rpcs::LIST_RPCS_METHOD,
         put_deploy::{PutDeployParams, PUT_DEPLOY_METHOD},
+        query_balance::{PurseIdentifier, QueryBalanceParams, QUERY_BALANCE_METHOD},
         query_global_state::{QueryGlobalStateParams, QUERY_GLOBAL_STATE_METHOD},
     },
     DictionaryItemIdentifier,

--- a/lib/rpcs.rs
+++ b/lib/rpcs.rs
@@ -3,6 +3,4 @@
 pub mod common;
 pub mod results;
 pub(crate) mod v1_4_5;
-pub use v1_4_5::{
-    get_dictionary_item::DictionaryItemIdentifier, query_global_state::GlobalStateIdentifier,
-};
+pub use v1_4_5::{get_dictionary_item::DictionaryItemIdentifier, query_balance::PurseIdentifier};

--- a/lib/rpcs/common.rs
+++ b/lib/rpcs/common.rs
@@ -3,6 +3,7 @@
 #[cfg(doc)]
 use crate::types::Block;
 use crate::types::BlockHash;
+use casper_hashing::Digest;
 
 use serde::{Deserialize, Serialize};
 
@@ -14,4 +15,18 @@ pub enum BlockIdentifier {
     Hash(BlockHash),
     /// Identify the block by its height.
     Height(u64),
+}
+
+/// Identifier for possible ways to query global state.
+///
+/// Soon to be deprecated in favour of [`BlockIdentifier`].
+#[derive(Clone, Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub enum GlobalStateIdentifier {
+    /// Query using a block hash.
+    BlockHash(BlockHash),
+    /// Query using a block height.
+    BlockHeight(u64),
+    /// Query using the state root hash.
+    StateRootHash(Digest),
 }

--- a/lib/rpcs/common.rs
+++ b/lib/rpcs/common.rs
@@ -4,9 +4,9 @@
 use crate::types::Block;
 use crate::types::BlockHash;
 
-use casper_hashing::Digest;
-
 use serde::{Deserialize, Serialize};
+
+use casper_hashing::Digest;
 
 /// Enum of possible ways to identify a [`Block`].
 #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]

--- a/lib/rpcs/common.rs
+++ b/lib/rpcs/common.rs
@@ -3,6 +3,7 @@
 #[cfg(doc)]
 use crate::types::Block;
 use crate::types::BlockHash;
+
 use casper_hashing::Digest;
 
 use serde::{Deserialize, Serialize};

--- a/lib/rpcs/results.rs
+++ b/lib/rpcs/results.rs
@@ -23,4 +23,5 @@ pub use super::v1_4_5::list_rpcs::{
     SchemaParam,
 };
 pub use super::v1_4_5::put_deploy::PutDeployResult;
+pub use super::v1_4_5::query_balance::QueryBalanceResult;
 pub use super::v1_4_5::query_global_state::QueryGlobalStateResult;

--- a/lib/rpcs/v1_4_5.rs
+++ b/lib/rpcs/v1_4_5.rs
@@ -15,4 +15,5 @@ pub(crate) mod get_state_root_hash;
 pub(crate) mod get_validator_changes;
 pub(crate) mod list_rpcs;
 pub(crate) mod put_deploy;
+pub(crate) mod query_balance;
 pub(crate) mod query_global_state;

--- a/lib/rpcs/v1_4_5/query_balance.rs
+++ b/lib/rpcs/v1_4_5/query_balance.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
+use casper_types::{account::AccountHash, ProtocolVersion, PublicKey, URef, U512};
+
 use crate::rpcs::common::GlobalStateIdentifier;
-use casper_types::account::AccountHash;
-use casper_types::{ProtocolVersion, PublicKey, URef, U512};
 
 pub(crate) const QUERY_BALANCE_METHOD: &str = "query_balance";
 

--- a/lib/rpcs/v1_4_5/query_balance.rs
+++ b/lib/rpcs/v1_4_5/query_balance.rs
@@ -1,0 +1,49 @@
+use serde::{Deserialize, Serialize};
+
+use crate::rpcs::common::GlobalStateIdentifier;
+use casper_types::account::AccountHash;
+use casper_types::{ProtocolVersion, PublicKey, URef, U512};
+
+pub(crate) const QUERY_BALANCE_METHOD: &str = "query_balance";
+
+/// Identifier of a purse.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum PurseIdentifier {
+    /// The main purse of the account identified by this public key.
+    MainPurseUnderPublicKey(PublicKey),
+    /// The main purse of the account identified by this account hash.
+    MainPurseUnderAccountHash(AccountHash),
+    /// The purse identified by this URef.
+    PurseUref(URef),
+}
+
+/// Params for "query_balance" RPC request.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct QueryBalanceParams {
+    /// The state identifier used for the query.
+    pub state_identifier: Option<GlobalStateIdentifier>,
+    /// The identifier to obtain the purse corresponding to balance query.
+    pub purse_identifier: PurseIdentifier,
+}
+
+impl QueryBalanceParams {
+    pub(crate) fn new(
+        state_identifier: Option<GlobalStateIdentifier>,
+        purse_identifier: PurseIdentifier,
+    ) -> Self {
+        QueryBalanceParams {
+            state_identifier,
+            purse_identifier,
+        }
+    }
+}
+
+/// Result for "query_balance" RPC response.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct QueryBalanceResult {
+    /// The RPC API version.
+    pub api_version: ProtocolVersion,
+    /// The balance represented in motes.
+    pub balance: U512,
+}

--- a/lib/rpcs/v1_4_5/query_global_state.rs
+++ b/lib/rpcs/v1_4_5/query_global_state.rs
@@ -1,25 +1,13 @@
 use serde::{Deserialize, Serialize};
 
-use casper_hashing::Digest;
 use casper_types::{Key, ProtocolVersion};
 
-use crate::types::{BlockHash, BlockHeader, StoredValue};
+use crate::rpcs::common::GlobalStateIdentifier;
+use crate::types::{BlockHeader, StoredValue};
 #[cfg(doc)]
 use crate::BlockIdentifier;
 
 pub(crate) const QUERY_GLOBAL_STATE_METHOD: &str = "query_global_state";
-
-/// Identifier for possible ways to query global state.
-///
-/// Soon to be deprecated in favour of [`BlockIdentifier`].
-#[derive(Clone, Serialize, Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
-pub enum GlobalStateIdentifier {
-    /// Query using a block hash.
-    BlockHash(BlockHash),
-    /// Query using the state root hash.
-    StateRootHash(Digest),
-}
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]

--- a/lib/rpcs/v1_4_5/query_global_state.rs
+++ b/lib/rpcs/v1_4_5/query_global_state.rs
@@ -2,10 +2,12 @@ use serde::{Deserialize, Serialize};
 
 use casper_types::{Key, ProtocolVersion};
 
-use crate::rpcs::common::GlobalStateIdentifier;
-use crate::types::{BlockHeader, StoredValue};
 #[cfg(doc)]
 use crate::BlockIdentifier;
+use crate::{
+    types::{BlockHeader, StoredValue},
+    GlobalStateIdentifier,
+};
 
 pub(crate) const QUERY_GLOBAL_STATE_METHOD: &str = "query_global_state";
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -263,7 +263,7 @@ mod sealed_public_key {
 pub(super) mod public_key {
     use super::*;
 
-    const ARG_NAME: &str = "public-key";
+    pub const ARG_NAME: &str = "public-key";
     const ARG_SHORT: char = 'p';
     const IS_REQUIRED: bool = true;
     const ARG_HELP: &str =
@@ -301,5 +301,31 @@ pub(super) mod session_account {
 
     pub fn get(matches: &ArgMatches) -> Result<String, CliError> {
         sealed_public_key::get(matches, ARG_NAME, IS_REQUIRED)
+    }
+}
+
+/// Handles providing the arg for and retrieval of the purse URef.
+pub(super) mod purse_uref {
+    use super::*;
+
+    pub const ARG_NAME: &str = "purse-uref";
+    const ARG_SHORT: char = 'u';
+    const ARG_VALUE_NAME: &str = "FORMATTED STRING";
+    const ARG_HELP: &str =
+        "The URef under which the purse is stored. This must be a properly formatted URef \
+        \"uref-<HEX STRING>-<THREE DIGIT INTEGER>\"";
+
+    pub fn arg(display_order: usize, is_required: bool) -> Arg<'static> {
+        Arg::new(ARG_NAME)
+            .long(ARG_NAME)
+            .short(ARG_SHORT)
+            .required(is_required)
+            .value_name(ARG_VALUE_NAME)
+            .help(ARG_HELP)
+            .display_order(display_order)
+    }
+
+    pub fn get(matches: &ArgMatches) -> Option<&str> {
+        matches.value_of(ARG_NAME)
     }
 }

--- a/src/deploy/creation_common.rs
+++ b/src/deploy/creation_common.rs
@@ -317,6 +317,7 @@ pub(super) mod arg_simple {
         }
 
         pub fn get(matches: &ArgMatches) -> Vec<&str> {
+            #[allow(clippy::iter_overeager_cloned)]
             matches
                 .values_of(ARG_NAME)
                 .iter()
@@ -337,6 +338,7 @@ pub(super) mod arg_simple {
         }
 
         pub fn get(matches: &ArgMatches) -> Vec<&str> {
+            #[allow(clippy::iter_overeager_cloned)]
             matches
                 .values_of(ARG_NAME)
                 .iter()

--- a/src/get_balance.rs
+++ b/src/get_balance.rs
@@ -1,7 +1,7 @@
 use std::str;
 
 use async_trait::async_trait;
-use clap::{Arg, ArgMatches, Command};
+use clap::{ArgMatches, Command};
 
 use casper_client::cli::CliError;
 
@@ -16,34 +16,6 @@ enum DisplayOrder {
     RpcId,
     StateRootHash,
     PurseURef,
-}
-
-/// Handles providing the arg for and retrieval of the purse URef.
-mod purse_uref {
-    use super::*;
-
-    const ARG_NAME: &str = "purse-uref";
-    const ARG_SHORT: char = 'p';
-    const ARG_VALUE_NAME: &str = "FORMATTED STRING";
-    const ARG_HELP: &str =
-        "The URef under which the purse is stored. This must be a properly formatted URef \
-        \"uref-<HEX STRING>-<THREE DIGIT INTEGER>\"";
-
-    pub(super) fn arg() -> Arg<'static> {
-        Arg::new(ARG_NAME)
-            .long(ARG_NAME)
-            .short(ARG_SHORT)
-            .required(true)
-            .value_name(ARG_VALUE_NAME)
-            .help(ARG_HELP)
-            .display_order(DisplayOrder::PurseURef as usize)
-    }
-
-    pub(super) fn get(matches: &ArgMatches) -> &str {
-        matches
-            .value_of(ARG_NAME)
-            .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME))
-    }
 }
 
 #[async_trait]
@@ -63,7 +35,10 @@ impl ClientCommand for GetBalance {
             .arg(common::state_root_hash::arg(
                 DisplayOrder::StateRootHash as usize,
             ))
-            .arg(purse_uref::arg())
+            .arg(common::purse_uref::arg(
+                DisplayOrder::PurseURef as usize,
+                true,
+            ))
     }
 
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
@@ -71,7 +46,8 @@ impl ClientCommand for GetBalance {
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);
         let state_root_hash = common::state_root_hash::get(matches);
-        let purse_uref = purse_uref::get(matches);
+        let purse_uref = common::purse_uref::get(matches)
+            .unwrap_or_else(|| panic!("should have {} arg", common::purse_uref::ARG_NAME));
 
         casper_client::cli::get_balance(
             maybe_rpc_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod get_state_root_hash;
 mod get_validator_changes;
 mod keygen;
 mod list_rpcs;
+mod query_balance;
 mod query_global_state;
 
 use std::process;
@@ -25,6 +26,7 @@ use once_cell::sync::Lazy;
 
 use casper_client::{cli, rpcs::results::GetChainspecResult, SuccessResponse};
 
+use crate::query_balance::QueryBalance;
 use account_address::AccountAddress;
 use block::{GetBlock, GetBlockTransfers};
 use command::{ClientCommand, Success};
@@ -77,6 +79,7 @@ enum DisplayOrder {
     GetStateRootHash,
     GetEraInfo,
     QueryGlobalState,
+    QueryBalance,
     GetDictionaryItem,
     GetBalance,
     GetAccount,
@@ -114,6 +117,7 @@ fn cli() -> Command<'static> {
         .subcommand(
             QueryGlobalState::build(DisplayOrder::QueryGlobalState as usize).alias("query-state"),
         )
+        .subcommand(QueryBalance::build(DisplayOrder::QueryBalance as usize))
         .subcommand(GetDictionaryItem::build(
             DisplayOrder::GetDictionaryItem as usize,
         ))
@@ -157,6 +161,7 @@ async fn main() {
         GetStateRootHash::NAME => GetStateRootHash::run(matches).await,
         GetEraInfo::NAME => GetEraInfo::run(matches).await,
         QueryGlobalState::NAME => QueryGlobalState::run(matches).await,
+        QueryBalance::NAME => QueryBalance::run(matches).await,
         GetDictionaryItem::NAME => GetDictionaryItem::run(matches).await,
         GetBalance::NAME => GetBalance::run(matches).await,
         GetAccount::NAME => GetAccount::run(matches).await,

--- a/src/query_balance.rs
+++ b/src/query_balance.rs
@@ -1,0 +1,277 @@
+use std::{fs, str};
+
+use async_trait::async_trait;
+use clap::{Arg, ArgGroup, ArgMatches, Command};
+
+use casper_client::cli::{
+    CliError, GlobalStateStrIdentifier, GlobalStateStrParams, PurseStrIdentifier, PurseStrParams,
+};
+
+use crate::{command::ClientCommand, common, Success};
+
+const ARG_HEX_STRING: &str = "HEX STRING";
+
+pub struct QueryBalance;
+
+/// This struct defines the order in which the args are shown for this subcommand's help message.
+enum DisplayOrder {
+    Verbose,
+    NodeAddress,
+    RpcId,
+    BlockHash,
+    BlockHeight,
+    StateRootHash,
+    PublicKey,
+    AccountHash,
+    PurseURef,
+}
+
+mod state_root_hash {
+    use super::*;
+
+    pub(super) const ARG_NAME: &str = "state-root-hash";
+    const ARG_SHORT: char = 's';
+    const ARG_VALUE_NAME: &str = ARG_HEX_STRING;
+    const ARG_HELP: &str = "Hex-encoded hash of the state root";
+
+    pub(super) fn arg() -> Arg<'static> {
+        Arg::new(ARG_NAME)
+            .long(ARG_NAME)
+            .short(ARG_SHORT)
+            .required(false)
+            .value_name(ARG_VALUE_NAME)
+            .help(ARG_HELP)
+            .display_order(DisplayOrder::StateRootHash as usize)
+    }
+
+    pub fn get(matches: &ArgMatches) -> Option<&str> {
+        matches.value_of(ARG_NAME)
+    }
+}
+
+mod block_hash {
+    use super::*;
+
+    pub(super) const ARG_NAME: &str = "block-hash";
+    const ARG_SHORT: char = 'b';
+    const ARG_VALUE_NAME: &str = ARG_HEX_STRING;
+    const ARG_HELP: &str = "Hex-encoded hash of the block";
+
+    pub(super) fn arg() -> Arg<'static> {
+        Arg::new(ARG_NAME)
+            .long(ARG_NAME)
+            .short(ARG_SHORT)
+            .required(false)
+            .value_name(ARG_VALUE_NAME)
+            .help(ARG_HELP)
+            .display_order(DisplayOrder::BlockHash as usize)
+    }
+
+    pub fn get(matches: &ArgMatches) -> Option<&str> {
+        matches.value_of(ARG_NAME)
+    }
+}
+
+mod block_height {
+    use super::*;
+
+    pub(super) const ARG_NAME: &str = "block-height";
+    const ARG_VALUE_NAME: &str = "INTEGER";
+    const ARG_HELP: &str = "Height of the block";
+
+    pub(super) fn arg() -> Arg<'static> {
+        Arg::new(ARG_NAME)
+            .long(ARG_NAME)
+            .required(false)
+            .value_name(ARG_VALUE_NAME)
+            .help(ARG_HELP)
+            .display_order(DisplayOrder::BlockHeight as usize)
+    }
+
+    pub fn get(matches: &ArgMatches) -> Option<&str> {
+        matches.value_of(ARG_NAME)
+    }
+}
+
+mod public_key {
+    use casper_types::{AsymmetricType, PublicKey};
+
+    use super::*;
+    use casper_client::{cli::CliError, AsymmetricKeyExt};
+
+    pub const ARG_NAME: &str = "public-key";
+    const ARG_SHORT: char = 'p';
+    const ARG_VALUE_NAME: &str = "FORMATTED STRING or PATH";
+    const ARG_HELP: &str =
+        "This must be a properly formatted public key. The public key may instead be read in from \
+        a file, in which case enter the path to the file as the --public-key argument. The file \
+        should be one of the two public key files generated via the `keygen` subcommand; \
+        \"public_key_hex\" or \"public_key.pem\"";
+
+    pub(super) fn arg() -> Arg<'static> {
+        Arg::new(ARG_NAME)
+            .long(ARG_NAME)
+            .short(ARG_SHORT)
+            .required(false)
+            .value_name(ARG_VALUE_NAME)
+            .help(ARG_HELP)
+            .display_order(DisplayOrder::PublicKey as usize)
+    }
+
+    pub(super) fn get(matches: &ArgMatches) -> Result<String, CliError> {
+        let value = matches.value_of(ARG_NAME).unwrap_or_default();
+
+        // Try to read as a PublicKey PEM file first.
+        if let Ok(public_key) = PublicKey::from_file(value) {
+            return Ok(public_key.to_hex());
+        }
+
+        // Try to read as a hex-encoded PublicKey file next.
+        if let Ok(hex_public_key) = fs::read_to_string(value) {
+            let _ = PublicKey::from_hex(&hex_public_key).map_err(|error| {
+                eprintln!(
+                    "Can't parse the contents of {} as a public key: {}",
+                    value, error
+                );
+                CliError::FailedToParsePublicKey {
+                    context: "get public key",
+                    error,
+                }
+            })?;
+            return Ok(hex_public_key);
+        }
+        Ok(value.to_string())
+    }
+}
+
+mod account_hash {
+    use super::*;
+
+    pub(super) const ARG_NAME: &str = "account-hash";
+    const ARG_SHORT: char = 'a';
+    const ARG_VALUE_NAME: &str = "FORMATTED STRING";
+    const ARG_HELP: &str =
+        "This must be a properly formatted account hash. The format for account hash is \
+        \"account-hash-<HEX STRING>\".";
+
+    pub(super) fn arg() -> Arg<'static> {
+        Arg::new(ARG_NAME)
+            .long(ARG_NAME)
+            .short(ARG_SHORT)
+            .required(false)
+            .value_name(ARG_VALUE_NAME)
+            .help(ARG_HELP)
+            .display_order(DisplayOrder::AccountHash as usize)
+    }
+
+    pub fn get(matches: &ArgMatches) -> Option<&str> {
+        matches.value_of(ARG_NAME)
+    }
+}
+
+fn maybe_global_state_str_params(matches: &ArgMatches) -> Option<GlobalStateStrParams<'_>> {
+    if let Some(state_root_hash) = state_root_hash::get(matches) {
+        return Some(GlobalStateStrParams {
+            str_identifier: GlobalStateStrIdentifier::Hash {
+                is_block_hash: false,
+            },
+            identifier_value: state_root_hash,
+        });
+    }
+    if let Some(block_hash) = block_hash::get(matches) {
+        return Some(GlobalStateStrParams {
+            str_identifier: GlobalStateStrIdentifier::Hash {
+                is_block_hash: true,
+            },
+            identifier_value: block_hash,
+        });
+    }
+    if let Some(block_height) = block_height::get(matches) {
+        return Some(GlobalStateStrParams {
+            str_identifier: GlobalStateStrIdentifier::Height,
+            identifier_value: block_height,
+        });
+    }
+    None
+}
+
+fn purse_str_params(matches: &ArgMatches) -> Result<PurseStrParams, CliError> {
+    if let Ok(account_public_key) = public_key::get(matches) {
+        return Ok(PurseStrParams {
+            purse_str_identifier: PurseStrIdentifier::PublicKey,
+            identifier_value: account_public_key,
+        });
+    }
+    if let Some(formatted_account_hash) = account_hash::get(matches) {
+        return Ok(PurseStrParams {
+            purse_str_identifier: PurseStrIdentifier::AccountHash,
+            identifier_value: formatted_account_hash.to_string(),
+        });
+    }
+    if let Some(formatted_purse_uref) = common::purse_uref::get(matches) {
+        return Ok(PurseStrParams {
+            purse_str_identifier: PurseStrIdentifier::PurseURef,
+            identifier_value: formatted_purse_uref.to_string(),
+        });
+    }
+    unreachable!("clap arg groups and parsing should prevent this for purse identifier params")
+}
+
+#[async_trait]
+impl ClientCommand for QueryBalance {
+    const NAME: &'static str = "query-balance";
+    const ABOUT: &'static str = "Retrieve a purse's balance from the network";
+
+    fn build(display_order: usize) -> Command<'static> {
+        Command::new(Self::NAME)
+            .about(Self::ABOUT)
+            .display_order(display_order)
+            .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
+            .arg(common::node_address::arg(
+                DisplayOrder::NodeAddress as usize,
+            ))
+            .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
+            .arg(block_hash::arg())
+            .arg(block_height::arg())
+            .arg(state_root_hash::arg())
+            .group(
+                ArgGroup::new("state-identifier")
+                    .arg(block_hash::ARG_NAME)
+                    .arg(block_height::ARG_NAME)
+                    .arg(state_root_hash::ARG_NAME)
+                    .required(false),
+            )
+            .arg(public_key::arg())
+            .arg(account_hash::arg().required_unless_present(common::public_key::ARG_NAME))
+            .arg(
+                common::purse_uref::arg(DisplayOrder::PurseURef as usize, false)
+                    .required_unless_present(common::public_key::ARG_NAME)
+                    .required_unless_present(account_hash::ARG_NAME),
+            )
+            .group(
+                ArgGroup::new("purse-identifier")
+                    .arg(common::public_key::ARG_NAME)
+                    .arg(account_hash::ARG_NAME)
+                    .arg(common::purse_uref::ARG_NAME)
+                    .required(true),
+            )
+    }
+
+    async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
+        let maybe_rpc_id = common::rpc_id::get(matches);
+        let node_address = common::node_address::get(matches);
+        let verbosity_level = common::verbose::get(matches);
+        let maybe_global_state_str_params = maybe_global_state_str_params(matches);
+        let purse_str_params = purse_str_params(matches)?;
+
+        casper_client::cli::query_balance(
+            maybe_rpc_id,
+            node_address,
+            verbosity_level,
+            maybe_global_state_str_params,
+            purse_str_params,
+        )
+        .await
+        .map(Success::from)
+    }
+}

--- a/src/query_global_state.rs
+++ b/src/query_global_state.rs
@@ -3,7 +3,7 @@ use std::{fs, str};
 use async_trait::async_trait;
 use clap::{Arg, ArgGroup, ArgMatches, Command};
 
-use casper_client::cli::{CliError, GlobalStateStrParams};
+use casper_client::cli::{CliError, GlobalStateStrIdentifier, GlobalStateStrParams};
 
 use crate::{command::ClientCommand, common, Success};
 
@@ -159,14 +159,18 @@ mod path {
 fn global_state_str_params(matches: &ArgMatches) -> GlobalStateStrParams<'_> {
     if let Some(state_root_hash) = state_root_hash::get(matches) {
         return GlobalStateStrParams {
-            is_block_hash: false,
-            hash_value: state_root_hash,
+            str_identifier: GlobalStateStrIdentifier::Hash {
+                is_block_hash: false,
+            },
+            identifier_value: state_root_hash,
         };
     }
     if let Some(block_hash) = block_hash::get(matches) {
         return GlobalStateStrParams {
-            is_block_hash: true,
-            hash_value: block_hash,
+            str_identifier: GlobalStateStrIdentifier::Hash {
+                is_block_hash: true,
+            },
+            identifier_value: block_hash,
         };
     }
     unreachable!("clap arg groups and parsing should prevent this for global state params")


### PR DESCRIPTION
CHANGELOG:

* Add support for new node RPC method `query_balance`, used in the binary's new `query-balance` subcommand.

Closes: [2876](https://app.zenhub.com/workspaces/engineering-l1-60953fafb1945f0011a3592d/issues/casper-network/casper-node/2876)