### PR TITLE
Reinstate `get-balance` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to this project will be documented in this file.  The format
 * Move the previous top-level library API, which targets CLI consumers, to a new module `cli`.
 * Rename subcommand `get-account-info` to `get-account` while retaining the previous name as an alias for backwards compatibility.
 * Rename subcommand `get-era-info-by-switch-block` to `get-era-info` while retaining the previous name as an alias for backwards compatibility.
-* Alias subcommand `query-balance` to `get-balance` to retain backwards compatibility.
+* Deprecated `get-balance` subcommand in favor of the newly added `query-balance` subcommand.
 
 ### Removed
 * Remove the C library support.

--- a/README.md
+++ b/README.md
@@ -404,15 +404,15 @@ cargo run --release -- query-global-state \
 This yields details of the newly-created account object, including the `URef` of the account's main purse.
 
 
-### Get the balance of a purse
+### Query the balance of a purse
 
-This can be done via `get-balance`. For example, to get the balance of the main purse of our newly-created account:
+This can be done via `query-balance`. For example, to get the balance of the main purse of our newly-created account:
 
 ```
-cargo run --release -- get-balance \
+cargo run --release -- query-balance \
     --node-address=http://localhost:11101 \
     --state-root-hash=242666f5959e6a51b7a75c23264f3cb326eecd6bec6dbab147f5801ec23daed6 \
-    --purse-uref=uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007
+    --purse-identifier=account-hash-f7196ed0f4a4aa2aae02daa8f0bdad39ed3098c028979db4f96c3c25670a8240
 ```
 
 <details><summary>example output</summary>

--- a/src/common.rs
+++ b/src/common.rs
@@ -265,6 +265,68 @@ pub(super) mod public_key {
     }
 }
 
