### PR TITLE
Reuse `reqwest::Client` in JSON RPC call

### DIFF
--- a/lib/json_rpc/call.rs
+++ b/lib/json_rpc/call.rs
@@ -7,6 +7,8 @@ use serde_json::json;
 use crate::{Error, JsonRpcId, SuccessResponse, Verbosity};
 
 const RPC_API_PATH: &str = "rpc";
+/// Statically declared client used when making HTTP requests
+/// so opened connections are pooled.
 static CLIENT: OnceCell<Client> = OnceCell::new();
 
 /// Struct representing a single JSON-RPC call to the casper node.

--- a/lib/json_rpc/call.rs
+++ b/lib/json_rpc/call.rs
@@ -1,4 +1,5 @@
 use jsonrpc_lite::{JsonRpc, Params};
+use once_cell::sync::OnceCell;
 use reqwest::Client;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::json;
@@ -6,6 +7,7 @@ use serde_json::json;
 use crate::{Error, JsonRpcId, SuccessResponse, Verbosity};
 
 const RPC_API_PATH: &str = "rpc";
+static CLIENT: OnceCell<Client> = OnceCell::new();
 
 /// Struct representing a single JSON-RPC call to the casper node.
 #[derive(Debug)]
@@ -51,7 +53,7 @@ impl Call {
 
         crate::json_pretty_print(&rpc_request, self.verbosity)?;
 
-        let client = Client::new();
+        let client = CLIENT.get_or_init(Client::new);
         let http_response = client
             .post(&url)
             .json(&rpc_request)


### PR DESCRIPTION
This PR refactors the usage of `reqwest::Client` to reuse the same structure whenever users make requests. This is feasible because the client pools requests asynchronously, so reusing it consumes fewer resources.

`once_cell`'s `OnceCell` was used instead of `std`'s one because it's still an unstable feature in `std` as of right now.