### PR TITLE
Provide support for passing runtime args as JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add support for new node RPC method `info_get_status`, used in the binary's new `get-node-status` subcommand.
 * Add support for new node RPC method `info_get_peers`, used in the binary's new `get-peers` subcommand.
 * Add support for new node RPC method `query_balance`, used in the binary's new `query-balance` subcommand.
+* Add support for passing payment and session args as JSON.
 
 ### Changed
 * Update dependencies.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ signature = "1"
 tempfile = "3"
 thiserror = "1"
 tokio = { version = "1.19", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
+uint = "0.9.0"
 untrusted = "0.7.1"
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -25,42 +25,42 @@ OPTIONS:
     -V, --version    Print version information
 
 SUBCOMMANDS:
-    put-deploy               Creates a deploy and sends it to the network for execution
-    make-deploy              Creates a deploy and outputs it to a file or stdout. As a file, the
-                                 deploy can subsequently be signed by other parties using the 'sign-
-                                 deploy' subcommand and then sent to the network for execution using
-                                 the 'send-deploy' subcommand
-    sign-deploy              Reads a previously-saved deploy from a file, cryptographically
-                                 signs it, and outputs it to a file or stdout
-    send-deploy              Reads a previously-saved deploy from a file and sends it to the
+    put-deploy               Create a deploy and send it to the network for execution
+    make-deploy              Create a deploy and output it to a file or stdout. As a file, the
+                                 deploy can subsequently be signed by other parties using the
+                                 'sign-deploy' subcommand and then sent to the network for execution
+                                 using the 'send-deploy' subcommand
+    sign-deploy              Read a previously-saved deploy from a file, cryptographically sign
+                                 it, and output it to a file or stdout
+    send-deploy              Read a previously-saved deploy from a file and send it to the
                                  network for execution
-    transfer                 Transfers funds between purses
-    make-transfer            Creates a transfer deploy and outputs it to a file or stdout. As a
+    transfer                 Transfer funds between purses
+    make-transfer            Create a transfer deploy and output it to a file or stdout. As a
                                  file, the deploy can subsequently be signed by other parties using
                                  the 'sign-deploy' subcommand and then sent to the network for
                                  execution using the 'send-deploy' subcommand
-    get-deploy               Retrieves a deploy from the network
-    get-block                Retrieves a block from the network
-    get-block-transfers      Retrieves all transfers for a block from the network
-    list-deploys             Retrieves the list of all deploy hashes in a given block
-    get-state-root-hash      Retrieves a state root hash at a given block
-    get-era-info             Retrieves era information from the network
-    query-global-state       Retrieves a stored value from the network using either the state
-                                 root hash or block hash
-    get-dictionary-item      Query for values managed in a dictionary
-    get-balance              Retrieves a purse's balance from the network
-    get-account              Retrieves account information from the network
-    get-auction-info         Returns the bids and validators as of either a specific block (by
+    get-deploy               Retrieve a deploy from the network
+    get-block                Retrieve a block from the network
+    get-block-transfers      Retrieve all transfers for a block from the network
+    list-deploys             Retrieve the list of all deploy hashes in a given block
+    get-state-root-hash      Retrieve a state root hash at a given block
+    get-era-info             Retrieve era information from the network
+    query-global-state       Retrieve a stored value from the network
+    query-balance            Retrieve a purse's balance from the network
+    get-dictionary-item      Retrieve a stored value from a dictionary
+    get-account              Retrieve account information from the network
+    get-auction-info         Retrieve the bids and validators as of either a specific block (by
                                  height or hash), or the most recently added block
-    get-validator-changes    Retrieves status changes of active validators
-    get-peers                Retrieves network identity and address of each of the specified
+    get-validator-changes    Retrieve status changes of active validators
+    get-peers                Retrieve network identity and address of each of the specified
                                  node's peers
-    get-node-status          Retrieves status of the specified node
-    get-chainspec            Retrieves the chainspec of the network
+    get-node-status          Retrieve status of the specified node
+    get-chainspec            Retrieve the chainspec of the network (to print the full TOML, run
+                                 with '-vv')
     list-rpcs                List all currently supported RPCs
-    keygen                   Generates account key files in the given directory
-    account-address          Generates an account hash from a given public key
-    generate-completion      Generates a shell completion script
+    keygen                   Generate account key files in the given directory
+    account-address          Generate an account hash from a given public key
+    generate-completion      Generate a shell completion script
     help                     Print this message or the help of the given subcommand(s)
 ```
 </details>

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -20,15 +20,16 @@
 //! * `maybe_block_id` - Must be a hex-encoded, 32-byte hash digest or a `u64` representing the
 //!   [`Block`] height or empty.  If empty, the latest `Block` known on the server will be used.
 
-mod cl_type;
 /// Deploy module.
 pub mod deploy;
 mod deploy_str_params;
 mod dictionary_item_str_params;
 mod error;
+mod json_args;
 mod parse;
 mod payment_str_params;
 mod session_str_params;
+mod simple_args;
 #[cfg(test)]
 mod tests;
 
@@ -54,12 +55,16 @@ use crate::{
 };
 #[cfg(doc)]
 use crate::{Account, Block, Deploy, Error, StoredValue, Transfer};
-pub use cl_type::help;
 pub use deploy_str_params::DeployStrParams;
 pub use dictionary_item_str_params::DictionaryItemStrParams;
 pub use error::CliError;
+use json_args::JsonArg;
+pub use json_args::{
+    help as json_args_help, Error as JsonArgsError, ErrorDetails as JsonArgsErrorDetails,
+};
 pub use payment_str_params::PaymentStrParams;
 pub use session_str_params::SessionStrParams;
+pub use simple_args::help as simple_args_help;
 
 /// Creates a [`Deploy`] and sends it to the network for execution.
 ///

--- a/lib/cli/error.rs
+++ b/lib/cli/error.rs
@@ -4,9 +4,10 @@ use humantime::{DurationError, TimestampError};
 use thiserror::Error;
 
 #[cfg(doc)]
-use casper_types::{account::AccountHash, Key, PublicKey, URef};
+use casper_types::{account::AccountHash, Key, NamedArg, PublicKey, RuntimeArgs, URef};
 use casper_types::{CLValueError, KeyFromStrError, UIntParseError, URefFromStrError};
 
+use crate::cli::JsonArgsError;
 #[cfg(doc)]
 use crate::{
     rpcs::{DictionaryItemIdentifier, GlobalStateIdentifier},
@@ -130,6 +131,17 @@ pub enum CliError {
         /// An error message.
         error: String,
     },
+
+    /// Error while parsing the json-args from a string to JSON.
+    #[error(
+        "failed to parse json-args to JSON: {0}.  They should be a JSON Array of Objects, each of \
+        the form {{\"name\":<String>,\"type\":<VALUE>,\"value\":<VALUE>}}"
+    )]
+    FailedToParseJsonArgs(#[from] serde_json::Error),
+
+    /// Error while building a [`NamedArg`] from parsed JSON input.
+    #[error(transparent)]
+    JsonArgs(#[from] JsonArgsError),
 
     /// Core error.
     #[error(transparent)]

--- a/lib/cli/json_args.rs
+++ b/lib/cli/json_args.rs
@@ -1,0 +1,1019 @@
+//! `CLType` and `CLValue` parsing and validation from "json args" syntax.
+
+mod error;
+pub mod help;
+
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use casper_types::{
+    bytesrepr::{ToBytes, OPTION_NONE_TAG, OPTION_SOME_TAG, RESULT_ERR_TAG, RESULT_OK_TAG},
+    AsymmetricType, CLType, CLValue, Key, NamedArg, PublicKey, URef, U128, U256, U512,
+};
+
+use crate::cli::CliError;
+pub use error::{Error, ErrorDetails};
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub(super) struct JsonArg {
+    name: String,
+    #[serde(rename = "type")]
+    cl_type: CLType,
+    value: Value,
+}
+
+impl TryFrom<JsonArg> for NamedArg {
+    type Error = CliError;
+
+    fn try_from(json_arg: JsonArg) -> Result<Self, Self::Error> {
+        let mut bytes = vec![];
+        json_to_bytesrepr(&json_arg.cl_type, &json_arg.value, &mut bytes).map_err(|details| {
+            Error::new(
+                json_arg.name.clone(),
+                json_arg.cl_type.clone(),
+                json_arg.value,
+                details,
+            )
+        })?;
+        Ok(NamedArg::new(
+            json_arg.name,
+            CLValue::from_components(json_arg.cl_type, bytes),
+        ))
+    }
+}
+
+fn json_to_bytesrepr(
+    cl_type: &CLType,
+    json_value: &Value,
+    output: &mut Vec<u8>,
+) -> Result<(), ErrorDetails> {
+    match (cl_type, json_value) {
+        (&CLType::Bool, Value::Bool(bool)) => bool.write_bytes(output)?,
+        (&CLType::I32, Value::Number(number)) => {
+            let value = number
+                .as_i64()
+                .and_then(|value| i32::try_from(value).ok())
+                .ok_or(ErrorDetails::CannotParseToI32)?;
+            value.write_bytes(output)?
+        }
+        (&CLType::I64, Value::Number(number)) => {
+            let value = number.as_i64().ok_or(ErrorDetails::CannotParseToI64)?;
+            value.write_bytes(output)?
+        }
+        (&CLType::U8, Value::Number(number)) => {
+            let value = number
+                .as_u64()
+                .and_then(|value| u8::try_from(value).ok())
+                .ok_or(ErrorDetails::CannotParseToU8)?;
+            value.write_bytes(output)?
+        }
+        (&CLType::U32, Value::Number(number)) => {
+            let value = number
+                .as_u64()
+                .and_then(|value| u32::try_from(value).ok())
+                .ok_or(ErrorDetails::CannotParseToU32)?;
+            value.write_bytes(output)?
+        }
+        (&CLType::U64, Value::Number(number)) => {
+            let value = number.as_u64().ok_or(ErrorDetails::CannotParseToU64)?;
+            value.write_bytes(output)?
+        }
+        (&CLType::U128, Value::String(string)) => {
+            let value = U128::from_dec_str(string)?;
+            value.write_bytes(output)?
+        }
+        (&CLType::U128, Value::Number(number)) => {
+            let value = number.as_u64().ok_or(ErrorDetails::CannotParseToU64)?;
+            U128::from(value).write_bytes(output)?
+        }
+        (&CLType::U256, Value::String(string)) => {
+            let value = U256::from_dec_str(string)?;
+            value.write_bytes(output)?
+        }
+        (&CLType::U256, Value::Number(number)) => {
+            let value = number.as_u64().ok_or(ErrorDetails::CannotParseToU64)?;
+            U256::from(value).write_bytes(output)?
+        }
+        (&CLType::U512, Value::String(string)) => {
+            let value = U512::from_dec_str(string)?;
+            value.write_bytes(output)?
+        }
+        (&CLType::U512, Value::Number(number)) => {
+            let value = number.as_u64().ok_or(ErrorDetails::CannotParseToU64)?;
+            U512::from(value).write_bytes(output)?
+        }
+        (&CLType::Unit, Value::Null) => (),
+        (&CLType::String, Value::String(string)) => string.write_bytes(output)?,
+        (&CLType::Key, Value::String(string)) => {
+            let value = Key::from_formatted_str(string)?;
+            value.write_bytes(output)?
+        }
+        (&CLType::Key, Value::Object(map)) => {
+            // This is an alternative JSON representation of a `Key`, e.g. if calling
+            // `serde_json::to_string()` on a `Key` enum.
+            if map.len() != 1 {
+                return Err(ErrorDetails::KeyObjectHasInvalidNumberOfFields);
+            }
+            let (mapped_variant, mapped_string) = match map.iter().next() {
+                Some((k, Value::String(v))) => (k, v),
+                _ => return Err(ErrorDetails::KeyObjectHasInvalidFieldType),
+            };
+            let value = Key::from_formatted_str(mapped_string)?;
+            // Return an error if the variant name doesn't match the parsed `Key` variant.
+            match value {
+                Key::Account(_) if mapped_variant == "Account" => {}
+                Key::Hash(_) if mapped_variant == "Hash" => {}
+                Key::URef(_) if mapped_variant == "URef" => {}
+                Key::Transfer(_) if mapped_variant == "Transfer" => {}
+                Key::DeployInfo(_) if mapped_variant == "DeployInfo" => {}
+                Key::EraInfo(_) if mapped_variant == "EraInfo" => {}
+                Key::Balance(_) if mapped_variant == "Balance" => {}
+                Key::Bid(_) if mapped_variant == "Bid" => {}
+                Key::Withdraw(_) if mapped_variant == "Withdraw" => {}
+                Key::Dictionary(_) if mapped_variant == "Dictionary" => {}
+                Key::SystemContractRegistry if mapped_variant == "SystemContractRegistry" => {}
+                Key::Unbond(_) if mapped_variant == "Unbond" => {}
+                Key::ChainspecRegistry if mapped_variant == "ChainspecRegistry" => {}
+                _ => return Err(ErrorDetails::KeyObjectHasInvalidVariant),
+            }
+            value.write_bytes(output)?
+        }
+        (&CLType::URef, Value::String(string)) => {
+            let value = URef::from_formatted_str(string)?;
+            value.write_bytes(output)?
+        }
+        (&CLType::PublicKey, Value::String(string)) => {
+            let value = PublicKey::from_hex(string)?;
+            value.write_bytes(output)?
+        }
+        (&CLType::Option(ref _inner_cl_type), Value::Null) => {
+            output.push(OPTION_NONE_TAG);
+        }
+        (&CLType::Option(ref inner_cl_type), _) => {
+            output.push(OPTION_SOME_TAG);
+            json_to_bytesrepr(&*inner_cl_type, json_value, output)?
+        }
+        (&CLType::List(ref inner_cl_type), Value::Array(vec)) => {
+            (vec.len() as u32).write_bytes(output)?;
+            for item in vec {
+                json_to_bytesrepr(&*inner_cl_type, item, output)?;
+            }
+        }
+        (&CLType::List(ref inner_cl_type), Value::String(string)) => {
+            // Support passing a `Vec<u8>` as a hex-encoded string.
+            if **inner_cl_type != CLType::U8 {
+                return Err(ErrorDetails::IncompatibleType);
+            }
+            let mut value = base16::decode(string)?;
+            (value.len() as u32).write_bytes(output)?;
+            output.append(&mut value);
+        }
+        (&CLType::ByteArray(expected_length), Value::String(string)) => {
+            let mut value = base16::decode(string)?;
+            let actual_length = value.len() as u32;
+            if actual_length != expected_length {
+                return Err(ErrorDetails::ByteArrayLengthMismatch {
+                    expected_length,
+                    actual_length,
+                });
+            }
+            output.append(&mut value);
+        }
+        (&CLType::ByteArray(expected_length), Value::Array(array)) => {
+            // While we generally output byte arrays in JSON as hex-encoded strings, we want to
+            // support explicit JSON arrays too.
+            let actual_length = array.len() as u32;
+            if actual_length != expected_length {
+                return Err(ErrorDetails::ByteArrayLengthMismatch {
+                    expected_length,
+                    actual_length,
+                });
+            }
+            for value in array {
+                let byte = value
+                    .as_u64()
+                    .and_then(|value| u8::try_from(value).ok())
+                    .ok_or(ErrorDetails::CannotParseToU8)?;
+                output.push(byte);
+            }
+        }
+        (&CLType::Result { ref ok, ref err }, Value::Object(map)) => {
+            if map.len() != 1 {
+                return Err(ErrorDetails::ResultObjectHasInvalidNumberOfFields);
+            }
+            match map.iter().next() {
+                Some((key, value)) if key.to_ascii_lowercase() == "ok" => {
+                    output.push(RESULT_OK_TAG);
+                    json_to_bytesrepr(&*ok, value, output)?
+                }
+                Some((key, value)) if key.to_ascii_lowercase() == "err" => {
+                    output.push(RESULT_ERR_TAG);
+                    json_to_bytesrepr(&*err, value, output)?
+                }
+                _ => return Err(ErrorDetails::ResultObjectHasInvalidVariant),
+            }
+        }
+        (
+            &CLType::Map {
+                key: ref key_type,
+                value: ref value_type,
+            },
+            Value::Object(map),
+        ) => {
+            // While we generally output maps in JSON as arrays of objects of the form
+            // '[{"key":KEY-1,"value":VALUE-1},{"key":KEY-2,"value":VALUE-2}]', we want to
+            // support maps which can be converted to JSON via `serde_json::to_string`.  Such maps
+            // are limited to ones where the key type is a String or Number, and will take the form
+            // '{"KEY-1":VALUE-1,"KEY-2":VALUE-2}'.
+            match **key_type {
+                CLType::I32
+                | CLType::I64
+                | CLType::U8
+                | CLType::U32
+                | CLType::U64
+                | CLType::U128
+                | CLType::U256
+                | CLType::U512
+                | CLType::String => (),
+                _ => return Err(ErrorDetails::MapTypeNotValidAsObject(*key_type.clone())),
+            };
+            (map.len() as u32).write_bytes(output)?;
+            for (key_as_str, value) in map.iter() {
+                let key = match **key_type {
+                    CLType::I32 => json!(i32::from_str(key_as_str)?),
+                    CLType::I64 => json!(i64::from_str(key_as_str)?),
+                    CLType::U8 => json!(u8::from_str(key_as_str)?),
+                    CLType::U32 => json!(u32::from_str(key_as_str)?),
+                    CLType::U64 => json!(u64::from_str(key_as_str)?),
+                    CLType::U128 => json!(U128::from_dec_str(key_as_str)?),
+                    CLType::U256 => json!(U256::from_dec_str(key_as_str)?),
+                    CLType::U512 => json!(U512::from_dec_str(key_as_str)?),
+                    CLType::String => json!(key_as_str),
+                    _ => return Err(ErrorDetails::MapTypeNotValidAsObject(*key_type.clone())),
+                };
+                json_to_bytesrepr(&*key_type, &key, output)?;
+                json_to_bytesrepr(&*value_type, value, output)?;
+            }
+        }
+        (
+            &CLType::Map {
+                key: ref key_type,
+                value: ref value_type,
+            },
+            Value::Array(array),
+        ) => {
+            (array.len() as u32).write_bytes(output)?;
+            for item in array {
+                let map = if let Some(map) = item.as_object() {
+                    map
+                } else {
+                    return Err(ErrorDetails::MapArrayHasInvalidEntryType);
+                };
+                if map.len() != 2 {
+                    return Err(ErrorDetails::MapEntryObjectHasInvalidNumberOfFields);
+                }
+                let key = map
+                    .get("key")
+                    .ok_or(ErrorDetails::MapEntryObjectMissingKeyField)?;
+                json_to_bytesrepr(&*key_type, key, output)?;
+                let value = map
+                    .get("value")
+                    .ok_or(ErrorDetails::MapEntryObjectMissingValueField)?;
+                json_to_bytesrepr(&*value_type, value, output)?;
+            }
+        }
+        (&CLType::Tuple1(ref inner_cl_types), Value::Array(vec)) => {
+            if vec.len() != inner_cl_types.len() {
+                return Err(ErrorDetails::TupleEntryCountMismatch {
+                    expected: inner_cl_types.len(),
+                    actual: vec.len(),
+                });
+            }
+            json_to_bytesrepr(&*inner_cl_types[0], &vec[0], output)?
+        }
+        (&CLType::Tuple2(ref inner_cl_types), Value::Array(vec)) => {
+            if vec.len() != inner_cl_types.len() {
+                return Err(ErrorDetails::TupleEntryCountMismatch {
+                    expected: inner_cl_types.len(),
+                    actual: vec.len(),
+                });
+            }
+            json_to_bytesrepr(&*inner_cl_types[0], &vec[0], output)?;
+            json_to_bytesrepr(&*inner_cl_types[1], &vec[1], output)?
+        }
+        (&CLType::Tuple3(ref inner_cl_types), Value::Array(vec)) => {
+            if vec.len() != inner_cl_types.len() {
+                return Err(ErrorDetails::TupleEntryCountMismatch {
+                    expected: inner_cl_types.len(),
+                    actual: vec.len(),
+                });
+            }
+            json_to_bytesrepr(&*inner_cl_types[0], &vec[0], output)?;
+            json_to_bytesrepr(&*inner_cl_types[1], &vec[1], output)?;
+            json_to_bytesrepr(&*inner_cl_types[2], &vec[2], output)?
+        }
+        _ => return Err(ErrorDetails::IncompatibleType),
+    };
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use casper_types::{account::AccountHash, bytesrepr::Bytes, AccessRights, CLTyped, EraId};
+
+    use super::*;
+
+    const ARRAY: [u8; 32] = [17; 32];
+
+    fn arg_name() -> String {
+        "arg name".to_string()
+    }
+
+    fn create_input(type_str: &str, value_str: &str) -> String {
+        format!(
+            r#"{{"name":"{}","type":{},"value":{}}}"#,
+            arg_name(),
+            type_str,
+            value_str
+        )
+    }
+
+    fn should_parse<T: ToBytes + CLTyped + Serialize>(
+        type_str: &str,
+        value_str: &str,
+        expected: T,
+    ) {
+        let input = create_input(type_str, value_str);
+        let parsed: JsonArg = serde_json::from_str(&input).unwrap();
+        let named_arg = NamedArg::try_from(parsed)
+            .unwrap_or_else(|error| panic!("unexpected error: {}", error));
+        let expected = NamedArg::new(arg_name(), CLValue::from_t(expected).unwrap());
+        assert_eq!(named_arg, expected);
+    }
+
+    fn get_error(type_str: &str, value_str: &str) -> ErrorDetails {
+        let input = create_input(type_str, value_str);
+        let json_arg: JsonArg = serde_json::from_str(&input).unwrap();
+        let mut bytes = vec![];
+        json_to_bytesrepr(&json_arg.cl_type, &json_arg.value, &mut bytes).unwrap_err()
+    }
+
+    #[test]
+    fn should_parse_bool() {
+        const TYPE: &str = r#""Bool""#;
+        should_parse(TYPE, "true", true);
+        should_parse(TYPE, "false", false);
+    }
+
+    #[test]
+    fn should_parse_i32() {
+        const TYPE: &str = r#""I32""#;
+        should_parse(TYPE, "-2147483648", i32::MIN);
+        should_parse(TYPE, "-1", -1_i32);
+        should_parse(TYPE, "0", 0_i32);
+        should_parse(TYPE, "1", 1_i32);
+        should_parse(TYPE, "2147483647", i32::MAX);
+    }
+
+    #[test]
+    fn should_parse_i64() {
+        const TYPE: &str = r#""I64""#;
+        should_parse(TYPE, "-9223372036854775808", i64::MIN);
+        should_parse(TYPE, "-1", -1_i64);
+        should_parse(TYPE, "0", 0_i64);
+        should_parse(TYPE, "1", 1_i64);
+        should_parse(TYPE, "9223372036854775807", i64::MAX);
+    }
+
+    #[test]
+    fn should_parse_u8() {
+        const TYPE: &str = r#""U8""#;
+        should_parse(TYPE, "0", 0_u8);
+        should_parse(TYPE, "255", u8::MAX);
+    }
+
+    #[test]
+    fn should_parse_u32() {
+        const TYPE: &str = r#""U32""#;
+        should_parse(TYPE, "0", 0_u32);
+        should_parse(TYPE, "4294967295", u32::MAX);
+    }
+
+    #[test]
+    fn should_parse_u64() {
+        const TYPE: &str = r#""U64""#;
+        should_parse(TYPE, "0", 0_u64);
+        should_parse(TYPE, "18446744073709551615", u64::MAX);
+    }
+
+    #[test]
+    fn should_parse_u128() {
+        const TYPE: &str = r#""U128""#;
+        // From string.
+        should_parse(TYPE, r#""0""#, U128::zero());
+        should_parse(
+            TYPE,
+            r#""340282366920938463463374607431768211455""#,
+            U128::MAX,
+        );
+
+        // From number.
+        should_parse(TYPE, "0", U128::zero());
+        should_parse(TYPE, "18446744073709551615", U128::from(u64::MAX));
+    }
+
+    #[test]
+    fn should_parse_u256() {
+        const TYPE: &str = r#""U256""#;
+        // From string.
+        should_parse(TYPE, r#""0""#, U256::zero());
+        should_parse(
+            TYPE,
+            r#""115792089237316195423570985008687907853269984665640564039457584007913129639935""#,
+            U256::MAX,
+        );
+
+        // From number.
+        should_parse(TYPE, "0", U256::zero());
+        should_parse(TYPE, "18446744073709551615", U256::from(u64::MAX));
+    }
+
+    #[test]
+    fn should_parse_u512() {
+        const TYPE: &str = r#""U512""#;
+        // From string.
+        should_parse(TYPE, r#""0""#, U512::zero());
+        should_parse(
+            TYPE,
+            r#""13407807929942597099574024998205846127479365820592393377723561443721764030073546976801874298166903427690031858186486050853753882811946569946433649006084095""#,
+            U512::MAX,
+        );
+
+        // From number.
+        should_parse(TYPE, "0", U512::zero());
+        should_parse(TYPE, "18446744073709551615", U512::from(u64::MAX));
+    }
+
+    #[test]
+    fn should_parse_unit() {
+        const TYPE: &str = r#""Unit""#;
+        should_parse(TYPE, "null", ());
+    }
+
+    #[test]
+    fn should_parse_string() {
+        const TYPE: &str = r#""String""#;
+        should_parse(TYPE, r#""""#, String::new());
+        should_parse(TYPE, r#""some text""#, "some text".to_string());
+    }
+
+    #[test]
+    fn should_parse_key() {
+        const TYPE: &str = r#""Key""#;
+        const UREF: URef = URef::new(ARRAY, AccessRights::NONE);
+
+        // From formatted string.
+        should_parse(
+            TYPE,
+            r#""account-hash-1111111111111111111111111111111111111111111111111111111111111111""#,
+            Key::Account(AccountHash::new(ARRAY)),
+        );
+        // From JSON Object.
+        should_parse(
+            TYPE,
+            r#"{"Account":"account-hash-1111111111111111111111111111111111111111111111111111111111111111"}"#,
+            Key::Account(AccountHash::new(ARRAY)),
+        );
+
+        // From formatted string.
+        should_parse(
+            TYPE,
+            r#""hash-1111111111111111111111111111111111111111111111111111111111111111""#,
+            Key::Hash(ARRAY),
+        );
+        // From JSON Object.
+        should_parse(
+            TYPE,
+            r#"{"Hash":"hash-1111111111111111111111111111111111111111111111111111111111111111"}"#,
+            Key::Hash(ARRAY),
+        );
+
+        // From formatted string.
+        should_parse(
+            TYPE,
+            r#""uref-1111111111111111111111111111111111111111111111111111111111111111-000""#,
+            Key::URef(UREF),
+        );
+        // From JSON Object.
+        should_parse(
+            TYPE,
+            r#"{"URef":"uref-1111111111111111111111111111111111111111111111111111111111111111-000"}"#,
+            Key::URef(UREF),
+        );
+
+        // From formatted string.
+        should_parse(TYPE, r#""era-1""#, Key::EraInfo(EraId::new(1)));
+        // From JSON Object.
+        should_parse(TYPE, r#"{"EraInfo":"era-1"}"#, Key::EraInfo(EraId::new(1)));
+    }
+
+    #[test]
+    fn should_parse_uref() {
+        const TYPE: &str = r#""URef""#;
+        should_parse(
+            TYPE,
+            r#""uref-1111111111111111111111111111111111111111111111111111111111111111-007""#,
+            URef::new(ARRAY, AccessRights::all()),
+        );
+    }
+
+    #[test]
+    fn should_parse_public_key() {
+        const TYPE: &str = r#""PublicKey""#;
+        should_parse(
+            TYPE,
+            r#""011111111111111111111111111111111111111111111111111111111111111111""#,
+            PublicKey::ed25519_from_bytes(ARRAY).unwrap(),
+        );
+    }
+
+    #[test]
+    fn should_parse_option() {
+        const SIMPLE_TYPE: &str = r#"{"Option":"U64"}"#;
+        should_parse(SIMPLE_TYPE, "999", Some(999_u64));
+        should_parse::<Option<u64>>(SIMPLE_TYPE, "null", None);
+
+        const COMPLEX_TYPE: &str = r#"{"Option":{"Tuple2":["Bool","U8"]}}"#;
+        should_parse(COMPLEX_TYPE, "[true,1]", Some((true, 1_u8)));
+        should_parse::<Option<(bool, u8)>>(COMPLEX_TYPE, "null", None);
+    }
+
+    #[test]
+    fn should_parse_list() {
+        const SIMPLE_TYPE: &str = r#"{"List":"U64"}"#;
+        should_parse(SIMPLE_TYPE, "[1,2,3]", vec![1_u64, 2, 3]);
+        should_parse(SIMPLE_TYPE, "[]", Vec::<u64>::new());
+
+        const COMPLEX_TYPE: &str = r#"{"List":{"Option":{"Tuple2":["Bool","U8"]}}}"#;
+        should_parse(
+            COMPLEX_TYPE,
+            "[[true,1],null,[false,2]]",
+            vec![Some((true, 1_u8)), None, Some((false, 2))],
+        );
+        should_parse(COMPLEX_TYPE, "[]", Vec::<Option<(bool, u8)>>::new());
+
+        // For List of U8 only, we can parse from a JSON String.
+        const BYTE_LIST_TYPE: &str = r#"{"List":"U8"}"#;
+        should_parse(
+            BYTE_LIST_TYPE,
+            r#""0102ff""#,
+            Bytes::from(vec![1_u8, 2, 255]),
+        );
+        should_parse(BYTE_LIST_TYPE, r#""""#, Bytes::from(vec![]));
+    }
+
+    #[test]
+    fn should_parse_byte_array() {
+        const BYTE_ARRAY_3_TYPE: &str = r#"{"ByteArray":3}"#;
+        const BYTE_ARRAY_3: [u8; 3] = [1, 20, 255];
+        // From hex-encoded string.
+        should_parse(BYTE_ARRAY_3_TYPE, r#""0114ff""#, BYTE_ARRAY_3);
+        // From array.
+        should_parse(BYTE_ARRAY_3_TYPE, "[1,20,255]", BYTE_ARRAY_3);
+
+        const BYTE_ARRAY_EMPTY_TYPE: &str = r#"{"ByteArray":0}"#;
+        // From hex-encoded string.
+        should_parse(BYTE_ARRAY_EMPTY_TYPE, r#""""#, []);
+        // From array.
+        should_parse(BYTE_ARRAY_EMPTY_TYPE, "[]", []);
+    }
+
+    #[test]
+    fn should_parse_result() {
+        const SIMPLE_TYPE: &str = r#"{"Result":{"ok":"Bool","err":"U8"}}"#;
+
+        should_parse::<Result<bool, u8>>(SIMPLE_TYPE, r#"{"Ok":true}"#, Ok(true));
+        should_parse::<Result<bool, u8>>(SIMPLE_TYPE, r#"{"ok":true}"#, Ok(true));
+        should_parse::<Result<bool, u8>>(SIMPLE_TYPE, r#"{"Err":1}"#, Err(1));
+        should_parse::<Result<bool, u8>>(SIMPLE_TYPE, r#"{"err":1}"#, Err(1));
+
+        const COMPLEX_TYPE: &str =
+            r#"{"Result":{"ok":{"Option":{"Tuple2":["Bool","U8"]}},"err":{"Option":"String"}}}"#;
+        should_parse::<Result<Option<(bool, u8)>, Option<String>>>(
+            COMPLEX_TYPE,
+            r#"{"Ok":[true,255]}"#,
+            Ok(Some((true, 255))),
+        );
+        should_parse::<Result<Option<(bool, u8)>, Option<String>>>(
+            COMPLEX_TYPE,
+            r#"{"Err":"failed"}"#,
+            Err(Some("failed".to_string())),
+        );
+    }
+
+    #[test]
+    fn should_parse_map() {
+        const SIMPLE_TYPE: &str = r#"{"Map":{"key":"U8","value":"Bool"}}"#;
+        let mut simple_map = BTreeMap::new();
+        simple_map.insert(1_u8, true);
+        simple_map.insert(2, false);
+
+        // From a JSON Object, only applicable where the key type is a Number or String.
+        let value_str = r#"{"1":true,"2":false}"#;
+        assert_eq!(value_str, serde_json::to_string(&simple_map).unwrap());
+        should_parse(SIMPLE_TYPE, value_str, simple_map.clone());
+        // From a JSON Array of Objects each with a 'key' and 'value' field.
+        should_parse(
+            SIMPLE_TYPE,
+            r#"[{"key":1,"value":true},{"key":2,"value":false}]"#,
+            simple_map,
+        );
+
+        // Empty map, from a JSON Object.
+        should_parse(SIMPLE_TYPE, "{}", BTreeMap::<u8, bool>::new());
+        // Empty map, from a JSON Array.
+        should_parse(SIMPLE_TYPE, "[]", BTreeMap::<u8, bool>::new());
+
+        const COMPLEX_TYPE: &str =
+            r#"{"Map":{"key":{"List":"U64"},"value":{"Map":{"key":"U8","value":"Bool"}}}}"#;
+        let list1 = vec![1_u64, 2, 3];
+        let mut simple_map1 = BTreeMap::new();
+        simple_map1.insert(10_u8, true);
+        simple_map1.insert(20, false);
+        let list2 = vec![4_u64, 5, 6];
+        let mut simple_map2 = BTreeMap::new();
+        simple_map2.insert(30_u8, true);
+        simple_map2.insert(40, false);
+        let mut complex_map = BTreeMap::new();
+        complex_map.insert(list1, simple_map1);
+        complex_map.insert(list2, simple_map2);
+        assert!(serde_json::to_string(&complex_map).is_err());
+
+        // Should fail from a JSON Object, as the key type is not a Number or String.
+        let input = create_input(COMPLEX_TYPE, value_str);
+        let parsed: JsonArg = serde_json::from_str(&input).unwrap();
+        assert!(NamedArg::try_from(parsed).is_err());
+
+        // From a JSON Array of Objects each with a 'key' and 'value' field.
+        should_parse(
+            COMPLEX_TYPE,
+            r#"[{"key":[1,2,3],"value":{"10":true,"20":false}},{"key":[4,5,6],"value":{"30":true,"40":false}}]"#,
+            complex_map,
+        );
+    }
+
+    #[test]
+    fn should_parse_tuple1() {
+        const SIMPLE_TYPE: &str = r#"{"Tuple1":["Bool"]}"#;
+        should_parse(SIMPLE_TYPE, "[true]", (true,));
+
+        const COMPLEX_TYPE: &str =
+            r#"{"Tuple1":[{"Result":{"ok":{"Option":"String"},"err":"I32"}}]}"#;
+        should_parse::<(Result<Option<String>, i32>,)>(
+            COMPLEX_TYPE,
+            r#"[{"Ok":null}]"#,
+            (Ok(None),),
+        );
+    }
+
+    #[test]
+    fn should_parse_tuple2() {
+        const SIMPLE_TYPE: &str = r#"{"Tuple2":["Bool","U8"]}"#;
+        should_parse(SIMPLE_TYPE, "[true,128]", (true, 128_u8));
+
+        const COMPLEX_TYPE1: &str =
+            r#"{"Tuple2":[{"Result":{"ok":{"Option":"String"},"err":"I32"}},"Bool"]}"#;
+        should_parse::<(Result<Option<String>, i32>, bool)>(
+            COMPLEX_TYPE1,
+            r#"[{"Ok":null},true]"#,
+            (Ok(None), true),
+        );
+
+        const COMPLEX_TYPE2: &str =
+            r#"{"Tuple2":["Bool",{"Result":{"ok":{"Option":"String"},"err":"I32"}}]}"#;
+        should_parse::<(bool, Result<Option<String>, i32>)>(
+            COMPLEX_TYPE2,
+            r#"[true,{"Ok":null}]"#,
+            (true, Ok(None)),
+        );
+    }
+
+    #[test]
+    fn should_parse_tuple3() {
+        const SIMPLE_TYPE: &str = r#"{"Tuple3":["Bool","U8","String"]}"#;
+        should_parse(
+            SIMPLE_TYPE,
+            r#"[true,128,"a"]"#,
+            (true, 128_u8, "a".to_string()),
+        );
+
+        const COMPLEX_TYPE1: &str =
+            r#"{"Tuple3":[{"Result":{"ok":{"Option":"String"},"err":"I32"}},"Bool","Unit"]}"#;
+        should_parse::<(Result<Option<String>, i32>, bool, ())>(
+            COMPLEX_TYPE1,
+            r#"[{"Ok":null},true,null]"#,
+            (Ok(None), true, ()),
+        );
+
+        const COMPLEX_TYPE2: &str =
+            r#"{"Tuple3":["Bool",{"Result":{"ok":{"Option":"String"},"err":"I32"}},"Unit"]}"#;
+        should_parse::<(bool, Result<Option<String>, i32>, ())>(
+            COMPLEX_TYPE2,
+            r#"[true,{"Ok":null},null]"#,
+            (true, Ok(None), ()),
+        );
+
+        const COMPLEX_TYPE3: &str =
+            r#"{"Tuple3":["Bool","Unit",{"Result":{"ok":{"Option":"String"},"err":"I32"}}]}"#;
+        should_parse::<(bool, (), Result<Option<String>, i32>)>(
+            COMPLEX_TYPE3,
+            r#"[true,null,{"Ok":null}]"#,
+            (true, (), Ok(None)),
+        );
+    }
+
+    #[test]
+    fn should_fail_to_parse_key_from_object() {
+        const TYPE: &str = r#""Key""#;
+
+        // Object has extra field.
+        let error = get_error(TYPE, r#"{"EraInfo":"era-1","extra field":null}"#);
+        assert!(
+            matches!(error, ErrorDetails::KeyObjectHasInvalidNumberOfFields),
+            "{}",
+            error
+        );
+
+        // Object has no fields.
+        let error = get_error(TYPE, "{}");
+        assert!(
+            matches!(error, ErrorDetails::KeyObjectHasInvalidNumberOfFields),
+            "{}",
+            error
+        );
+
+        // Object's key is not a valid `Key` variant.
+        let error = get_error(TYPE, r#"{"not a key variant":"era-1"}"#);
+        assert!(
+            matches!(error, ErrorDetails::KeyObjectHasInvalidVariant),
+            "{}",
+            error
+        );
+
+        // Object's value is an Array, not a `Key` as a formatted string.
+        let error = get_error(TYPE, r#"{"EraInfo":["era-1"]}"#);
+        assert!(
+            matches!(error, ErrorDetails::KeyObjectHasInvalidFieldType),
+            "{}",
+            error
+        );
+
+        // Object's value is a String, but not a validly-formatted Key string.
+        let error = get_error(TYPE, r#"{"EraInfo":"er-1"}"#);
+        assert!(
+            matches!(error, ErrorDetails::ParseKeyFromString(_)),
+            "{}",
+            error
+        );
+    }
+
+    #[test]
+    fn should_fail_to_parse_byte_array() {
+        const TYPE: &str = r#"{"ByteArray":3}"#;
+
+        // Parsing from String: wrong number of hex-decoded bytes.
+        let error = get_error(TYPE, r#""01020304""#);
+        assert!(
+            matches!(
+                error,
+                ErrorDetails::ByteArrayLengthMismatch {
+                    expected_length: 3,
+                    actual_length: 4
+                }
+            ),
+            "{}",
+            error
+        );
+
+        // Parsing from String: invalid hex-encoded string.
+        let error = get_error(TYPE, r#""01020g""#);
+        assert!(matches!(error, ErrorDetails::HexDecode(_)), "{}", error);
+
+        // Parsing from Array: wrong number of bytes.
+        let error = get_error(TYPE, "[1,2,3,4]");
+        assert!(
+            matches!(
+                error,
+                ErrorDetails::ByteArrayLengthMismatch {
+                    expected_length: 3,
+                    actual_length: 4
+                }
+            ),
+            "{}",
+            error
+        );
+
+        // Parsing from Array: invalid element.
+        let error = get_error(TYPE, "[1,2,256]");
+        assert!(matches!(error, ErrorDetails::CannotParseToU8), "{}", error);
+    }
+
+    #[test]
+    fn should_fail_to_parse_result() {
+        const TYPE: &str = r#"{"Result":{"ok":"Bool","err":"U8"}}"#;
+
+        // Object has extra field.
+        let error = get_error(TYPE, r#"{"Ok":true,"extra field":null}"#);
+        assert!(
+            matches!(error, ErrorDetails::ResultObjectHasInvalidNumberOfFields),
+            "{}",
+            error
+        );
+
+        // Object has no fields.
+        let error = get_error(TYPE, "{}");
+        assert!(
+            matches!(error, ErrorDetails::ResultObjectHasInvalidNumberOfFields),
+            "{}",
+            error
+        );
+
+        // Object's key is not a valid `Result` variant.
+        let error = get_error(TYPE, r#"{"A-ok":true}"#);
+        assert!(
+            matches!(error, ErrorDetails::ResultObjectHasInvalidVariant),
+            "{}",
+            error
+        );
+    }
+
+    #[test]
+    fn should_fail_to_parse_map_from_object() {
+        const INVALID_KEY_TYPE_FOR_OBJECT: &str = r#"{"Map":{"key":"Bool","value":"U8"}}"#;
+
+        // `CLType::Map<Bool, _>` cannot be represented as a JSON Object.
+        let error = get_error(INVALID_KEY_TYPE_FOR_OBJECT, r#"{"true":1}"#);
+        assert!(
+            matches!(error, ErrorDetails::MapTypeNotValidAsObject(CLType::Bool)),
+            "{}",
+            error
+        );
+
+        // As above, but with an empty Object should still fail.
+        let error = get_error(INVALID_KEY_TYPE_FOR_OBJECT, "{}");
+        assert!(
+            matches!(error, ErrorDetails::MapTypeNotValidAsObject(CLType::Bool)),
+            "{}",
+            error
+        );
+    }
+
+    #[test]
+    fn should_fail_to_parse_map_from_array() {
+        const TYPE: &str = r#"{"Map":{"key":"U8","value":"Bool"}}"#;
+
+        // From an Array, but with a non-Object entry.
+        let error = get_error(TYPE, r#"[{"key":1,"value":true},"non-object entry"]"#);
+        assert!(
+            matches!(error, ErrorDetails::MapArrayHasInvalidEntryType),
+            "{}",
+            error
+        );
+
+        // From an Array, but with an entry containing an extra field.
+        let error = get_error(
+            TYPE,
+            r#"[{"key":1,"value":true},{"key":2,"value":false,"extra field":null}]"#,
+        );
+        assert!(
+            matches!(error, ErrorDetails::MapEntryObjectHasInvalidNumberOfFields),
+            "{}",
+            error
+        );
+
+        // From an Array, but with an entry missing the "key" field.
+        let error = get_error(
+            TYPE,
+            r#"[{"key":1,"value":true},{"not key":2,"value":false}]"#,
+        );
+        assert!(
+            matches!(error, ErrorDetails::MapEntryObjectMissingKeyField),
+            "{}",
+            error
+        );
+
+        // From an Array, but with an entry missing the "key" field.
+        let error = get_error(
+            TYPE,
+            r#"[{"key":1,"value":true},{"key":2,"not value":false}]"#,
+        );
+        assert!(
+            matches!(error, ErrorDetails::MapEntryObjectMissingValueField),
+            "{}",
+            error
+        );
+    }
+
+    #[test]
+    fn should_fail_to_parse_tuple1() {
+        const TYPE: &str = r#"{"Tuple1":["Bool"]}"#;
+
+        // From an Array with too few entries.
+        let error = get_error(TYPE, "[]");
+        assert!(
+            matches!(
+                error,
+                ErrorDetails::TupleEntryCountMismatch {
+                    expected: 1,
+                    actual: 0
+                }
+            ),
+            "{}",
+            error
+        );
+
+        // From an Array with too many entries.
+        let error = get_error(TYPE, "[true,1]");
+        assert!(
+            matches!(
+                error,
+                ErrorDetails::TupleEntryCountMismatch {
+                    expected: 1,
+                    actual: 2
+                }
+            ),
+            "{}",
+            error
+        );
+    }
+
+    #[test]
+    fn should_fail_to_parse_tuple2() {
+        const TYPE: &str = r#"{"Tuple2":["Bool","U8"]}"#;
+
+        // From an Array with too few entries.
+        let error = get_error(TYPE, "[true]");
+        assert!(
+            matches!(
+                error,
+                ErrorDetails::TupleEntryCountMismatch {
+                    expected: 2,
+                    actual: 1
+                }
+            ),
+            "{}",
+            error
+        );
+
+        // From an Array with too many entries.
+        let error = get_error(TYPE, "[true,1,null]");
+        assert!(
+            matches!(
+                error,
+                ErrorDetails::TupleEntryCountMismatch {
+                    expected: 2,
+                    actual: 3
+                }
+            ),
+            "{}",
+            error
+        );
+    }
+
+    #[test]
+    fn should_fail_to_parse_tuple3() {
+        const TYPE: &str = r#"{"Tuple3":["Bool","U8","String"]}"#;
+
+        // From an Array with too few entries.
+        let error = get_error(TYPE, "[true,1]");
+        assert!(
+            matches!(
+                error,
+                ErrorDetails::TupleEntryCountMismatch {
+                    expected: 3,
+                    actual: 2
+                }
+            ),
+            "{}",
+            error
+        );
+
+        // From an Array with too many entries.
+        let error = get_error(TYPE, r#"[true,1,"a",null]"#);
+        assert!(
+            matches!(
+                error,
+                ErrorDetails::TupleEntryCountMismatch {
+                    expected: 3,
+                    actual: 4
+                }
+            ),
+            "{}",
+            error
+        );
+    }
+}

--- a/lib/cli/json_args/error.rs
+++ b/lib/cli/json_args/error.rs
@@ -1,0 +1,216 @@
+use std::num::ParseIntError;
+
+use serde_json::Value;
+use thiserror::Error;
+
+#[cfg(doc)]
+use casper_types::{account::AccountHash, CLValue, Key, NamedArg, PublicKey, URef};
+use casper_types::{
+    bytesrepr::Error as BytesreprError, crypto::Error as CryptoError, CLType, KeyFromStrError,
+    URefFromStrError,
+};
+
+/// Error associated with parsing a JSON arg into a [`NamedArg`].
+#[derive(Error, Debug)]
+#[error(
+    "failed to construct a CLValue of type {cl_type:?} from {json_value} for arg {arg_name}: \
+    {details}"
+)]
+pub struct Error {
+    /// The name of the relevant argument.
+    pub arg_name: String,
+    /// The `CLType` into which the value should be parsed.
+    pub cl_type: CLType,
+    /// The JSON value from which parsing failed.
+    pub json_value: Value,
+    /// Details of the error.
+    pub details: ErrorDetails,
+}
+
+impl Error {
+    pub(super) fn new(
+        arg_name: String,
+        cl_type: CLType,
+        json_value: Value,
+        details: ErrorDetails,
+    ) -> Self {
+        Error {
+            arg_name,
+            cl_type,
+            json_value,
+            details,
+        }
+    }
+}
+
+/// Details of an error associated with parsing a JSON arg into a [`NamedArg`].
+#[derive(Error, Debug)]
+pub enum ErrorDetails {
+    /// bytesrepr error while constructing a [`CLValue`].
+    #[error("failed bytesrepr encoding: {0}")]
+    Bytesrepr(BytesreprError),
+
+    /// Cannot convert the given JSON Number to an `i32`.
+    #[error("cannot convert given JSON Number to `i32`")]
+    CannotParseToI32,
+
+    /// Cannot convert the given JSON Number to an `i64`.
+    #[error("cannot convert given JSON Number to `i64`")]
+    CannotParseToI64,
+
+    /// Cannot convert the given JSON Number to a `u8`.
+    #[error("cannot convert given JSON Number to `u8`")]
+    CannotParseToU8,
+
+    /// Cannot convert the given JSON Number to a `u32`.
+    #[error("cannot convert given JSON Number to `u32`")]
+    CannotParseToU32,
+
+    /// Cannot convert the given JSON Number to a `u64`.
+    #[error("cannot convert given JSON Number to `u64`")]
+    CannotParseToU64,
+
+    /// Error parsing an integer from a decimal string representation.
+    #[error(transparent)]
+    ParseInt(#[from] ParseIntError),
+
+    /// Error parsing a big integer from a decimal string representation.
+    #[error(transparent)]
+    ParseBigint(#[from] uint::FromDecStrErr),
+
+    /// Error parsing a [`Key`] from a formatted string representation.
+    #[error("failed parsing a Key: {0}")]
+    ParseKeyFromString(KeyFromStrError),
+
+    /// JSON Object representing a [`Key`] must have the structure
+    /// `{"<KEY VARIANT>":"<KEY AS FORMATTED STRING>"}`, but the given one does not have just one
+    /// field.
+    #[error(
+        "invalid number of fields: JSON Object representing a Key must have exactly one field, the \
+        name of the Key variant mapped to the Key as a formatted string"
+    )]
+    KeyObjectHasInvalidNumberOfFields,
+
+    /// JSON Object representing a [`Key`] must have the structure
+    /// `{"<KEY VARIANT>":"<KEY AS FORMATTED STRING>"}`, but the given one does not have a String
+    /// value.
+    #[error(
+        "invalid field type: JSON Object representing a Key must have exactly one field, the name \
+        of the Key variant mapped to the Key as a formatted string"
+    )]
+    KeyObjectHasInvalidFieldType,
+
+    /// JSON Object representing a [`Key`] must have the structure
+    /// `{"<KEY VARIANT>":"<KEY AS FORMATTED STRING>"}`, but the given one does match any valid
+    /// `Key` variant.
+    #[error(
+        "invalid Key variant: JSON Object representing a Key must have exactly one field, the name \
+        of the Key variant mapped to the Key as a formatted string"
+    )]
+    KeyObjectHasInvalidVariant,
+
+    /// Error parsing a [`URef`] from a formatted string representation.
+    #[error("failed parsing a URef: {0}")]
+    ParseURef(URefFromStrError),
+
+    /// Error parsing a [`PublicKey`] from a formatted string representation.
+    #[error(transparent)]
+    ParsePublicKey(#[from] CryptoError),
+
+    /// Error parsing a hex string.
+    #[error(transparent)]
+    HexDecode(#[from] base16::DecodeError),
+
+    /// Number of hex-decoded bytes not as expected.
+    #[error("number of hex-decoded bytes ({actual_length}) not as expected ({expected_length})")]
+    ByteArrayLengthMismatch {
+        /// The expected number of bytes.
+        expected_length: u32,
+        /// The actual number of bytes.
+        actual_length: u32,
+    },
+
+    /// JSON Object representing a `Result` must have the structure `{"Ok":<VALUE>}` or
+    /// `{"Err":<VALUE>}`, but the given one does not have just one field.
+    #[error(
+        "invalid number of fields: JSON Object representing a Result must have exactly one field \
+        named 'Ok' or 'Err'"
+    )]
+    ResultObjectHasInvalidNumberOfFields,
+
+    /// JSON Object representing a `Result` must have the structure `{"Ok":<VALUE>}` or
+    /// `{"Err":<VALUE>}`, but the given one is neither `"Ok"` nor `"Err"`.
+    #[error(
+        "invalid Result variant: JSON Object representing a Result must have exactly one field \
+        named 'Ok' or 'Err'"
+    )]
+    ResultObjectHasInvalidVariant,
+
+    /// `CLType::Map`s can only be represented as JSON Objects if the map's key type is a string or
+    /// number.
+    #[error(
+        "invalid map key type ({0:?}): only maps with key types of string or number can be \
+        represented as JSON Objects, maps with more complex key types must use a JSON Array"
+    )]
+    MapTypeNotValidAsObject(CLType),
+
+    /// JSON Array representing a `CLType::Map` must have all entries with the structure
+    /// `{"key":<VALUE>,"value":<VALUE>}`, but the given one has an entry which is not an Object.
+    #[error("invalid entry type: JSON Array representing a Map must have all entries as Objects")]
+    MapArrayHasInvalidEntryType,
+
+    /// JSON Object representing a map entry must have the structure
+    /// `{"key":<VALUE>,"value":<VALUE>}`, but the given one does not have exactly two fields.
+    #[error(
+        "invalid number of fields: JSON Object representing a Map entry must have exactly two \
+        fields, named 'key' and 'value'"
+    )]
+    MapEntryObjectHasInvalidNumberOfFields,
+
+    /// JSON Object representing a map entry must have the structure
+    /// `{"key":<VALUE>,"value":<VALUE>}`, but the given one does not have `"key"`.
+    #[error(
+        "missing key field: JSON Object representing a Map entry must have exactly two fields, \
+        named 'key' and 'value'"
+    )]
+    MapEntryObjectMissingKeyField,
+
+    /// JSON Object representing a map entry must have the structure
+    /// `{"key":<VALUE>,"value":<VALUE>}`, but the given one does not have `"value"`.
+    #[error(
+        "missing value field: JSON Object representing a Map entry must have exactly two fields, \
+        named 'key' and 'value'"
+    )]
+    MapEntryObjectMissingValueField,
+
+    /// Number of tuple entries not as expected.
+    #[error("number of tuple entries ({actual}) not as expected ({expected})")]
+    TupleEntryCountMismatch {
+        /// The expected number of tuple entries.
+        expected: usize,
+        /// The actual number of tuple entries.
+        actual: usize,
+    },
+
+    /// The given `CLType` fundamentally cannot be constructed from the given type of JSON value.
+    #[error("the given CLType cannot be constructed from the given type of JSON value")]
+    IncompatibleType,
+}
+
+impl From<KeyFromStrError> for ErrorDetails {
+    fn from(error: KeyFromStrError) -> Self {
+        ErrorDetails::ParseKeyFromString(error)
+    }
+}
+
+impl From<URefFromStrError> for ErrorDetails {
+    fn from(error: URefFromStrError) -> Self {
+        ErrorDetails::ParseURef(error)
+    }
+}
+
+impl From<BytesreprError> for ErrorDetails {
+    fn from(error: BytesreprError) -> Self {
+        ErrorDetails::Bytesrepr(error)
+    }
+}

--- a/lib/cli/json_args/help.rs
+++ b/lib/cli/json_args/help.rs
@@ -1,0 +1,220 @@
+//! Functions for use in help commands.
+
+use std::fmt::Write;
+
+use once_cell::sync::Lazy;
+
+// The default terminal width used by Clap.
+const MAX_INFO_LINE_LENGTH: usize = 100;
+
+struct InfoAndExamples {
+    info: &'static str,
+    examples: Vec<&'static str>,
+}
+
+static ALL_INFO_AND_EXAMPLES: Lazy<Vec<InfoAndExamples>> = Lazy::new(|| {
+    vec![
+        InfoAndExamples {
+            info: "CLType Bool is represented as a JSON Bool, e.g.",
+            examples: vec![r#"{"name":"entry_point_name","type":"Bool","value":false}"#],
+        },
+        InfoAndExamples {
+            info: "CLTypes I32, I64, U8, U32 and U64 are represented as a JSON Number, e.g.",
+            examples: vec![
+                r#"{"name":"entry_point_name","type":"I32","value":-1}"#,
+                r#"{"name":"entry_point_name","type":"I64","value":-2}"#,
+                r#"{"name":"entry_point_name","type":"U8","value":1}"#,
+                r#"{"name":"entry_point_name","type":"U32","value":2}"#,
+                r#"{"name":"entry_point_name","type":"U64","value":3}"#,
+            ],
+        },
+        InfoAndExamples {
+            info: "CLTypes U128, U256 and U512 are represented as a JSON String of the decimal \
+                value, or can be represented as a Number if the value is not more than u64::MAX \
+                (18446744073709551615), e.g.",
+            examples: vec![
+                r#"{"name":"entry_point_name","type":"U128","value":1}"#,
+                r#"{"name":"entry_point_name","type":"U128","value":"20000000000000000000"}"#,
+                r#"{"name":"entry_point_name","type":"U256","value":2}"#,
+                r#"{"name":"entry_point_name","type":"U256","value":"20000000000000000000"}"#,
+                r#"{"name":"entry_point_name","type":"U512","value":3}"#,
+                r#"{"name":"entry_point_name","type":"U512","value":"20000000000000000000"}"#,
+            ],
+        },
+        InfoAndExamples {
+            info: "CLType Unit is represented as a JSON null, e.g.",
+            examples: vec![r#"{"name":"entry_point_name","type":"Unit","value":null}"#],
+        },
+        InfoAndExamples {
+            info: "CLType String is represented as a JSON String, e.g.",
+            examples: vec![r#"{"name":"entry_point_name","type":"String","value":"a"}"#],
+        },
+        InfoAndExamples {
+            info: "CLType Key is represented as a JSON String (where the value is a properly \
+                formatted string representation of a Key) or may also be represented as a JSON \
+                Object of the form {\"<KEY VARIANT>\":\"<KEY AS FORMATTED STRING>\"}, e.g.",
+            examples: vec![
+                r#"{"name":"entry_point_name","type":"Key","value":"account-hash-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":{"Account":"account-hash-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":"hash-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":{"Hash":"hash-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":"uref-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201-000"}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":{"URef":"uref-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201-000"}}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":"transfer-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":{"Transfer":"transfer-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":"deploy-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":{"DeployInfo":"deploy-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":"era-1"}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":{"EraInfo":"era-1"}}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":"balance-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":{"Balance":"balance-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":"bid-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":{"Bid":"bid-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":"withdraw-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":{"Withdraw":"withdraw-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":"unbond-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":{"Unbond":"unbond-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":"dictionary-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":{"Dictionary":"dictionary-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":"system-contract-registry-0000000000000000000000000000000000000000000000000000000000000000"}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":{"SystemContractRegistry":"system-contract-registry-0000000000000000000000000000000000000000000000000000000000000000"}}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":"chainspec-registry-1111111111111111111111111111111111111111111111111111111111111111"}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":{"ChainspecRegistry":"chainspec-registry-1111111111111111111111111111111111111111111111111111111111111111"}}"#,
+            ],
+        },
+        InfoAndExamples {
+            info:
+                "CLTypes URef and PublicKey are represented as a JSON String where the value is a \
+                properly formatted string representation of the respective type, e.g.",
+            examples: vec![
+                r#"{"name":"entry_point_name","type":"URef","value":"uref-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201-007"}"#,
+                r#"{"name":"entry_point_name","type":"PublicKey","value":"017279ea868d185a40ed32ec076807c070de9c0fe986f5418c2aa71478f1e8ddf8"}"#,
+                r#"{"name":"entry_point_name","type":"PublicKey","value":"02030963b980a774f9bf4fded595007b60045ca9593fe6d47296e4e1aaa2745c90d2"}"#,
+            ],
+        },
+        InfoAndExamples {
+            info: "CLType Option<T> is represented as a JSON null for None, or the JSON type \
+                appropriate for the wrapped type T, e.g.",
+            examples: vec![
+                r#"{"name":"entry_point_name","type":{"Option":"U64"},"value":999}"#,
+                r#"{"name":"entry_point_name","type":{"Option":"String"},"value":null}"#,
+            ],
+        },
+        InfoAndExamples {
+            info: "CLType List<T> is represented as a JSON Array where every element has a type \
+                suitable to represent T.  For the special case of List<U8>, it can be represented \
+                as a hex-encoded String, e.g.",
+            examples: vec![
+                r#"{"name":"entry_point_name","type":{"List":{"Option":"U256"}},"value":[1,null,"3"]}"#,
+                r#"{"name":"entry_point_name","type":{"List":"U8"},"value":"0102ff"}"#,
+            ],
+        },
+        InfoAndExamples {
+            info:
+                "CLType ByteArray is represented as a JSON String (hex-encoded) or more verbosely \
+                by an Array of Numbers, e.g.",
+            examples: vec![
+                r#"{"name":"entry_point_name","type":{"ByteArray":3},"value":"0114ff"}"#,
+                r#"{"name":"entry_point_name","type":{"ByteArray":3},"value":[1,20,255]}"#,
+            ],
+        },
+        InfoAndExamples {
+            info:
+                "CLType Result<T, E> is represented as a JSON Object with exactly one entry named \
+                either \"Ok\" or \"Err\" where the Object's value is suitable to represent T or E \
+                respectively, e.g.",
+            examples: vec![
+                r#"{"name":"entry_point_name","type":{"Result":{"ok":"Bool","err":"U8"}},"value":{"Ok":true}}"#,
+                r#"{"name":"entry_point_name","type":{"Result":{"ok":"Bool","err":"U8"}},"value":{"Err":1}}"#,
+            ],
+        },
+        InfoAndExamples {
+            info: "CLType Map<K, V> is represented as a JSON Array of Objects of the form \
+                {\"key\":<K-VALUE>,\"value\":<V-VALUE>}.  For the special case where K is String \
+                or a numerical type, the Map can be represented as a single JSON Object, with each \
+                entry having the name of the given key as a String, e.g.",
+            examples: vec![
+                r#"{"name":"entry_point_name","type":{"Map":{"key":"U8","value":"Bool"}},"value":[{"key":1,"value":true},{"key":2,"value":false}]}"#,
+                r#"{"name":"entry_point_name","type":{"Map":{"key":"U8","value":"Bool"}},"value":{"1":true,"2":false}}"#,
+            ],
+        },
+        InfoAndExamples {
+            info: "CLTypes Tuple1, Tuple2 and Tuple3 are represented as a JSON Array, e.g.",
+            examples: vec![
+                r#"{"name":"entry_point_name","type":{"Tuple1":["Bool"]},"value":[true]}"#,
+                r#"{"name":"entry_point_name","type":{"Tuple2":["Bool","U8"]},"value":[true,128]}"#,
+                r#"{"name":"entry_point_name","type":{"Tuple3":["Bool","U8","String"]},"value":[true,128,"a"]}"#,
+            ],
+        },
+    ]
+});
+
+static HELP: Lazy<String> = Lazy::new(|| {
+    let mut help = r#"The value must be a JSON Array of JSON Objects of the form
+{"name":<String>,"type":<VALUE>,"value":<VALUE>}
+
+For example, to provide the following session args:
+* The value "square" to an entry point named "shape" taking a CLType::String
+* The tuple value (100,100) to an entry point named "dimensions" taking a CLType::Tuple2<CLType::U32, CLType::U32>
+* The value "blue" to an entry point named "color" taking a CLType::Option<CLType::String>
+the following input would be used:
+'[{"name":"shape","type":"String","value":"square"},{"name":"dimensions","type":{"Tuple2":["U32","U32"]},"value":[100,100]},{"name":"color","type":{"Option":"String"},"value":"blue"}]'
+
+Details for each CLType variant:
+"#.to_string();
+
+    ALL_INFO_AND_EXAMPLES.iter().for_each(|elt| {
+        let mut line_number = 0;
+        let mut current_line_length = 0;
+        for word in elt.info.split_whitespace() {
+            if current_line_length + word.len() + 1 > MAX_INFO_LINE_LENGTH
+                && current_line_length != 0
+            {
+                help += "\n";
+                line_number += 1;
+                current_line_length = 0;
+            }
+            if current_line_length == 0 {
+                let bullet_or_space = if line_number == 0 { '*' } else { ' ' };
+                let _ = write!(help, "{} {}", bullet_or_space, word);
+                current_line_length += word.len() + 2;
+            } else {
+                let _ = write!(help, " {}", word);
+                current_line_length += word.len() + 1;
+            }
+        }
+
+        help += "\n";
+
+        elt.examples.iter().for_each(|example| {
+            let _ = writeln!(help, "  {}", example);
+        });
+        help += "\n";
+    });
+
+    help += "Note that CLType Any cannot be represented as JSON.\n";
+    help
+});
+
+/// Returns a string listing examples of the format required when passing in payment code or
+/// session code args.
+pub fn info_and_examples() -> &'static str {
+    &*HELP
+}
+
+#[cfg(test)]
+mod tests {
+    use casper_types::NamedArg;
+
+    use super::*;
+    use crate::cli::json_args::JsonArg;
+
+    #[test]
+    fn should_parse_examples() {
+        for example in ALL_INFO_AND_EXAMPLES.iter().flat_map(|elt| &elt.examples) {
+            let parsed: JsonArg = serde_json::from_str(example).unwrap();
+            NamedArg::try_from(parsed)
+                .unwrap_or_else(|error| panic!("unexpected error: {}", error));
+        }
+    }
+}

--- a/lib/cli/session_str_params.rs
+++ b/lib/cli/session_str_params.rs
@@ -9,6 +9,17 @@
 /// [the docs for the equivalent
 /// `payment_args_simple`](struct.PaymentStrParams.html#payment_args_simple).
 ///
+/// ## `session_args_json`
+///
+/// For methods taking `session_args_json`, this parameter is the session contract arguments, as a
+/// JSON-encoded Array of JSON Objects of the form:
+/// ```json
+/// [{"name":<String>,"type":<VALUE>,"value":<VALUE>}]
+/// ```
+///
+/// There are further details in
+/// [the docs for the equivalent `payment_args_json`](struct.PaymentStrParams.html#payment_args_json).
+///
 /// ## `session_args_complex`
 ///
 /// For methods taking `session_args_complex`, this parameter is the session contract arguments, in
@@ -16,8 +27,8 @@
 ///
 /// ---
 ///
-/// **Note** while multiple payment args can be specified for a single session code instance, only
-/// one of `session_args_simple` and `session_args_complex` may be used.
+/// **Note** while multiple session args can be specified for a single session code instance, only
+/// one of `session_args_simple`, `session_args_json` or `session_args_complex` may be used.
 #[derive(Default)]
 pub struct SessionStrParams<'a> {
     pub(super) session_hash: &'a str,
@@ -26,6 +37,7 @@ pub struct SessionStrParams<'a> {
     pub(super) session_package_name: &'a str,
     pub(super) session_path: &'a str,
     pub(super) session_args_simple: Vec<&'a str>,
+    pub(super) session_args_json: &'a str,
     pub(super) session_args_complex: &'a str,
     pub(super) session_version: &'a str,
     pub(super) session_entry_point: &'a str,
@@ -36,16 +48,19 @@ impl<'a> SessionStrParams<'a> {
     /// Constructs a `SessionStrParams` using a session smart contract file.
     ///
     /// * `session_path` is the path to the compiled Wasm session code.
-    /// * See the struct docs for a description of [`session_args_simple`](#session_args_simple) and
+    /// * See the struct docs for a description of [`session_args_simple`](#session_args_simple),
+    ///   [`session_args_json`](#session_args_json) and
     ///   [`session_args_complex`](#session_args_complex).
     pub fn with_path(
         session_path: &'a str,
         session_args_simple: Vec<&'a str>,
+        session_args_json: &'a str,
         session_args_complex: &'a str,
     ) -> Self {
         Self {
             session_path,
             session_args_simple,
+            session_args_json,
             session_args_complex,
             ..Default::default()
         }
@@ -57,17 +72,20 @@ impl<'a> SessionStrParams<'a> {
     ///   to be called as the session.
     /// * `session_entry_point` is the name of the method that will be used when calling the session
     ///   contract.
-    /// * See the struct docs for a description of [`session_args_simple`](#session_args_simple) and
+    /// * See the struct docs for a description of [`session_args_simple`](#session_args_simple),
+    ///   [`session_args_json`](#session_args_json) and
     ///   [`session_args_complex`](#session_args_complex).
     pub fn with_name(
         session_name: &'a str,
         session_entry_point: &'a str,
         session_args_simple: Vec<&'a str>,
+        session_args_json: &'a str,
         session_args_complex: &'a str,
     ) -> Self {
         Self {
             session_name,
             session_args_simple,
+            session_args_json,
             session_args_complex,
             session_entry_point,
             ..Default::default()
@@ -79,17 +97,20 @@ impl<'a> SessionStrParams<'a> {
     /// * `session_hash` is the hex-encoded hash of the stored contract to be called as the session.
     /// * `session_entry_point` is the name of the method that will be used when calling the session
     ///   contract.
-    /// * See the struct docs for a description of [`session_args_simple`](#session_args_simple) and
+    /// * See the struct docs for a description of [`session_args_simple`](#session_args_simple),
+    ///   [`session_args_json`](#session_args_json) and
     ///   [`session_args_complex`](#session_args_complex).
     pub fn with_hash(
         session_hash: &'a str,
         session_entry_point: &'a str,
         session_args_simple: Vec<&'a str>,
+        session_args_json: &'a str,
         session_args_complex: &'a str,
     ) -> Self {
         Self {
             session_hash,
             session_args_simple,
+            session_args_json,
             session_args_complex,
             session_entry_point,
             ..Default::default()
@@ -103,18 +124,21 @@ impl<'a> SessionStrParams<'a> {
     ///   if `session_version` is empty.
     /// * `session_entry_point` is the name of the method that will be used when calling the session
     ///   contract.
-    /// * See the struct docs for a description of [`session_args_simple`](#session_args_simple) and
+    /// * See the struct docs for a description of [`session_args_simple`](#session_args_simple),
+    ///   [`session_args_json`](#session_args_json) and
     ///   [`session_args_complex`](#session_args_complex).
     pub fn with_package_name(
         session_package_name: &'a str,
         session_version: &'a str,
         session_entry_point: &'a str,
         session_args_simple: Vec<&'a str>,
+        session_args_json: &'a str,
         session_args_complex: &'a str,
     ) -> Self {
         Self {
             session_package_name,
             session_args_simple,
+            session_args_json,
             session_args_complex,
             session_version,
             session_entry_point,
@@ -130,18 +154,21 @@ impl<'a> SessionStrParams<'a> {
     ///   if `session_version` is empty.
     /// * `session_entry_point` is the name of the method that will be used when calling the session
     ///   contract.
-    /// * See the struct docs for a description of [`session_args_simple`](#session_args_simple) and
+    /// * See the struct docs for a description of [`session_args_simple`](#session_args_simple),
+    ///   [`session_args_json`](#session_args_json) and
     ///   [`session_args_complex`](#session_args_complex).
     pub fn with_package_hash(
         session_package_hash: &'a str,
         session_version: &'a str,
         session_entry_point: &'a str,
         session_args_simple: Vec<&'a str>,
+        session_args_json: &'a str,
         session_args_complex: &'a str,
     ) -> Self {
         Self {
             session_package_hash,
             session_args_simple,
+            session_args_json,
             session_args_complex,
             session_version,
             session_entry_point,
@@ -151,12 +178,18 @@ impl<'a> SessionStrParams<'a> {
 
     /// Constructs a `SessionStrParams` representing a `Transfer` type of `Deploy`.
     ///
-    /// * See the struct docs for a description of [`session_args_simple`](#session_args_simple) and
+    /// * See the struct docs for a description of [`session_args_simple`](#session_args_simple),
+    ///   [`session_args_json`](#session_args_json) and
     ///   [`session_args_complex`](#session_args_complex).
-    pub fn with_transfer(session_args_simple: Vec<&'a str>, session_args_complex: &'a str) -> Self {
+    pub fn with_transfer(
+        session_args_simple: Vec<&'a str>,
+        session_args_json: &'a str,
+        session_args_complex: &'a str,
+    ) -> Self {
         Self {
             is_session_transfer: true,
             session_args_simple,
+            session_args_json,
             session_args_complex,
             ..Default::default()
         }

--- a/lib/cli/simple_args.rs
+++ b/lib/cli/simple_args.rs
@@ -1,4 +1,4 @@
-//! Supported `CLType` and `CLValue` parsing and validation.
+//! `CLType` and `CLValue` parsing and validation from "simple args" syntax.
 
 use std::str::FromStr;
 
@@ -10,7 +10,7 @@ use casper_types::{
 use super::CliError;
 
 /// Parse a `CLType` from `&str`.
-pub(crate) fn parse(strval: &str) -> Result<CLType, ()> {
+pub(crate) fn parse_cl_type(strval: &str) -> Result<CLType, ()> {
     let supported_types = supported_cl_types();
     let cl_type = match strval.to_lowercase() {
         t if t == supported_types[0].0 => supported_types[0].1.clone(),
@@ -170,7 +170,7 @@ enum OptionalStatus {
 
 /// Parses to a given CLValue taking into account whether the arg represents an optional type or
 /// not.
-fn parse_to_cl_value<T, F>(optional_status: OptionalStatus, parse: F) -> Result<CLValue, CliError>
+fn parse_cl_value<T, F>(optional_status: OptionalStatus, parse: F) -> Result<CLValue, CliError>
 where
     T: CLTyped + ToBytes,
     F: FnOnce() -> Result<T, CliError>,
@@ -223,7 +223,7 @@ pub fn parts_to_cl_value(cl_type: CLType, value: &str) -> Result<CLValue, CliErr
                     invalid
                 ))),
             };
-            parse_to_cl_value(optional_status, parse)
+            parse_cl_value(optional_status, parse)
         }
         CLType::I32 => {
             let parse = || {
@@ -231,7 +231,7 @@ pub fn parts_to_cl_value(cl_type: CLType, value: &str) -> Result<CLValue, CliErr
                     CliError::InvalidCLValue(format!("can't parse {} as i32: {}", value, error))
                 })
             };
-            parse_to_cl_value(optional_status, parse)
+            parse_cl_value(optional_status, parse)
         }
         CLType::I64 => {
             let parse = || {
@@ -242,7 +242,7 @@ pub fn parts_to_cl_value(cl_type: CLType, value: &str) -> Result<CLValue, CliErr
                     ))
                 })
             };
-            parse_to_cl_value(optional_status, parse)
+            parse_cl_value(optional_status, parse)
         }
         CLType::U8 => {
             let parse = || {
@@ -253,7 +253,7 @@ pub fn parts_to_cl_value(cl_type: CLType, value: &str) -> Result<CLValue, CliErr
                     ))
                 })
             };
-            parse_to_cl_value(optional_status, parse)
+            parse_cl_value(optional_status, parse)
         }
         CLType::U32 => {
             let parse = || {
@@ -264,7 +264,7 @@ pub fn parts_to_cl_value(cl_type: CLType, value: &str) -> Result<CLValue, CliErr
                     ))
                 })
             };
-            parse_to_cl_value(optional_status, parse)
+            parse_cl_value(optional_status, parse)
         }
         CLType::U64 => {
             let parse = || {
@@ -275,7 +275,7 @@ pub fn parts_to_cl_value(cl_type: CLType, value: &str) -> Result<CLValue, CliErr
                     ))
                 })
             };
-            parse_to_cl_value(optional_status, parse)
+            parse_cl_value(optional_status, parse)
         }
         CLType::U128 => {
             let parse = || {
@@ -286,7 +286,7 @@ pub fn parts_to_cl_value(cl_type: CLType, value: &str) -> Result<CLValue, CliErr
                     ))
                 })
             };