+pub(super) mod purse_identifier {
+    use super::*;
+
+    /// Legacy name of purse identifier argument from when the command was named "get-balance".
+    pub(crate) const PURSE_IDENTIFIER_ALIAS: &str = "purse-uref";
+
+    pub(super) const ARG_NAME: &str = "purse-identifier";
+    const ARG_SHORT: char = 'p';
+    const ARG_VALUE_NAME: &str = "FORMATTED STRING or PATH";
+    const ARG_HELP: &str =
+        "The identifier for the purse. This can be a public key or account hash, implying the main \
+        purse of the given account should be used. Alternatively it can be a purse URef. To \
+        provide a public key, it must be a properly formatted public key. The public key may \
+        be read in from a file, in which case enter the path to the file as the --purse-identifier \
+        argument. The file should be one of the two public key files generated via the `keygen` \
+        subcommand; \"public_key_hex\" or \"public_key.pem\". To provide an account hash, it must \
+        be formatted as \"account-hash-<HEX STRING>\", or for a URef as \
+        \"uref-<HEX STRING>-<THREE DIGIT INTEGER>\"";
+
+    pub fn arg(order: usize, is_required: bool) -> Arg<'static> {
+        Arg::new(ARG_NAME)
+            .alias(PURSE_IDENTIFIER_ALIAS)
+            .long(ARG_NAME)
+            .short(ARG_SHORT)
+            .required(is_required)
+            .value_name(ARG_VALUE_NAME)
+            .help(ARG_HELP)
+            .display_order(order)
+    }
+
+    pub fn get(matches: &ArgMatches) -> Result<String, CliError> {
+        let value = matches.value_of(ARG_NAME).unwrap_or_default();
+        public_key::try_read_from_file(value)
+    }
+}
+
+/// Handles providing the arg for and retrieval of the purse URef.
+pub(super) mod purse_uref {
+    use super::*;
+
+    pub const ARG_NAME: &str = "purse-uref";
+    const ARG_SHORT: char = 'u';
+    const ARG_VALUE_NAME: &str = "FORMATTED STRING";
+    const ARG_HELP: &str =
+        "The URef under which the purse is stored. This must be a properly formatted URef \
+        \"uref-<HEX STRING>-<THREE DIGIT INTEGER>\"";
+
+    pub fn arg(display_order: usize, is_required: bool) -> Arg<'static> {
+        Arg::new(ARG_NAME)
+            .long(ARG_NAME)
+            .short(ARG_SHORT)
+            .required(is_required)
+            .value_name(ARG_VALUE_NAME)
+            .help(ARG_HELP)
+            .display_order(display_order)
+    }
+
+    pub fn get(matches: &ArgMatches) -> Option<&str> {
+        matches.value_of(ARG_NAME)
+    }
+}
+
 /// Handles providing the arg for and retrieval of the session account arg when specifying an
 /// account for a Deploy.
 pub(super) mod session_account {

--- a/src/get_balance.rs
+++ b/src/get_balance.rs
@@ -21,7 +21,8 @@ enum DisplayOrder {
 #[async_trait]
 impl ClientCommand for GetBalance {
     const NAME: &'static str = "get-balance";
-    const ABOUT: &'static str = "Retrieve a purse's balance from the network";
+    const ABOUT: &'static str = "Retrieve a purse's balance from the network\n\
+                                NOTE: This command is deprecated; use `query-balance` instead.";
 
     fn build(display_order: usize) -> Command<'static> {
         Command::new(Self::NAME)

--- a/src/get_balance.rs
+++ b/src/get_balance.rs
@@ -1,0 +1,64 @@
+use std::str;
+
+use async_trait::async_trait;
+use clap::{ArgMatches, Command};
+
+use casper_client::cli::CliError;
+
+use crate::{command::ClientCommand, common, Success};
+
+pub struct GetBalance;
+
+/// This struct defines the order in which the args are shown for this subcommand's help message.
+enum DisplayOrder {
+    Verbose,
+    NodeAddress,
+    RpcId,
+    StateRootHash,
+    PurseURef,
+}
+
+#[async_trait]
+impl ClientCommand for GetBalance {
+    const NAME: &'static str = "get-balance";
+    const ABOUT: &'static str = "Retrieve a purse's balance from the network";
+
+    fn build(display_order: usize) -> Command<'static> {
+        Command::new(Self::NAME)
+            .about(Self::ABOUT)
+            .display_order(display_order)
+            .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
+            .arg(common::node_address::arg(
+                DisplayOrder::NodeAddress as usize,
+            ))
+            .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
+            .arg(common::state_root_hash::arg(
+                DisplayOrder::StateRootHash as usize,
+                true,
+            ))
+            .arg(common::purse_uref::arg(
+                DisplayOrder::PurseURef as usize,
+                true,
+            ))
+    }
+
+    async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
+        let maybe_rpc_id = common::rpc_id::get(matches);
+        let node_address = common::node_address::get(matches);
+        let verbosity_level = common::verbose::get(matches);
+        let state_root_hash = common::state_root_hash::get(matches)
+            .unwrap_or_else(|| panic!("should have {} arg", common::state_root_hash::ARG_NAME));
+        let purse_uref = common::purse_uref::get(matches)
+            .unwrap_or_else(|| panic!("should have {} arg", common::purse_uref::ARG_NAME));
+
+        casper_client::cli::get_balance(
+            maybe_rpc_id,
+            node_address,
+            verbosity_level,
+            state_root_hash,
+            purse_uref,
+        )
+        .await
+        .map(Success::from)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ fn cli() -> Command<'static> {
         .subcommand(SendDeploy::build(DisplayOrder::SendDeploy as usize))
         .subcommand(Transfer::build(DisplayOrder::Transfer as usize))
         .subcommand(MakeTransfer::build(DisplayOrder::MakeTransfer as usize))
-        .subcommand(GetBalance::build(DisplayOrder::GetBalance as usize))
+        .subcommand(GetBalance::build(DisplayOrder::GetBalance as usize).hide(true))
         .subcommand(GetDeploy::build(DisplayOrder::GetDeploy as usize))
         .subcommand(GetBlock::build(DisplayOrder::GetBlock as usize))
         .subcommand(GetBlockTransfers::build(

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod deploy;
 mod generate_completion;
 mod get_account;
 mod get_auction_info;
+mod get_balance;
 mod get_chainspec;
 mod get_dictionary_item;
 mod get_era_info;
@@ -21,6 +22,7 @@ mod query_global_state;
 use std::process;
 
 use clap::{crate_version, Command};
+use get_balance::GetBalance;
 use once_cell::sync::Lazy;
 
 use casper_client::{cli, rpcs::results::GetChainspecResult, SuccessResponse};
@@ -71,6 +73,7 @@ enum DisplayOrder {
     Transfer,
     MakeTransfer,
     GetDeploy,
+    GetBalance,
     GetBlock,
     GetBlockTransfers,
     ListDeploys,
@@ -101,6 +104,7 @@ fn cli() -> Command<'static> {
         .subcommand(SendDeploy::build(DisplayOrder::SendDeploy as usize))
         .subcommand(Transfer::build(DisplayOrder::Transfer as usize))
         .subcommand(MakeTransfer::build(DisplayOrder::MakeTransfer as usize))
+        .subcommand(GetBalance::build(DisplayOrder::GetBalance as usize))
         .subcommand(GetDeploy::build(DisplayOrder::GetDeploy as usize))
         .subcommand(GetBlock::build(DisplayOrder::GetBlock as usize))
         .subcommand(GetBlockTransfers::build(
@@ -151,6 +155,7 @@ async fn main() {
         Transfer::NAME => Transfer::run(matches).await,
         MakeTransfer::NAME => MakeTransfer::run(matches).await,
         GetDeploy::NAME => GetDeploy::run(matches).await,
+        GetBalance::NAME => GetBalance::run(matches).await,
         GetBlock::NAME => GetBlock::run(matches).await,
         GetBlockTransfers::NAME => GetBlockTransfers::run(matches).await,
         ListDeploys::NAME => ListDeploys::run(matches).await,

--- a/src/query_balance.rs
+++ b/src/query_balance.rs
@@ -1,16 +1,11 @@
 use std::str;
 
 use async_trait::async_trait;
-use clap::{Arg, ArgGroup, ArgMatches, Command};
+use clap::{ArgGroup, ArgMatches, Command};
 
 use casper_client::cli::CliError;
 
 use crate::{command::ClientCommand, common, Success};
-
-/// Legacy name of command.
-const COMMAND_ALIAS: &str = "get-balance";
-/// Legacy name of purse identifier argument from when the command was named "get-balance".
-const PURSE_IDENTIFIER_ALIAS: &str = "purse-uref";
 
 /// String to explain how to use the block identifier and state root hash args.
 const AFTER_HELP: &str =
@@ -30,39 +25,6 @@ enum DisplayOrder {
     PurseIdentifier,
 }
 
-mod purse_identifier {
-    use super::*;
-
-    pub(super) const ARG_NAME: &str = "purse-identifier";
-    const ARG_SHORT: char = 'p';
-    const ARG_VALUE_NAME: &str = "FORMATTED STRING or PATH";
-    const ARG_HELP: &str =
-        "The identifier for the purse. This can be a public key or account hash, implying the main \
-        purse of the given account should be used. Alternatively it can be a purse URef. To \
-        provide a public key, it must be a properly formatted public key. The public key may \
-        be read in from a file, in which case enter the path to the file as the --purse-identifier \
-        argument. The file should be one of the two public key files generated via the `keygen` \
-        subcommand; \"public_key_hex\" or \"public_key.pem\". To provide an account hash, it must \
-        be formatted as \"account-hash-<HEX STRING>\", or for a URef as \
-        \"uref-<HEX STRING>-<THREE DIGIT INTEGER>\"";
-
-    pub fn arg() -> Arg<'static> {
-        Arg::new(ARG_NAME)
-            .alias(PURSE_IDENTIFIER_ALIAS)
-            .long(ARG_NAME)
-            .short(ARG_SHORT)
-            .required(true)
-            .value_name(ARG_VALUE_NAME)
-            .help(ARG_HELP)
-            .display_order(DisplayOrder::PurseIdentifier as usize)
-    }
-
-    pub fn get(matches: &ArgMatches) -> Result<String, CliError> {
-        let value = matches.value_of(ARG_NAME).unwrap_or_default();
-        common::public_key::try_read_from_file(value)
-    }
-}
-
 #[async_trait]
 impl ClientCommand for QueryBalance {
     const NAME: &'static str = "query-balance";
@@ -70,7 +32,6 @@ impl ClientCommand for QueryBalance {
 
     fn build(display_order: usize) -> Command<'static> {
         Command::new(Self::NAME)
-            .alias(COMMAND_ALIAS)
             .about(Self::ABOUT)
             .after_help(AFTER_HELP)
             .display_order(display_order)
@@ -93,7 +54,10 @@ impl ClientCommand for QueryBalance {
                     .arg(common::state_root_hash::ARG_NAME)
                     .required(false),
             )
-            .arg(purse_identifier::arg())
+            .arg(common::purse_identifier::arg(
+                DisplayOrder::PurseIdentifier as usize,
+                true,
+            ))
     }
 
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
@@ -103,7 +67,7 @@ impl ClientCommand for QueryBalance {
 
         let maybe_block_id = common::block_identifier::get(matches);
         let maybe_state_root_hash = common::state_root_hash::get(matches).unwrap_or_default();
-        let purse_id = purse_identifier::get(matches)?;
+        let purse_id = common::purse_identifier::get(matches)?;
 
         casper_client::cli::query_balance(
             maybe_rpc_id,


### PR DESCRIPTION
Fixes https://github.com/casper-network/casper-node/issues/3045

This PR reinstates the `get-balance` subcommand by removing the alias from `query-balance` and restoring the deleted functionality. Additionally, `get-balance` was also marked as deprecated in the `about` section of the command. I am open to any other suggestions towards marking the functionality as deprecated.