### PR TITLE
`lock status` in JSON representation of `ContractPackage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add support for new node RPC method `info_get_peers`, used in the binary's new `get-peers` subcommand.
 * Add support for new node RPC method `query_balance`, used in the binary's new `query-balance` subcommand.
 * Add support for passing payment and session args as JSON.
+* Add support for new `lock_status` field in the the `ContractPackage` value.
 
 ### Changed
 * Update dependencies.

--- a/lib/types/contract_package.rs
+++ b/lib/types/contract_package.rs
@@ -101,6 +101,12 @@ impl Display for Group {
     }
 }
 
+#[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
+pub enum ContractPackageStatus {
+    Locked,
+    Unlocked,
+}
+
 /// Contract definition, metadata, and security container.
 #[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
@@ -109,6 +115,7 @@ pub struct ContractPackage {
     versions: Vec<ContractVersion>,
     disabled_versions: Vec<DisabledVersion>,
     groups: Vec<Group>,
+    lock_status: ContractPackageStatus,
 }
 
 impl ContractPackage {


### PR DESCRIPTION
This PR aligns the client with the changes made to the node in the following PR: https://github.com/casper-network/casper-node/pull/3312