### PR TITLE
More informative `InvalidRpcResponse` error

### DIFF
--- a/lib/error.rs
+++ b/lib/error.rs
@@ -92,7 +92,7 @@ pub enum Error {
         /// The JSON-RPC request method.
         rpc_method: &'static str,
         /// What kind of Json response was received.
-        response_kind: String,
+        response_kind: &'static str,
         /// The JSON response.
         response: serde_json::Value,
         /// If available, the original error from Serde.

--- a/lib/error.rs
+++ b/lib/error.rs
@@ -84,7 +84,7 @@ pub enum Error {
 
     /// Invalid response returned from the node.
     #[error(
-        "response for rpc-id {rpc_id} {rpc_method} is not valid because {source:?}: {response}"
+        "response {response_kind} for rpc-id {rpc_id} {rpc_method} is not valid because {source:?}: {response}"
     )]
     InvalidRpcResponse {
         /// The JSON-RPC ID.

--- a/lib/error.rs
+++ b/lib/error.rs
@@ -83,14 +83,20 @@ pub enum Error {
     },
 
     /// Invalid response returned from the node.
-    #[error("response for rpc-id {rpc_id} {rpc_method} is not valid: {response}")]
+    #[error(
+        "response for rpc-id {rpc_id} {rpc_method} is not valid because {source:?}: {response}"
+    )]
     InvalidRpcResponse {
         /// The JSON-RPC ID.
         rpc_id: JsonRpcId,
         /// The JSON-RPC request method.
         rpc_method: &'static str,
+        /// What kind of Json response was received.
+        response_kind: String,
         /// The JSON response.
         response: serde_json::Value,
+        /// If available, the original error from Serde.
+        source: Option<serde_json::Error>,
     },
 
     /// Failed to encode to JSON.

--- a/lib/json_rpc/call.rs
+++ b/lib/json_rpc/call.rs
@@ -94,7 +94,7 @@ impl Call {
                 serde_json::from_value(json_value).map_err(|err| Error::InvalidRpcResponse {
                     rpc_id: self.rpc_id.clone(),
                     rpc_method: method,
-                    response_kind: response_kind.to_string(),
+                    response_kind,
                     response: json!(rpc_response),
                     source: Some(err),
                 })?;
@@ -113,7 +113,7 @@ impl Call {
         Err(Error::InvalidRpcResponse {
             rpc_id: self.rpc_id.clone(),
             rpc_method: method,
-            response_kind: response_kind.to_string(),
+            response_kind,
             response: json!(rpc_response),
             source: None,
         })

--- a/lib/json_rpc/call.rs
+++ b/lib/json_rpc/call.rs
@@ -82,12 +82,21 @@ impl Call {
 
         crate::json_pretty_print(&rpc_response, self.verbosity)?;
 
+        let response_kind = match &rpc_response {
+            JsonRpc::Request(_) => "Request",
+            JsonRpc::Notification(_) => "Notification",
+            JsonRpc::Success(_) => "Success",
+            JsonRpc::Error(_) => "Error",
+        };
+
         if let Some(json_value) = rpc_response.get_result().cloned() {
             let value =
-                serde_json::from_value(json_value).map_err(|_| Error::InvalidRpcResponse {
+                serde_json::from_value(json_value).map_err(|err| Error::InvalidRpcResponse {
                     rpc_id: self.rpc_id.clone(),
                     rpc_method: method,
+                    response_kind: response_kind.to_string(),
                     response: json!(rpc_response),
+                    source: Some(err),
                 })?;
             let success_response = SuccessResponse::new(self.rpc_id.clone(), value);
             return Ok(success_response);
@@ -104,7 +113,9 @@ impl Call {
         Err(Error::InvalidRpcResponse {
             rpc_id: self.rpc_id.clone(),
             rpc_method: method,
+            response_kind: response_kind.to_string(),
             response: json!(rpc_response),
+            source: None,
         })
     }
 }


### PR DESCRIPTION
This PR extends the `InvalidRpcResponse` error variant to provide the original error message from serde (if available) and response kind (on of `Request`, `Notification`, `Success` or `Error`)