### PR TITLE
Update `GetDeployResponse` for v1.5.0

### DIFF
--- a/lib/rpcs/v1_5_0.rs
+++ b/lib/rpcs/v1_5_0.rs
@@ -1,6 +1,7 @@
 //! The JSON-RPC request and response types at v1.5.0 of casper-node.
 
 pub(crate) mod get_chainspec;
+pub(crate) mod get_deploy;
 pub(crate) mod get_node_status;
 pub(crate) mod query_balance;
 
@@ -33,11 +34,6 @@ pub(crate) mod get_block_transfers {
     pub(crate) use crate::rpcs::v1_4_5::get_block_transfers::{
         GetBlockTransfersParams, GET_BLOCK_TRANSFERS_METHOD,
     };
-}
-
-pub(crate) mod get_deploy {
-    pub use crate::rpcs::v1_4_5::get_deploy::GetDeployResult;
-    pub(crate) use crate::rpcs::v1_4_5::get_deploy::{GetDeployParams, GET_DEPLOY_METHOD};
 }
 
 pub(crate) mod get_dictionary_item {

--- a/lib/rpcs/v1_5_0/get_deploy.rs
+++ b/lib/rpcs/v1_5_0/get_deploy.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+
+use casper_types::ProtocolVersion;
+
+pub(crate) use crate::rpcs::v1_4_5::get_deploy::{GetDeployParams, GET_DEPLOY_METHOD};
+use crate::types::{BlockHashAndHeight, Deploy, ExecutionResult};
+
+/// The `result` field of a successful JSON-RPC response to an `info_get_deploy` request.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct GetDeployResult {
+    /// The JSON-RPC server version.
+    pub api_version: ProtocolVersion,
+    /// The deploy.
+    pub deploy: Deploy,
+    /// The map of block hash to execution result.
+    pub execution_results: Vec<ExecutionResult>,
+    /// The hash and height of the block in which this deploy was executed,
+    /// only provided if the full execution results are not know on this node.
+    #[serde(skip_serializing_if = "Option::is_none", flatten)]
+    pub block_hash_and_height: Option<BlockHashAndHeight>,
+}

--- a/lib/types.rs
+++ b/lib/types.rs
@@ -19,7 +19,8 @@ pub use account::{Account, ActionThresholds, AssociatedKey};
 pub use auction_state::AuctionState;
 pub use block::{
     v1::validate_hashes as validate_block_hashes_v1,
-    v2::validate_hashes as validate_block_hashes_v2, Block, BlockBody, BlockHash, BlockHeader,
+    v2::validate_hashes as validate_block_hashes_v2, Block, BlockBody, BlockHash,
+    BlockHashAndHeight, BlockHeader,
 };
 pub use contract::Contract;
 pub use contract_package::ContractPackage;

--- a/lib/types/block.rs
+++ b/lib/types/block.rs
@@ -3,6 +3,7 @@ pub mod v2;
 
 use std::fmt::{self, Display, Formatter};
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use casper_hashing::Digest;
@@ -26,7 +27,18 @@ use crate::types::{DeployHash, EraEnd, Proof, Timestamp};
 /// There are two separate functions to allow for validation of the block given the different
 /// hash mechanisms: [`validate_block_hashes_v1`] and [`validate_block_hashes_v2`].
 #[derive(
-    Copy, Clone, Default, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize, Debug,
+    Copy,
+    Clone,
+    Default,
+    PartialOrd,
+    Ord,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    Debug,
+    JsonSchema,
 )]
 #[serde(deny_unknown_fields)]
 pub struct BlockHash(Digest);
@@ -322,4 +334,15 @@ impl ToBytes for Block {
             + self.header.serialized_length()
             + self.body.serialized_length()
     }
+}
+
+/// Describes a block's hash and height.
+#[derive(Clone, Copy, Default, Eq, JsonSchema, Serialize, Deserialize, Debug, PartialEq)]
+pub struct BlockHashAndHeight {
+    /// The hash of the block.
+    #[schemars(description = "The hash of this deploy's block.")]
+    pub block_hash: BlockHash,
+    /// The height of the block.
+    #[schemars(description = "The height of this deploy's block.")]
+    pub block_height: u64,
 }


### PR DESCRIPTION
The JSON schema for the info_get_deploy RPC query was changed in https://github.com/casper-network/casper-node/pull/3008. This PR updates the `GetDeployResponse` struct for v1.5.0.