-            parse_to_cl_value(optional_status, parse)
+            parse_cl_value(optional_status, parse)
         }
         CLType::U256 => {
             let parse = || {
@@ -297,7 +297,7 @@ pub fn parts_to_cl_value(cl_type: CLType, value: &str) -> Result<CLValue, CliErr
                     ))
                 })
             };
-            parse_to_cl_value(optional_status, parse)
+            parse_cl_value(optional_status, parse)
         }
         CLType::U512 => {
             let parse = || {
@@ -308,7 +308,7 @@ pub fn parts_to_cl_value(cl_type: CLType, value: &str) -> Result<CLValue, CliErr
                     ))
                 })
             };
-            parse_to_cl_value(optional_status, parse)
+            parse_cl_value(optional_status, parse)
         }
         CLType::Unit => {
             let parse = || {
@@ -320,11 +320,11 @@ pub fn parts_to_cl_value(cl_type: CLType, value: &str) -> Result<CLValue, CliErr
                 }
                 Ok(())
             };
-            parse_to_cl_value(optional_status, parse)
+            parse_cl_value(optional_status, parse)
         }
         CLType::String => {
             let parse = || Ok(trimmed_value.to_string());
-            parse_to_cl_value(optional_status, parse)
+            parse_cl_value(optional_status, parse)
         }
         CLType::Key => {
             let parse = || {
@@ -335,7 +335,7 @@ pub fn parts_to_cl_value(cl_type: CLType, value: &str) -> Result<CLValue, CliErr
                     ))
                 })
             };
