### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## [1.5.0] - 2022-05-13
+
+### Changed
+* Update dependencies.
+
+
+
 ## [1.4.4] - 2022-04-06
 
 ### Changed
@@ -167,7 +174,8 @@ No changes.
 
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0
-[unreleased]: https://github.com/casper-ecosystem/casper-client-rs/compare/v1.4.4...main
+[unreleased]: https://github.com/casper-ecosystem/casper-client-rs/compare/v1.5.0...main
+[1.5.0]: https://github.com/casper-ecosystem/casper-client-rs/compare/v1.4.5...v1.5.0
 [1.4.4]: https://github.com/casper-ecosystem/casper-client-rs/compare/v1.4.3...v1.4.4
 [1.4.3]: https://github.com/casper-ecosystem/casper-client-rs/compare/v1.4.2...v1.4.3
 [1.4.2]: https://github.com/casper-ecosystem/casper-client-rs/compare/v1.4.1...v1.4.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-client"
-version = "1.4.4" # when updating, also update 'html_root_url' in lib.rs
+version = "1.5.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2021"
 description = "A client library and binary for interacting with the Casper network"
@@ -20,16 +20,16 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-async-trait = "0.1.52"
+async-trait = "0.1.56"
 base16 = "0.2.1"
 base64 = "0.13.0"
 casper-hashing = "*"
 casper-types = { version = "*", features = ["datasize"] }
-clap = { version = "3", features = ["cargo"] }
+clap = { version = "3", features = ["cargo", "deprecated"] }
 clap_complete = "3"
 derp = "0.0.14"
 ed25519-dalek = { version = "1", default-features = false }
-getrandom = "0.2.5"
+getrandom = "0.2.7"
 hex-buffer-serde = "0.3.0"
 humantime = "2"
 itertools = "0.10.3"
@@ -38,28 +38,18 @@ k256 = { version = "0.7.2", features = ["arithmetic", "ecdsa", "sha256", "zeroiz
 once_cell = "1"
 pem = "1"
 rand = "0.8.5"
-reqwest = { version = "0.11.9", features = ["json"] }
+reqwest = { version = "0.11.11", features = ["json"] }
 schemars = "0.8"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1"
 signature = "1"
 tempfile = "3"
 thiserror = "1"
-tokio = { version = "1.17", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.19", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 untrusted = "0.7.1"
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["git"] }
-
-[dev-dependencies]
-anyhow = "1"
-futures = "0.3.21"
-hyper = "0.14.17"
-semver = "1"
-serde = "1"
-tower = "0.4.12"
-warp = "0.3.2"
-warp-json-rpc = "0.3.0"
 
 [patch.crates-io]
 casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "dev" }

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -23,7 +23,7 @@
 //!   latest `Block` known on the server will be used.
 
 #![doc(
-    html_root_url = "https://docs.rs/casper-client/1.4.4",
+    html_root_url = "https://docs.rs/casper-client/1.5.0",
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",
     test(attr(forbid(warnings)))

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use clap::{Arg, ArgMatches};
+use clap::{Arg, ArgAction, ArgMatches};
 
 use casper_client::cli::CliError;
 use casper_types::PublicKey;
@@ -24,16 +24,15 @@ pub mod verbose {
         Arg::new(ARG_NAME)
             .short(ARG_NAME_SHORT)
             .required(false)
-            .multiple_occurrences(true)
+            .action(ArgAction::Count)
             .help(ARG_HELP)
             .display_order(order)
     }
 
     pub fn get(matches: &ArgMatches) -> u64 {
-        if matches.is_valid_arg(ARG_NAME) {
-            matches.occurrences_of(ARG_NAME)
-        } else {
-            0
+        match matches.try_get_one::<u8>(ARG_NAME) {
+            Ok(maybe_count) => maybe_count.copied().unwrap_or_default() as u64,
+            Err(_) => 0,
         }
     }
 }
@@ -61,7 +60,8 @@ pub mod node_address {
 
     pub fn get(matches: &ArgMatches) -> &str {
         matches
-            .value_of(ARG_NAME)
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
             .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME))
     }
 }
@@ -86,7 +86,10 @@ pub mod rpc_id {
     }
 
     pub fn get(matches: &ArgMatches) -> &str {
-        matches.value_of(ARG_NAME).unwrap_or_default()
+        matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_default()
     }
 }
 
@@ -110,7 +113,8 @@ pub mod secret_key {
 
     pub fn get(matches: &ArgMatches) -> &str {
         matches
-            .value_of(ARG_NAME)
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
             .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME))
     }
 }
