### PR TITLE
Avoid passing null params in RPC requests

### DIFF
--- a/lib/json_rpc/call.rs
+++ b/lib/json_rpc/call.rs
@@ -36,17 +36,18 @@ impl Call {
             format!("{}/{}", self.node_address, RPC_API_PATH)
         };
 
-        let params = match maybe_params {
-            Some(params) => Params::Map(
-                json!(params)
-                    .as_object()
-                    .unwrap_or_else(|| panic!("should be a JSON Map"))
-                    .clone(),
-            ),
-            None => Params::None(()),
+        let rpc_request = match maybe_params {
+            Some(params) => {
+                let params = Params::Map(
+                    json!(params)
+                        .as_object()
+                        .unwrap_or_else(|| panic!("should be a JSON Map"))
+                        .clone(),
+                );
+                JsonRpc::request_with_params(&self.rpc_id, method, params)
+            }
+            None => JsonRpc::request(&self.rpc_id, method),
         };
-
-        let rpc_request = JsonRpc::request_with_params(&self.rpc_id, method, params);
 
         crate::json_pretty_print(&rpc_request, self.verbosity)?;
 


### PR DESCRIPTION
This fixes the client to avoid sending JSON-RPC requests with `"params":null` since this is invalid and will be rejected by the node in the upcoming version.

Closes [#3152](https://github.com/casper-network/casper-node/issues/3152).