-            parse_to_cl_value(optional_status, parse)
+            parse_cl_value(optional_status, parse)
         }
         CLType::ByteArray(32) => {
             let parse = || {
@@ -347,7 +347,7 @@ pub fn parts_to_cl_value(cl_type: CLType, value: &str) -> Result<CLValue, CliErr
                     ))
                 })
             };
-            parse_to_cl_value(optional_status, parse)
+            parse_cl_value(optional_status, parse)
         }
         CLType::URef => {
             let parse = || {
@@ -359,7 +359,7 @@ pub fn parts_to_cl_value(cl_type: CLType, value: &str) -> Result<CLValue, CliErr
                     ))
                 })
             };
-            parse_to_cl_value(optional_status, parse)
+            parse_cl_value(optional_status, parse)
         }
         CLType::PublicKey => {
             let parse = || {
@@ -371,7 +371,7 @@ pub fn parts_to_cl_value(cl_type: CLType, value: &str) -> Result<CLValue, CliErr
                 })?;
                 Ok(pub_key)
             };
-            parse_to_cl_value(optional_status, parse)
+            parse_cl_value(optional_status, parse)
         }
         _ => unreachable!(),
     }

--- a/lib/cli/tests.rs
+++ b/lib/cli/tests.rs
@@ -103,9 +103,9 @@ fn args_simple() -> Vec<&'static str> {
 fn should_create_deploy() {
     let deploy_params = deploy_params();
     let payment_params =
-        PaymentStrParams::with_package_hash(PKG_HASH, VERSION, ENTRYPOINT, args_simple(), "");
+        PaymentStrParams::with_package_hash(PKG_HASH, VERSION, ENTRYPOINT, args_simple(), "", "");
     let session_params =
-        SessionStrParams::with_package_hash(PKG_HASH, VERSION, ENTRYPOINT, args_simple(), "");
+        SessionStrParams::with_package_hash(PKG_HASH, VERSION, ENTRYPOINT, args_simple(), "", "");
 
     let mut output = Vec::new();
 
@@ -135,7 +135,7 @@ fn should_create_deploy() {
 fn should_fail_to_create_large_deploy() {
     let deploy_params = deploy_params();
     let payment_params =
-        PaymentStrParams::with_package_hash(PKG_HASH, VERSION, ENTRYPOINT, args_simple(), "");
+        PaymentStrParams::with_package_hash(PKG_HASH, VERSION, ENTRYPOINT, args_simple(), "", "");
     // Create a string arg of 1048576 letter 'a's to ensure the deploy is greater than 1048576
     // bytes.
     let large_args_simple = format!("name_01:string='{:a<1048576}'", "");
@@ -145,6 +145,7 @@ fn should_fail_to_create_large_deploy() {
         VERSION,
         ENTRYPOINT,
         vec![large_args_simple.as_str()],
+        "",
         "",
     );
 

--- a/src/deploy/make.rs
+++ b/src/deploy/make.rs
@@ -31,7 +31,8 @@ impl ClientCommand for MakeDeploy {
     }
 
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
-        creation_common::show_arg_examples_and_exit_if_required(matches);
+        creation_common::show_simple_arg_examples_and_exit_if_required(matches);
+        creation_common::show_json_args_examples_and_exit_if_required(matches);
 
         let secret_key = common::secret_key::get(matches);
         let timestamp = creation_common::timestamp::get(matches);

--- a/src/deploy/make_transfer.rs
+++ b/src/deploy/make_transfer.rs
@@ -33,7 +33,8 @@ impl ClientCommand for MakeTransfer {
     }
 
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
-        creation_common::show_arg_examples_and_exit_if_required(matches);
+        creation_common::show_simple_arg_examples_and_exit_if_required(matches);
+        creation_common::show_json_args_examples_and_exit_if_required(matches);
 
         let amount = transfer::amount::get(matches);
         let target_account = transfer::target_account::get(matches);

--- a/src/deploy/put.rs
+++ b/src/deploy/put.rs
@@ -25,7 +25,8 @@ impl ClientCommand for PutDeploy {
     }
 
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
-        creation_common::show_arg_examples_and_exit_if_required(matches);
+        creation_common::show_simple_arg_examples_and_exit_if_required(matches);
+        creation_common::show_json_args_examples_and_exit_if_required(matches);
 
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);

--- a/src/deploy/transfer.rs
+++ b/src/deploy/transfer.rs
@@ -19,7 +19,8 @@ pub(super) mod amount {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
-            .required_unless_present(creation_common::show_arg_examples::ARG_NAME)
+            .required_unless_present(creation_common::show_simple_arg_examples::ARG_NAME)
+            .required_unless_present(creation_common::show_json_args_examples::ARG_NAME)
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
             .display_order(DisplayOrder::TransferAmount as usize)
@@ -50,7 +51,8 @@ pub(super) mod target_account {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
-            .required_unless_present(creation_common::show_arg_examples::ARG_NAME)
+            .required_unless_present(creation_common::show_simple_arg_examples::ARG_NAME)
+            .required_unless_present(creation_common::show_json_args_examples::ARG_NAME)
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
             .display_order(DisplayOrder::TransferTargetAccount as usize)
@@ -77,7 +79,8 @@ pub(super) mod transfer_id {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
-            .required_unless_present(creation_common::show_arg_examples::ARG_NAME)
+            .required_unless_present(creation_common::show_simple_arg_examples::ARG_NAME)
+            .required_unless_present(creation_common::show_json_args_examples::ARG_NAME)
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
             .display_order(DisplayOrder::TransferId as usize)
@@ -112,7 +115,8 @@ impl ClientCommand for Transfer {
     }
 
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
-        creation_common::show_arg_examples_and_exit_if_required(matches);
+        creation_common::show_simple_arg_examples_and_exit_if_required(matches);
+        creation_common::show_json_args_examples_and_exit_if_required(matches);
 
         let amount = amount::get(matches);
         let target_account = target_account::get(matches);


### PR DESCRIPTION
This PR adds support for providing payment args and session args as a JSON-encoded string.

They can be provided via the command line as `--payment-args-json` or `--session-args-json` available in the `put-deploy`, `make-deploy`, `transfer` and `make-transfer` subcommands.

Malformed input should result in fairly helpful error messages, for example passing
```
--session-args-json '[{"name":"abc","type":{"Option":"String"},"value":123}]'
```
results in
```
failed to construct a CLValue of type Option(String) from 123 for arg abc: the given CLType cannot be constructed from the given type of JSON value
```

Comprehensive help info and examples have been added to the rustdocs and to the binary's relevant subcommands.  For example, the output of `casper-client put-deploy -j` is:

```
Examples for passing values via --session-args-json or --payment-args-json:

The value must be a JSON Array of JSON Objects of the form
{"name":<String>,"type":<VALUE>,"value":<VALUE>}

For example, to provide the following session args:
* The value "square" to an entry point named "shape" taking a CLType::String
* The tuple value (100,100) to an entry point named "dimensions" taking a CLType::Tuple2<CLType::U32, CLType::U32>
* The value "blue" to an entry point named "color" taking a CLType::Option<CLType::String>
the following input would be used:
'[{"name":"shape","type":"String","value":"square"},{"name":"dimensions","type":{"Tuple2":["U32","U32"]},"value":[100,100]},{"name":"color","type":{"Option":"String"},"value":"blue"}]'

Details for each CLType variant:
* CLType Bool is represented as a JSON Bool, e.g.
  {"name":"entry_point_name","type":"Bool","value":false}

* CLTypes I32, I64, U8, U32 and U64 are represented as a JSON Number, e.g.
  {"name":"entry_point_name","type":"I32","value":-1}
  {"name":"entry_point_name","type":"I64","value":-2}
  {"name":"entry_point_name","type":"U8","value":1}
  {"name":"entry_point_name","type":"U32","value":2}
  {"name":"entry_point_name","type":"U64","value":3}

* CLTypes U128, U256 and U512 are represented as a JSON String of the decimal value, or can be
  represented as a Number if the value is not more than u64::MAX (18446744073709551615), e.g.
  {"name":"entry_point_name","type":"U128","value":1}
  {"name":"entry_point_name","type":"U128","value":"20000000000000000000"}
  {"name":"entry_point_name","type":"U256","value":2}
  {"name":"entry_point_name","type":"U256","value":"20000000000000000000"}
  {"name":"entry_point_name","type":"U512","value":3}
  {"name":"entry_point_name","type":"U512","value":"20000000000000000000"}

* CLType Unit is represented as a JSON null, e.g.
  {"name":"entry_point_name","type":"Unit","value":null}

* CLType String is represented as a JSON String, e.g.
  {"name":"entry_point_name","type":"String","value":"a"}

* CLType Key is represented as a JSON String (where the value is a properly formatted string
  representation of a Key) or may also be represented as a JSON Object of the form {"<KEY
  VARIANT>":"<KEY AS FORMATTED STRING>"}, e.g.
  {"name":"entry_point_name","type":"Key","value":"account-hash-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}
  {"name":"entry_point_name","type":"Key","value":{"Account":"account-hash-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}}
  {"name":"entry_point_name","type":"Key","value":"hash-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}
  {"name":"entry_point_name","type":"Key","value":{"Hash":"hash-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}}
  {"name":"entry_point_name","type":"Key","value":"uref-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201-000"}
  {"name":"entry_point_name","type":"Key","value":{"URef":"uref-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201-000"}}
  {"name":"entry_point_name","type":"Key","value":"transfer-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}
  {"name":"entry_point_name","type":"Key","value":{"Transfer":"transfer-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}}
  {"name":"entry_point_name","type":"Key","value":"deploy-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}
  {"name":"entry_point_name","type":"Key","value":{"DeployInfo":"deploy-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}}
  {"name":"entry_point_name","type":"Key","value":"era-1"}
  {"name":"entry_point_name","type":"Key","value":{"EraInfo":"era-1"}}
  {"name":"entry_point_name","type":"Key","value":"balance-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}
  {"name":"entry_point_name","type":"Key","value":{"Balance":"balance-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}}
  {"name":"entry_point_name","type":"Key","value":"bid-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}
  {"name":"entry_point_name","type":"Key","value":{"Bid":"bid-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}}
  {"name":"entry_point_name","type":"Key","value":"withdraw-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}
  {"name":"entry_point_name","type":"Key","value":{"Withdraw":"withdraw-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}}
  {"name":"entry_point_name","type":"Key","value":"unbond-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}
  {"name":"entry_point_name","type":"Key","value":{"Unbond":"unbond-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}}
  {"name":"entry_point_name","type":"Key","value":"dictionary-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}
  {"name":"entry_point_name","type":"Key","value":{"Dictionary":"dictionary-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}}
  {"name":"entry_point_name","type":"Key","value":"system-contract-registry-0000000000000000000000000000000000000000000000000000000000000000"}
  {"name":"entry_point_name","type":"Key","value":{"SystemContractRegistry":"system-contract-registry-0000000000000000000000000000000000000000000000000000000000000000"}}
  {"name":"entry_point_name","type":"Key","value":"chainspec-registry-1111111111111111111111111111111111111111111111111111111111111111"}
  {"name":"entry_point_name","type":"Key","value":{"ChainspecRegistry":"chainspec-registry-1111111111111111111111111111111111111111111111111111111111111111"}}

* CLTypes URef and PublicKey are represented as a JSON String where the value is a properly
  formatted string representation of the respective type, e.g.
  {"name":"entry_point_name","type":"URef","value":"uref-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201-007"}
  {"name":"entry_point_name","type":"PublicKey","value":"017279ea868d185a40ed32ec076807c070de9c0fe986f5418c2aa71478f1e8ddf8"}
  {"name":"entry_point_name","type":"PublicKey","value":"02030963b980a774f9bf4fded595007b60045ca9593fe6d47296e4e1aaa2745c90d2"}

* CLType Option<T> is represented as a JSON null for None, or the JSON type appropriate for the
  wrapped type T, e.g.
  {"name":"entry_point_name","type":{"Option":"U64"},"value":999}
  {"name":"entry_point_name","type":{"Option":"String"},"value":null}

* CLType List<T> is represented as a JSON Array where every element has a type suitable to represent
  T. For the special case of List<U8>, it can be represented as a hex-encoded String, e.g.
  {"name":"entry_point_name","type":{"List":{"Option":"U256"}},"value":[1,null,"3"]}
  {"name":"entry_point_name","type":{"List":"U8"},"value":"0102ff"}

* CLType ByteArray is represented as a JSON String (hex-encoded) or more verbosely by an Array of
  Numbers, e.g.
  {"name":"entry_point_name","type":{"ByteArray":3},"value":"0114ff"}
  {"name":"entry_point_name","type":{"ByteArray":3},"value":[1,20,255]}

* CLType Result<T, E> is represented as a JSON Object with exactly one entry named either "Ok" or
  "Err" where the Object's value is suitable to represent T or E respectively, e.g.
  {"name":"entry_point_name","type":{"Result":{"ok":"Bool","err":"U8"}},"value":{"Ok":true}}
  {"name":"entry_point_name","type":{"Result":{"ok":"Bool","err":"U8"}},"value":{"Err":1}}

* CLType Map<K, V> is represented as a JSON Array of Objects of the form
  {"key":<K-VALUE>,"value":<V-VALUE>}. For the special case where K is String or a numerical type,
  the Map can be represented as a single JSON Object, with each entry having the name of the given
  key as a String, e.g.
  {"name":"entry_point_name","type":{"Map":{"key":"U8","value":"Bool"}},"value":[{"key":1,"value":true},{"key":2,"value":false}]}
  {"name":"entry_point_name","type":{"Map":{"key":"U8","value":"Bool"}},"value":{"1":true,"2":false}}

* CLTypes Tuple1, Tuple2 and Tuple3 are represented as a JSON Array, e.g.
  {"name":"entry_point_name","type":{"Tuple1":["Bool"]},"value":[true]}
  {"name":"entry_point_name","type":{"Tuple2":["Bool","U8"]},"value":[true,128]}
  {"name":"entry_point_name","type":{"Tuple3":["Bool","U8","String"]},"value":[true,128,"a"]}

Note that CLType Any cannot be represented as JSON.
```

Closes [#2001](https://github.com/casper-network/casper-node/issues/2001).