@@ -133,6 +137,7 @@ pub mod force {
             .long(ARG_NAME)
             .short(ARG_SHORT)
             .required(false)
+            .action(ArgAction::SetTrue)
             .help(if singular {
                 ARG_HELP_SINGULAR
             } else {
@@ -142,7 +147,10 @@ pub mod force {
     }
 
     pub fn get(matches: &ArgMatches) -> bool {
-        matches.is_present(ARG_NAME)
+        matches
+            .get_one::<bool>(ARG_NAME)
+            .copied()
+            .unwrap_or_default()
     }
 }
 
@@ -166,7 +174,7 @@ pub mod state_root_hash {
     }
 
     pub(crate) fn get(matches: &ArgMatches) -> Option<&str> {
-        matches.value_of(ARG_NAME)
+        matches.get_one::<String>(ARG_NAME).map(String::as_str)
     }
 }
 
@@ -197,7 +205,10 @@ pub mod block_identifier {
     }
 
     pub(crate) fn get(matches: &ArgMatches) -> &str {
-        matches.value_of(ARG_NAME).unwrap_or_default()
+        matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_default()
     }
 }
 
@@ -228,13 +239,16 @@ pub(super) mod public_key {
     }
 
     pub fn get(matches: &ArgMatches, is_required: bool) -> Result<String, CliError> {
-        let value = matches.value_of(ARG_NAME).unwrap_or_else(|| {
-            if is_required {
-                panic!("should have {} arg", ARG_NAME)
-            } else {
-                ""
-            }
-        });
+        let value = matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_else(|| {
+                if is_required {
+                    panic!("should have {} arg", ARG_NAME)
+                } else {
+                    ""
+                }
+            });
         try_read_from_file(value)
     }
 
@@ -296,7 +310,10 @@ pub(super) mod purse_identifier {
     }
 
     pub fn get(matches: &ArgMatches) -> Result<String, CliError> {
-        let value = matches.value_of(ARG_NAME).unwrap_or_default();
+        let value = matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_default();
         public_key::try_read_from_file(value)
     }
 }
@@ -323,7 +340,7 @@ pub(super) mod purse_uref {
     }
 
     pub fn get(matches: &ArgMatches) -> Option<&str> {
-        matches.value_of(ARG_NAME)
+        matches.get_one::<String>(ARG_NAME).map(String::as_str)
     }
 }
 
@@ -351,7 +368,10 @@ pub(super) mod session_account {
     }
 
     pub fn get(matches: &ArgMatches) -> Result<String, CliError> {
-        let value = matches.value_of(ARG_NAME).unwrap_or_default();
+        let value = matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_default();
         super::public_key::try_read_from_file(value)
     }
 }

--- a/src/deploy/creation_common.rs
+++ b/src/deploy/creation_common.rs
@@ -3,7 +3,7 @@
 
 use std::process;
 
-use clap::{Arg, ArgGroup, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgGroup, ArgMatches, Command};
 
 use casper_client::cli::{help, PaymentStrParams, SessionStrParams};
 
@@ -63,19 +63,19 @@ pub(super) mod show_arg_examples {
             .long(ARG_NAME)
             .short(ARG_SHORT)
             .required(false)
+            .action(ArgAction::SetTrue)
             .help(ARG_HELP)
             .display_order(DisplayOrder::ShowArgExamples as usize)
     }
 
     pub(in crate::deploy) fn get(matches: &ArgMatches) -> bool {
-        if !matches.is_present(ARG_NAME) {
-            return false;
+        if let Some(true) = matches.get_one::<bool>(ARG_NAME) {
+            println!("Examples for passing values via --session-arg or --payment-arg:");
+            println!("{}", help::supported_cl_type_examples());
+            return true;
         }
 
-        println!("Examples for passing values via --session-arg or --payment-arg:");
-        println!("{}", help::supported_cl_type_examples());
-
-        true
+        false
     }
 }
 
@@ -205,7 +205,10 @@ pub(super) mod timestamp {
     }
 
     pub(in crate::deploy) fn get(matches: &ArgMatches) -> &str {
-        matches.value_of(ARG_NAME).unwrap_or_default()
+        matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_default()
     }
 }
 
@@ -233,7 +236,10 @@ pub(super) mod ttl {
     }
 
     pub(in crate::deploy) fn get(matches: &ArgMatches) -> &str {
-        matches.value_of(ARG_NAME).unwrap_or_default()
+        matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_default()
     }
 }
 
@@ -258,7 +264,8 @@ pub(super) mod chain_name {
 
     pub(in crate::deploy) fn get(matches: &ArgMatches) -> &str {
         matches
-            .value_of(ARG_NAME)
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
             .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME))
     }
 }
@@ -283,7 +290,7 @@ pub(super) mod session_path {
     }
 
     pub(in crate::deploy) fn get(matches: &ArgMatches) -> Option<&str> {
-        matches.value_of(ARG_NAME)
+        matches.get_one::<String>(ARG_NAME).map(String::as_str)
     }
 }
 
@@ -317,7 +324,11 @@ pub(super) mod arg_simple {
         }
 
         pub fn get(matches: &ArgMatches) -> Vec<&str> {
-            matches.values_of(ARG_NAME).into_iter().flatten().collect()
+            matches
+                .get_many::<String>(ARG_NAME)
+                .unwrap_or_default()
+                .map(|simple_session_arg| simple_session_arg.as_str())
+                .collect()
         }
     }
 
@@ -332,7 +343,11 @@ pub(super) mod arg_simple {
         }
 
         pub fn get(matches: &ArgMatches) -> Vec<&str> {
-            matches.values_of(ARG_NAME).into_iter().flatten().collect()
+            matches
+                .get_many::<String>(ARG_NAME)
+                .unwrap_or_default()
+                .map(|simple_payment_arg| simple_payment_arg.as_str())
+                .collect()
         }
     }
 
@@ -340,7 +355,7 @@ pub(super) mod arg_simple {
         Arg::new(name)
             .long(name)
             .required(false)
-            .multiple_occurrences(true)
+            .action(ArgAction::Append)
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP.as_str())
             .display_order(order)
@@ -368,7 +383,10 @@ pub(super) mod args_complex {
         }
 
         pub fn get(matches: &ArgMatches) -> &str {
-            matches.value_of(ARG_NAME).unwrap_or_default()
+            matches
+                .get_one::<String>(ARG_NAME)
+                .map(String::as_str)
+                .unwrap_or_default()
         }
     }
 
@@ -383,7 +401,10 @@ pub(super) mod args_complex {
         }
 
         pub fn get(matches: &ArgMatches) -> &str {
-            matches.value_of(ARG_NAME).unwrap_or_default()
+            matches
+                .get_one::<String>(ARG_NAME)
+                .map(String::as_str)
+                .unwrap_or_default()
         }
     }
 
@@ -415,7 +436,7 @@ pub(super) mod payment_path {
     }
 
     pub fn get(matches: &ArgMatches) -> Option<&str> {
-        matches.value_of(ARG_NAME)
+        matches.get_one::<String>(ARG_NAME).map(String::as_str)
     }
 }
 
@@ -442,7 +463,7 @@ pub(super) mod standard_payment_amount {
     }
 
     pub fn get(matches: &ArgMatches) -> Option<&str> {
-        matches.value_of(ARG_NAME)
+        matches.get_one::<String>(ARG_NAME).map(String::as_str)
     }
 }
 
@@ -567,7 +588,7 @@ pub(super) mod output {
     }
 
     pub fn get(matches: &ArgMatches) -> Option<&str> {
-        matches.value_of(ARG_NAME)
+        matches.get_one::<String>(ARG_NAME).map(String::as_str)
     }
 }
 
@@ -591,7 +612,8 @@ pub(super) mod input {
 
     pub fn get(matches: &ArgMatches) -> &str {
         matches
-            .value_of(ARG_NAME)
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
             .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME))
     }
 }
@@ -614,7 +636,7 @@ pub(super) mod session_hash {
     }
 
     pub fn get(matches: &ArgMatches) -> Option<&str> {
-        matches.value_of(ARG_NAME)
+        matches.get_one::<String>(ARG_NAME).map(String::as_str)
     }
 }
 
@@ -636,7 +658,7 @@ pub(super) mod session_name {
     }
 
     pub fn get(matches: &ArgMatches) -> Option<&str> {
-        matches.value_of(ARG_NAME)
+        matches.get_one::<String>(ARG_NAME).map(String::as_str)
     }
 }
 
@@ -649,13 +671,17 @@ pub(super) mod is_session_transfer {
     pub fn arg() -> Arg<'static> {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
+            .action(ArgAction::SetTrue)
             .help(ARG_HELP)
             .required(false)
             .display_order(DisplayOrder::SessionTransfer as usize)
     }
 
     pub fn get(matches: &ArgMatches) -> bool {
-        matches.is_present(ARG_NAME)
+        matches
+            .get_one::<bool>(ARG_NAME)
+            .copied()
+            .unwrap_or_default()
     }
 }
 
@@ -677,7 +703,7 @@ pub(super) mod session_package_hash {
     }
 
     pub fn get(matches: &ArgMatches) -> Option<&str> {
-        matches.value_of(ARG_NAME)
+        matches.get_one::<String>(ARG_NAME).map(String::as_str)
     }
 }
 
@@ -699,7 +725,7 @@ pub(super) mod session_package_name {
     }
 
     pub fn get(matches: &ArgMatches) -> Option<&str> {
-        matches.value_of(ARG_NAME)
+        matches.get_one::<String>(ARG_NAME).map(String::as_str)
     }
 }
 
@@ -720,7 +746,10 @@ pub(super) mod session_entry_point {
     }
 
     pub fn get(matches: &ArgMatches) -> &str {
-        matches.value_of(ARG_NAME).unwrap_or_default()
+        matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_default()
     }
 }
 
@@ -741,7 +770,10 @@ pub(super) mod session_version {
     }
 
     pub fn get(matches: &ArgMatches) -> &str {
-        matches.value_of(ARG_NAME).unwrap_or_default()
+        matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_default()
     }
 }
 
@@ -763,7 +795,7 @@ pub(super) mod payment_hash {
     }
 
     pub fn get(matches: &ArgMatches) -> Option<&str> {
-        matches.value_of(ARG_NAME)
+        matches.get_one::<String>(ARG_NAME).map(String::as_str)
     }
 }
 
@@ -786,7 +818,7 @@ pub(super) mod payment_name {
     }
 
     pub fn get(matches: &ArgMatches) -> Option<&str> {
-        matches.value_of(ARG_NAME)
+        matches.get_one::<String>(ARG_NAME).map(String::as_str)
     }
 }
 
@@ -808,7 +840,7 @@ pub(super) mod payment_package_hash {
     }
 
     pub fn get(matches: &ArgMatches) -> Option<&str> {
-        matches.value_of(ARG_NAME)
+        matches.get_one::<String>(ARG_NAME).map(String::as_str)
     }
 }
 
@@ -830,7 +862,7 @@ pub(super) mod payment_package_name {
     }
 
     pub fn get(matches: &ArgMatches) -> Option<&str> {
-        matches.value_of(ARG_NAME)
+        matches.get_one::<String>(ARG_NAME).map(String::as_str)
     }
 }
 
@@ -851,7 +883,10 @@ pub(super) mod payment_entry_point {
     }
 
     pub fn get(matches: &ArgMatches) -> &str {
-        matches.value_of(ARG_NAME).unwrap_or_default()
+        matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_default()
     }
 }
 
@@ -872,6 +907,9 @@ pub(super) mod payment_version {
     }
 
     pub fn get(matches: &ArgMatches) -> &str {
-        matches.value_of(ARG_NAME).unwrap_or_default()
+        matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_default()
     }
 }

--- a/src/deploy/get.rs
+++ b/src/deploy/get.rs
@@ -35,7 +35,8 @@ mod deploy_hash {
 
     pub(super) fn get(matches: &ArgMatches) -> &str {
         matches
-            .value_of(ARG_NAME)
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
             .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME))
     }
 }

--- a/src/deploy/transfer.rs
+++ b/src/deploy/transfer.rs
@@ -27,7 +27,8 @@ pub(super) mod amount {
 
     pub(in crate::deploy) fn get(matches: &ArgMatches) -> &str {
         matches
-            .value_of(ARG_NAME)
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
             .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME))
     }
 }
@@ -56,7 +57,10 @@ pub(super) mod target_account {
     }
 
     pub(in crate::deploy) fn get(matches: &ArgMatches) -> &str {
-        matches.value_of(ARG_NAME).unwrap_or_default()
+        matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_default()
     }
 }
 
@@ -80,7 +84,10 @@ pub(super) mod transfer_id {
     }
 
     pub(in crate::deploy) fn get(matches: &ArgMatches) -> &str {
-        matches.value_of(ARG_NAME).unwrap_or_default()
+        matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_default()
     }
 }
 

--- a/src/generate_completion.rs
+++ b/src/generate_completion.rs
@@ -1,7 +1,7 @@
-use std::{fs::File, path::PathBuf, process, str::FromStr};
+use std::{fs::File, path::PathBuf, process};
 
 use async_trait::async_trait;
-use clap::{crate_name, Arg, ArgMatches, Command};
+use clap::{crate_name, value_parser, Arg, ArgMatches, Command};
 use clap_complete::Shell;
 
 use casper_client::{cli::CliError, Error};
@@ -40,7 +40,7 @@ mod output_dir {
 
     pub(super) fn get(matches: &ArgMatches) -> PathBuf {
         matches
-            .value_of(ARG_NAME)
+            .get_one::<String>(ARG_NAME)
             .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME))
             .into()
     }
@@ -60,19 +60,16 @@ mod shell {
             .long(ARG_NAME)
             .required(false)
             .default_value(ARG_DEFAULT)
-            .possible_values(Shell::possible_values())
+            .value_parser(value_parser!(Shell))
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
             .display_order(DisplayOrder::Shell as usize)
     }
 
     pub fn get(matches: &ArgMatches) -> Shell {
-        Shell::from_str(
-            matches
-                .value_of(ARG_NAME)
-                .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME)),
-        )
-        .unwrap_or_else(|error| panic!("invalid value for --{}: {}", ARG_NAME, error))
+        *matches
+            .get_one::<Shell>(ARG_NAME)
+            .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME))
     }
 }
 

--- a/src/get_dictionary_item.rs
+++ b/src/get_dictionary_item.rs
@@ -47,7 +47,10 @@ mod key {
     }
 
     pub(super) fn get(arg_name: &'static str, matches: &ArgMatches) -> Result<String, CliError> {
-        let value = matches.value_of(arg_name).unwrap_or_default();
+        let value = matches
+            .get_one::<String>(arg_name)
+            .map(String::as_str)
+            .unwrap_or_default();
 
         // Try to read as a PublicKey PEM file first.
         if let Ok(public_key) = PublicKey::from_file(value) {
@@ -126,7 +129,10 @@ mod dictionary_name {
     }
 
     pub(super) fn get(matches: &ArgMatches) -> &str {
-        matches.value_of(ARG_NAME).unwrap_or_default()
+        matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_default()
     }
 }
 
@@ -148,7 +154,10 @@ mod dictionary_item_key {
     }
 
     pub(super) fn get(matches: &ArgMatches) -> &str {
-        matches.value_of(ARG_NAME).unwrap_or_default()
+        matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_default()
     }
 }
 
@@ -171,7 +180,10 @@ mod seed_uref {
     }
 
     pub(super) fn get(matches: &ArgMatches) -> &str {
-        matches.value_of(ARG_NAME).unwrap_or_default()
+        matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_default()
     }
 }
 
@@ -193,7 +205,10 @@ mod dictionary_address {
     }
 
     pub(super) fn get(matches: &ArgMatches) -> &str {
-        matches.value_of(ARG_NAME).unwrap_or_default()
+        matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_default()
     }
 }
 

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use clap::{Arg, ArgMatches, Command};
+use clap::{builder::PossibleValuesParser, Arg, ArgMatches, Command};
 use once_cell::sync::Lazy;
 
 use casper_client::{
@@ -45,7 +45,10 @@ mod output_dir {
     }
 
     pub(super) fn get(matches: &ArgMatches) -> String {
-        matches.value_of(ARG_NAME).unwrap_or(".").to_string()
+        matches
+            .get_one::<String>(ARG_NAME)
+            .cloned()
+            .unwrap_or_else(|| ".".to_string())
     }
 }
 
@@ -64,8 +67,10 @@ mod algorithm {
             .short(ARG_SHORT)
             .required(false)
             .default_value(keygen::ED25519)
-            .possible_value(keygen::ED25519)
-            .possible_value(keygen::SECP256K1)
+            .value_parser(PossibleValuesParser::new([
+                keygen::ED25519,
+                keygen::SECP256K1,
+            ]))
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
             .display_order(DisplayOrder::Algorithm as usize)
@@ -73,7 +78,8 @@ mod algorithm {
 
     pub fn get(matches: &ArgMatches) -> &str {
         matches
-            .value_of(ARG_NAME)
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
             .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME))
     }
 }

--- a/src/query_global_state.rs
+++ b/src/query_global_state.rs
@@ -61,7 +61,8 @@ mod key {
 
     pub(crate) fn get(matches: &ArgMatches) -> Result<String, CliError> {
         let value = matches
-            .value_of(ARG_NAME)
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
             .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME));
 
         // Try to read as a PublicKey PEM file first.
@@ -109,7 +110,10 @@ mod path {
     }
 
     pub(crate) fn get(matches: &ArgMatches) -> &str {
-        matches.value_of(ARG_NAME).unwrap_or_default()
+        matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_default()
     }
 }
 


### PR DESCRIPTION
This PR updates the dependencies, with the bulk of the changes being to support clap 3.2.

This also brings over the relevant changes applied to the changelog and manifest in the `main` branch.