### PR TITLE
Support bytes via simple arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to this project will be documented in this file.  The format
 * Add support for new node RPC method `info_get_status`, used in the binary's new `get-node-status` subcommand.
 * Add support for new node RPC method `info_get_peers`, used in the binary's new `get-peers` subcommand.
 * Add support for new node RPC method `query_balance`, used in the binary's new `query-balance` subcommand.
+* Add support for passing variable-length byte lists as simple args in payment and session args.
+* Add support for passing fixed-length byte arrays as simple args in payment and session args.
 * Add support for passing payment and session args as JSON.
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,35 +20,35 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-async-trait = "0.1.56"
+async-trait = "0.1.58"
 base16 = "0.2.1"
-base64 = "0.13.0"
+base64 = "0.13.1"
 casper-hashing = "*"
 casper-types = { version = "*", features = ["std"] }
-clap = { version = "3", features = ["cargo", "deprecated"] }
-clap_complete = "3"
+clap = { version = "4", features = ["cargo", "deprecated"] }
+clap_complete = "4"
 derp = "0.0.14"
 ed25519-dalek = { version = "1", default-features = false }
-getrandom = "0.2.7"
+getrandom = "0.2.8"
 hex-buffer-serde = "0.3.0"
 humantime = "2"
-itertools = "0.10.3"
-jsonrpc-lite = "0.5.0"
-k256 = { version = "0.7.2", features = ["arithmetic", "ecdsa", "sha256", "zeroize"] }
+itertools = "0.10.5"
+jsonrpc-lite = "0.6.0"
+k256 = { version = "0.7.3", features = ["arithmetic", "ecdsa", "sha256", "zeroize"] }
 num-traits = "0.2.15"
 once_cell = "1"
 pem = "1"
 rand = "0.8.5"
-reqwest = { version = "0.11.11", features = ["json"] }
+reqwest = { version = "0.11.12", features = ["json"] }
 schemars = "0.8"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1"
 signature = "1"
 tempfile = "3"
 thiserror = "1"
-tokio = { version = "1.19", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
-uint = "0.9.0"
-untrusted = "0.7.1"
+tokio = { version = "1.21", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
+uint = "0.9.4"
+untrusted = "0.9.0"
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["git"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ humantime = "2"
 itertools = "0.10.3"
 jsonrpc-lite = "0.5.0"
 k256 = { version = "0.7.2", features = ["arithmetic", "ecdsa", "sha256", "zeroize"] }
+num-traits = "0.2.15"
 once_cell = "1"
 pem = "1"
 rand = "0.8.5"

--- a/lib/cli/json_args.rs
+++ b/lib/cli/json_args.rs
@@ -155,12 +155,12 @@ fn write_json_to_bytesrepr(
         }
         (&CLType::Option(ref inner_cl_type), _) => {
             output.push(OPTION_SOME_TAG);
-            write_json_to_bytesrepr(&*inner_cl_type, json_value, output)?
+            write_json_to_bytesrepr(inner_cl_type, json_value, output)?
         }
         (&CLType::List(ref inner_cl_type), Value::Array(vec)) => {
             (vec.len() as u32).write_bytes(output)?;
             for item in vec {
-                write_json_to_bytesrepr(&*inner_cl_type, item, output)?;
+                write_json_to_bytesrepr(inner_cl_type, item, output)?;
             }
         }
         (&CLType::List(ref inner_cl_type), Value::String(string)) => {
@@ -208,11 +208,11 @@ fn write_json_to_bytesrepr(
             match map.iter().next() {
                 Some((key, value)) if key.to_ascii_lowercase() == "ok" => {
                     output.push(RESULT_OK_TAG);
-                    write_json_to_bytesrepr(&*ok, value, output)?
+                    write_json_to_bytesrepr(ok, value, output)?
                 }
                 Some((key, value)) if key.to_ascii_lowercase() == "err" => {
                     output.push(RESULT_ERR_TAG);
-                    write_json_to_bytesrepr(&*err, value, output)?
+                    write_json_to_bytesrepr(err, value, output)?
                 }
                 _ => return Err(ErrorDetails::ResultObjectHasInvalidVariant),
             }
@@ -255,8 +255,8 @@ fn write_json_to_bytesrepr(
                     CLType::String => json!(key_as_str),
                     _ => return Err(ErrorDetails::MapTypeNotValidAsObject(*key_type.clone())),
                 };
-                write_json_to_bytesrepr(&*key_type, &key, output)?;
-                write_json_to_bytesrepr(&*value_type, value, output)?;
+                write_json_to_bytesrepr(key_type, &key, output)?;
+                write_json_to_bytesrepr(value_type, value, output)?;
             }
         }
         (
@@ -279,11 +279,11 @@ fn write_json_to_bytesrepr(
                 let key = map
                     .get("key")
                     .ok_or(ErrorDetails::MapEntryObjectMissingKeyField)?;
-                write_json_to_bytesrepr(&*key_type, key, output)?;
+                write_json_to_bytesrepr(key_type, key, output)?;
                 let value = map
                     .get("value")
                     .ok_or(ErrorDetails::MapEntryObjectMissingValueField)?;
-                write_json_to_bytesrepr(&*value_type, value, output)?;
+                write_json_to_bytesrepr(value_type, value, output)?;
             }
         }
         (&CLType::Tuple1(ref inner_cl_types), Value::Array(vec)) => {

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -8,8 +8,8 @@ use serde::{self, Deserialize};
 
 use casper_hashing::Digest;
 use casper_types::{
-    account::AccountHash, bytesrepr, crypto, AsymmetricType, CLType, CLValue, HashAddr, Key,
-    NamedArg, PublicKey, RuntimeArgs, SecretKey, UIntParseError, URef, U512,
+    account::AccountHash, bytesrepr, crypto, AsymmetricType, CLValue, HashAddr, Key, NamedArg,
+    PublicKey, RuntimeArgs, SecretKey, UIntParseError, URef, U512,
 };
 
 use super::{simple_args, CliError, PaymentStrParams, SessionStrParams};
@@ -88,8 +88,6 @@ pub(super) fn session_account(value: &str) -> Result<Option<PublicKey>, CliError
 mod arg_simple {
     use super::*;
 
-    const ARG_VALUE_NAME: &str = r#""NAME:TYPE='VALUE'" OR "NAME:TYPE=null""#;
-
     pub(crate) mod session {
         use super::*;
 
@@ -117,40 +115,9 @@ mod arg_simple {
     fn get(values: &[&str]) -> Result<RuntimeArgs, CliError> {
         let mut runtime_args = RuntimeArgs::new();
         for arg in values {
-            let parts = split_arg(arg)?;
-            parts_to_cl_value(parts, &mut runtime_args)?;
+            simple_args::insert_arg(arg, &mut runtime_args)?;
         }
         Ok(runtime_args)
-    }
-
-    /// Splits a single arg of the form `NAME:TYPE='VALUE'` into its constituent parts.
-    fn split_arg(arg: &str) -> Result<(&str, CLType, &str), CliError> {
-        let parts: Vec<_> = arg.splitn(3, &[':', '='][..]).collect();
-        if parts.len() != 3 {
-            return Err(CliError::InvalidCLValue(format!(
-                "arg {} should be formatted as {}",
-                arg, ARG_VALUE_NAME
-            )));
-        }
-        let cl_type = simple_args::parse_cl_type(parts[1]).map_err(|_| {
-            CliError::InvalidCLValue(format!(
-                "unknown variant {}, expected one of {}",
-                parts[1],
-                simple_args::help::supported_cl_type_list()
-            ))
-        })?;
-        Ok((parts[0], cl_type, parts[2]))
-    }
-
-    /// Insert a value built from a single arg which has been split into its constituent parts.
-    fn parts_to_cl_value(
-        parts: (&str, CLType, &str),
-        runtime_args: &mut RuntimeArgs,
-    ) -> Result<(), CliError> {
-        let (name, cl_type, value) = parts;
-        let cl_value = simple_args::parts_to_cl_value(cl_type, value)?;
-        runtime_args.insert_cl_value(name, cl_value);
-        Ok(())
     }
 }
 
@@ -802,87 +769,18 @@ pub(super) fn purse_identifier(purse_id: &str) -> Result<PurseIdentifier, CliErr
 
 #[cfg(test)]
 mod tests {
-    use casper_types::{
-        account::AccountHash, bytesrepr::ToBytes, AccessRights, CLTyped, CLValue, NamedArg,
-        PublicKey, RuntimeArgs, URef, U128, U256, U512,
-    };
     use std::convert::TryFrom;
 
     use super::*;
 
-    mod bad {
-        pub const EMPTY: &str = "";
-        pub const ARG_UNQUOTED: &str = "name:u32=0"; // value needs single quotes to be valid
-        pub const ARG_BAD_TYPE: &str = "name:wat='false'";
-        pub const ARG_GIBBERISH: &str = "asdf|1234(..)";
-        pub const LARGE_2K_INPUT: &str = r#"
-        eJy2irIizK6zT0XOklyBAY1KVUsAbyF6eJUYBmRPHqX2rONbaEieJt4Ci1eZYjBdHdEq46oMBH0LeiQO8RIJb95
-        SJGEp83RxakDj7trunJVvMbj2KZFnpJOyEauFa35dlaVG9Ki7hjFy4BLlDyA0Wgwk20RXFkbgKQIQVvR16RPffR
-        WO86WqZ3gMuOh447svZRYfhbRF3NVBaWRz7SJ9Zm3w8djisvS0Y3GSnpzKnSEQirApqomfQTHTrU9ww2SMgdGuu
-        EllGLsj3ze8WzIbXLlJvXdnJFz7UfsgX4xowG4d6xSiUVWCY4sVItNXlqs8adfZZHH7AjqLjlRRvWwjNCiWsiqx
-        ICe9jlkdEVeRAO0BqF6FhjSxPt9X3y6WXAomB0YTIFQGyto4jMBOhWb96ny3DG3WISUSdaKWf8KaRuAQD4ao3ML
-        jJZSXkTlovZTYQmYlkYo4s3635YLthuh0hSorRs0ju7ffeY3tu7VRvttgvbBLVjFJjYrwW1YAEOaxDdLnhiTIQn
-        H0zRLWnCQ4Czk5BWsRLDdupJbKRWRZcQ7pehSgfc5qtXpJRFVtL2L82hxfBdiXqzXl3KdQ21CnGxTzcgEv0ptrs
-        XGJwNgd04YiZzHrZL7iF3xFann6DJVyEZ0eEifTfY8rtxPCMDutjr68iFjnjy40c7SfhvsZLODuEjS4VQkIwfJc
-        QP5fH3cQ2K4A4whpzTVc3yqig468Cjbxfobw4Z7YquZnuFw1TXSrM35ZBXpI4WKo9QLxmE2HkgMI1Uac2dWyG0U
-        iCAxpHxC4uTIFEq2MUuGd7ZgYs8zoYpODvtAcZ8nUqKssdugQUGfXw9Cs1pcDZgEppYVVw1nYoHXKCjK3oItexs
-        uIaZ0m1o91L9Js5lhaDybyDoye9zPFOnEIwKdcH0dO9cZmv6UyvVZS2oVKJm7nHQAJDARjVfC7GYAT2AQhFZxIQ
-        DP9jjHCqxMJz6p499G5lk8cYAhnlUm7GCr4AwvjsEU7sEsJcZLDCLG6FaFMdLHJS5v2yPYzpuWebjcNCXbk4yER
-        F9NsvlDBrLhoDt1GDgJPlRF8B5h5BSzPHsCjNVa9h2YWx1GVl6Yrrk04FSMSj0nRO8OoxkyU0ugtBQlUv3rQ833
-        Vcs7jCGetaazcvaI45dRDGe6LyEPwojlC4IaB8PtljKo2zn0u91lQGJY7rj1qLUtFBRDCKERs7W1j9A2eGJ3ORY
-        Db7Q3K7BY9XbANGoYiwtLoytopYCQs5RYHepkoQ19f1E9IcqCFQg9h0rWK494xb88GfSGKBpPHddrQYXFrr715u
-        NkAj885V8Mnam5kSzsOmrg504QhPSOaqpkY36xyXUP13yWK4fEf39tJ2PN2DlAsxFAWJUec4CiS47rgrU87oESt
-        KZJni3Jhccczlq1CaRKaYYV38joEzPL0UNKr5RiCodTWJmdN07JI5txtQqgc8kvHOrxgOASPQOPSbAUz33vZx3b
-        eNsTYUD0Dxa4IkMUNHSy6mpaSOElO7wgUvWJEajnVWZJ5gWehyE4yqo6PkL3VBj51Jg2uozPa8xnbSfymlVVLFl
-        EIfMyPwUj1J9ngQw0J3bn33IIOB3bkNfB50f1MkKkhyn1TMZJcnZ7IS16PXBH6DD7Sht1PVKhER2E3QS7z8YQ6B
-        q27ktZZ33IcCnayahxHnyf2Wzab9ic5eSJLzsVi0VWP7DePt2GnCbz5D2tcAxgVVFmdIsEakytjmeEGyMu9k2R7
-        Q8d1wPtqKgayVtgdIaMbvsnXMkRqITkf3o8Qh495pm1wkKArTGFGODXc1cCKheFUEtJWdK92DHH7OuRENHAb5KS
-        PKzSUg2k18wyf9XCy1pQKv31wii3rWrWMCbxOWmhuzw1N9tqO8U97NsThRSoPAjpd05G2roia4m4CaPWTAUmVky
-        RfiWoA7bglAh4Aoz2LN2ezFleTNJjjLw3n9bYPg5BdRL8n8wimhXDo9SW46A5YS62C08ZOVtvfn82YRaYkuKKz7
-        3NJ25PnQG6diMm4Lm3wi22yR7lY7oYYJjLNcaLYOI6HOvaJ
-        "#;
-    }
-
-    mod happy {
-        pub const HASH: &str = "09dcee4b212cfd53642ab323fbef07dafafc6f945a80a00147f62910a915c4e6";
-        pub const NAME: &str = "name";
-        pub const PACKAGE_HASH: &str =
-            "09dcee4b212cfd53642ab323fbef07dafafc6f945a80a00147f62910a915c4e6";
-        pub const PACKAGE_NAME: &str = "package_name";
-        pub const PATH: &str = "./session.wasm";
-        pub const ENTRY_POINT: &str = "entrypoint";
-        pub const VERSION: &str = "1.0.0";
-        pub const TRANSFER: bool = true;
-    }
-
-    fn invalid_simple_args_test(cli_string: &str) {
-        assert!(
-            arg_simple::payment::parse(&[cli_string]).is_err(),
-            "{} should be an error",
-            cli_string
-        );
-        assert!(
-            arg_simple::session::parse(&[cli_string]).is_err(),
-            "{} should be an error",
-            cli_string
-        );
-    }
-
-    fn valid_simple_args_test<T: CLTyped + ToBytes>(cli_string: &str, expected: T) {
-        let expected = Some(RuntimeArgs::from(vec![NamedArg::new(
-            "x".to_string(),
-            CLValue::from_t(expected).unwrap(),
-        )]));
-
-        assert_eq!(
-            arg_simple::payment::parse(&[cli_string]).expect("should parse"),
-            expected
-        );
-        assert_eq!(
-            arg_simple::session::parse(&[cli_string]).expect("should parse"),
-            expected
-        );
-    }
+    const HASH: &str = "09dcee4b212cfd53642ab323fbef07dafafc6f945a80a00147f62910a915c4e6";
+    const NAME: &str = "name";
+    const PACKAGE_HASH: &str = "09dcee4b212cfd53642ab323fbef07dafafc6f945a80a00147f62910a915c4e6";
+    const PACKAGE_NAME: &str = "package_name";
+    const PATH: &str = "./session.wasm";
+    const ENTRY_POINT: &str = "entrypoint";
+    const VERSION: &str = "1.0.0";
+    const TRANSFER: bool = true;
 
     impl<'a> TryFrom<SessionStrParams<'a>> for ExecutableDeployItem {
         type Error = CliError;
@@ -898,174 +796,6 @@ mod tests {
         fn try_from(params: PaymentStrParams<'a>) -> Result<ExecutableDeployItem, Self::Error> {
             payment_executable_deploy_item(params)
         }
-    }
-
-    #[test]
-    fn should_parse_bool_via_args_simple() {
-        valid_simple_args_test("x:bool='f'", false);
-        valid_simple_args_test("x:bool='false'", false);
-        valid_simple_args_test("x:bool='t'", true);
-        valid_simple_args_test("x:bool='true'", true);
-        valid_simple_args_test("x:opt_bool='f'", Some(false));
-        valid_simple_args_test("x:opt_bool='t'", Some(true));
-        valid_simple_args_test::<Option<bool>>("x:opt_bool=null", None);
-    }
-
-    #[test]
-    fn should_parse_i32_via_args_simple() {
-        valid_simple_args_test("x:i32='2147483647'", i32::max_value());
-        valid_simple_args_test("x:i32='0'", 0_i32);
-        valid_simple_args_test("x:i32='-2147483648'", i32::min_value());
-        valid_simple_args_test("x:opt_i32='-1'", Some(-1_i32));
-        valid_simple_args_test::<Option<i32>>("x:opt_i32=null", None);
-    }
-
-    #[test]
-    fn should_parse_i64_via_args_simple() {
-        valid_simple_args_test("x:i64='9223372036854775807'", i64::max_value());
-        valid_simple_args_test("x:i64='0'", 0_i64);
-        valid_simple_args_test("x:i64='-9223372036854775808'", i64::min_value());
-        valid_simple_args_test("x:opt_i64='-1'", Some(-1_i64));
-        valid_simple_args_test::<Option<i64>>("x:opt_i64=null", None);
-    }
-
-    #[test]
-    fn should_parse_u8_via_args_simple() {
-        valid_simple_args_test("x:u8='0'", 0_u8);
-        valid_simple_args_test("x:u8='255'", u8::max_value());
-        valid_simple_args_test("x:opt_u8='1'", Some(1_u8));
-        valid_simple_args_test::<Option<u8>>("x:opt_u8=null", None);
-    }
-
-    #[test]
-    fn should_parse_u32_via_args_simple() {
-        valid_simple_args_test("x:u32='0'", 0_u32);
-        valid_simple_args_test("x:u32='4294967295'", u32::max_value());
-        valid_simple_args_test("x:opt_u32='1'", Some(1_u32));
-        valid_simple_args_test::<Option<u32>>("x:opt_u32=null", None);
-    }
-
-    #[test]
-    fn should_parse_u64_via_args_simple() {
-        valid_simple_args_test("x:u64='0'", 0_u64);
-        valid_simple_args_test("x:u64='18446744073709551615'", u64::max_value());
-        valid_simple_args_test("x:opt_u64='1'", Some(1_u64));
-        valid_simple_args_test::<Option<u64>>("x:opt_u64=null", None);
-    }
-
-    #[test]
-    fn should_parse_u128_via_args_simple() {
-        valid_simple_args_test("x:u128='0'", U128::zero());
-        valid_simple_args_test(
-            "x:u128='340282366920938463463374607431768211455'",
-            U128::max_value(),
-        );
-        valid_simple_args_test("x:opt_u128='1'", Some(U128::from(1)));
-        valid_simple_args_test::<Option<U128>>("x:opt_u128=null", None);
-    }
-
-    #[test]
-    fn should_parse_u256_via_args_simple() {
-        valid_simple_args_test("x:u256='0'", U256::zero());
-        valid_simple_args_test(
-            "x:u256='115792089237316195423570985008687907853269984665640564039457584007913129639935'",
-            U256::max_value(),
-        );
-        valid_simple_args_test("x:opt_u256='1'", Some(U256::from(1)));
-        valid_simple_args_test::<Option<U256>>("x:opt_u256=null", None);
-    }
-
-    #[test]
-    fn should_parse_u512_via_args_simple() {
-        valid_simple_args_test("x:u512='0'", U512::zero());
-        valid_simple_args_test(
-            "x:u512='134078079299425970995740249982058461274793658205923933777235614437217640300735\
-            46976801874298166903427690031858186486050853753882811946569946433649006084095'",
-            U512::max_value(),
-        );
-        valid_simple_args_test("x:opt_u512='1'", Some(U512::from(1)));
-        valid_simple_args_test::<Option<U512>>("x:opt_u512=null", None);
-    }
-
-    #[test]
-    fn should_parse_unit_via_args_simple() {
-        valid_simple_args_test("x:unit=''", ());
-        valid_simple_args_test("x:opt_unit=''", Some(()));
-        valid_simple_args_test::<Option<()>>("x:opt_unit=null", None);
-    }
-
-    #[test]
-    fn should_parse_string_via_args_simple() {
-        let value = String::from("test string");
-        valid_simple_args_test(&format!("x:string='{}'", value), value.clone());
-        valid_simple_args_test(&format!("x:opt_string='{}'", value), Some(value));
-        valid_simple_args_test::<Option<String>>("x:opt_string=null", None);
-    }
-
-    #[test]
-    fn should_parse_key_via_args_simple() {
-        let bytes = (1..33).collect::<Vec<_>>();
-        let array = <[u8; 32]>::try_from(bytes.as_ref()).unwrap();
-
-        let key_account = Key::Account(AccountHash::new(array));
-        let key_hash = Key::Hash(array);
-        let key_uref = Key::URef(URef::new(array, AccessRights::NONE));
-
-        for key in &[key_account, key_hash, key_uref] {
-            valid_simple_args_test(&format!("x:key='{}'", key.to_formatted_string()), *key);
-            valid_simple_args_test(
-                &format!("x:opt_key='{}'", key.to_formatted_string()),
-                Some(*key),
-            );
-            valid_simple_args_test::<Option<Key>>("x:opt_key=null", None);
-        }
-    }
-
-    #[test]
-    fn should_parse_account_hash_via_args_simple() {
-        let bytes = (1..33).collect::<Vec<_>>();
-        let array = <[u8; 32]>::try_from(bytes.as_ref()).unwrap();
-        let value = AccountHash::new(array);
-        valid_simple_args_test(
-            &format!("x:account_hash='{}'", value.to_formatted_string()),
-            value,
-        );
-        valid_simple_args_test(
-            &format!("x:opt_account_hash='{}'", value.to_formatted_string()),
-            Some(value),
-        );
-        valid_simple_args_test::<Option<AccountHash>>("x:opt_account_hash=null", None);
-    }
-
-    #[test]
-    fn should_parse_uref_via_args_simple() {
-        let bytes = (1..33).collect::<Vec<_>>();
-        let array = <[u8; 32]>::try_from(bytes.as_ref()).unwrap();
-        let value = URef::new(array, AccessRights::READ_ADD_WRITE);
-        valid_simple_args_test(&format!("x:uref='{}'", value.to_formatted_string()), value);
-        valid_simple_args_test(
-            &format!("x:opt_uref='{}'", value.to_formatted_string()),
-            Some(value),
-        );
-        valid_simple_args_test::<Option<URef>>("x:opt_uref=null", None);
-    }
-
-    #[test]
-    fn should_parse_public_key_via_args_simple() {
-        let hex_value = "0119bf44096984cdfe8541bac167dc3b96c85086aa30b6b6cb0c5c38ad703166e1";
-        let value = PublicKey::from_hex(hex_value).unwrap();
-        valid_simple_args_test(&format!("x:public_key='{}'", hex_value), value.clone());
-        valid_simple_args_test(&format!("x:opt_public_key='{}'", hex_value), Some(value));
-        valid_simple_args_test::<Option<PublicKey>>("x:opt_public_key=null", None);
-    }
-
-    #[test]
-    fn should_fail_to_parse_bad_args() {
-        invalid_simple_args_test(bad::ARG_BAD_TYPE);
-        invalid_simple_args_test(bad::ARG_GIBBERISH);
-        invalid_simple_args_test(bad::ARG_UNQUOTED);
-        invalid_simple_args_test(bad::EMPTY);
-        invalid_simple_args_test(bad::LARGE_2K_INPUT);
     }
 
     #[test]
@@ -1115,11 +845,11 @@ mod tests {
     fn should_fail_to_parse_conflicting_session_parameters() {
         assert!(matches!(
             session_executable_deploy_item(SessionStrParams {
-                session_hash: happy::HASH,
-                session_name: happy::NAME,
-                session_package_hash: happy::PACKAGE_HASH,
-                session_package_name: happy::PACKAGE_NAME,
-                session_path: happy::PATH,
+                session_hash: HASH,
+                session_name: NAME,
+                session_package_hash: PACKAGE_HASH,
+                session_package_name: PACKAGE_NAME,
+                session_path: PATH,
                 session_args_simple: vec![],
                 session_args_json: "",
                 session_args_complex: "",
@@ -1139,11 +869,11 @@ mod tests {
         assert!(matches!(
             payment_executable_deploy_item(PaymentStrParams {
                 payment_amount: "12345",
-                payment_hash: happy::HASH,
-                payment_name: happy::NAME,
-                payment_package_hash: happy::PACKAGE_HASH,
-                payment_package_name: happy::PACKAGE_NAME,
-                payment_path: happy::PATH,
+                payment_hash: HASH,
+                payment_name: NAME,
+                payment_package_hash: PACKAGE_HASH,
+                payment_package_name: PACKAGE_NAME,
+                payment_path: PATH,
                 payment_args_simple: vec![],
                 payment_args_json: "",
                 payment_args_complex: "",
@@ -1162,7 +892,7 @@ mod tests {
         let missing_file = "missing/file";
         assert!(matches!(
             session_executable_deploy_item(SessionStrParams {
-                session_hash: happy::HASH,
+                session_hash: HASH,
                 session_name: "",
                 session_package_hash: "",
                 session_package_name: "",
@@ -1187,7 +917,7 @@ mod tests {
         assert!(matches!(
             payment_executable_deploy_item(PaymentStrParams {
                 payment_amount: "",
-                payment_hash: happy::HASH,
+                payment_hash: HASH,
                 payment_name: "",
                 payment_package_hash: "",
                 payment_package_name: "",
@@ -1211,7 +941,7 @@ mod tests {
         #[test]
         fn session_name_should_fail_to_parse_missing_entry_point() {
             let result = session_executable_deploy_item(SessionStrParams {
-                session_name: happy::NAME,
+                session_name: NAME,
                 ..Default::default()
             });
 
@@ -1227,7 +957,7 @@ mod tests {
         #[test]
         fn session_hash_should_fail_to_parse_missing_entry_point() {
             let result = session_executable_deploy_item(SessionStrParams {
-                session_hash: happy::HASH,
+                session_hash: HASH,
                 ..Default::default()
             });
 
@@ -1243,7 +973,7 @@ mod tests {
         #[test]
         fn session_package_hash_should_fail_to_parse_missing_entry_point() {
             let result = session_executable_deploy_item(SessionStrParams {
-                session_package_hash: happy::PACKAGE_HASH,
+                session_package_hash: PACKAGE_HASH,
                 ..Default::default()
             });
 
@@ -1259,7 +989,7 @@ mod tests {
         #[test]
         fn session_package_name_should_fail_to_parse_missing_entry_point() {
             let result = session_executable_deploy_item(SessionStrParams {
-                session_package_name: happy::PACKAGE_NAME,
+                session_package_name: PACKAGE_NAME,
                 ..Default::default()
             });
 
@@ -1275,7 +1005,7 @@ mod tests {
         #[test]
         fn payment_name_should_fail_to_parse_missing_entry_point() {
             let result = payment_executable_deploy_item(PaymentStrParams {
-                payment_name: happy::NAME,
+                payment_name: NAME,
                 ..Default::default()
             });
 
@@ -1291,7 +1021,7 @@ mod tests {
         #[test]
         fn payment_hash_should_fail_to_parse_missing_entry_point() {
             let result = payment_executable_deploy_item(PaymentStrParams {
-                payment_hash: happy::HASH,
+                payment_hash: HASH,
                 ..Default::default()
             });
 
@@ -1307,7 +1037,7 @@ mod tests {
         #[test]
         fn payment_package_hash_should_fail_to_parse_missing_entry_point() {
             let result = payment_executable_deploy_item(PaymentStrParams {
-                payment_package_hash: happy::PACKAGE_HASH,
+                payment_package_hash: PACKAGE_HASH,
                 ..Default::default()
             });
 
@@ -1323,7 +1053,7 @@ mod tests {
         #[test]
         fn payment_package_name_should_fail_to_parse_missing_entry_point() {
             let result = payment_executable_deploy_item(PaymentStrParams {
-                payment_package_name: happy::PACKAGE_NAME,
+                payment_package_name: PACKAGE_NAME,
                 ..Default::default()
             });
 
@@ -1353,8 +1083,8 @@ mod tests {
         ///     context: "parse_session_info",
         ///     session_str_params[
         ///         test[
-        ///             session_path => happy::PATH,
-        ///             conflict: session_package_hash => happy::PACKAGE_HASH,
+        ///             session_path => PATH,
+        ///             conflict: session_package_hash => PACKAGE_HASH,
         ///             requires[],
         ///             path_conflicts_with_package_hash
         ///         ]
@@ -1371,14 +1101,14 @@ mod tests {
         ///     #[test]
         ///     fn path_conflicts_with_package_hash() {
         ///         let info: StdResult<ExecutableDeployItem, _> = SessionStrParams {
-        ///                 session_path: happy::PATH,
-        ///                 session_package_hash: happy::PACKAGE_HASH,
+        ///                 session_path: PATH,
+        ///                 session_package_hash: PACKAGE_HASH,
         ///                 ..Default::default()
         ///             }
         ///             .try_into();
         ///         let mut conflicting = vec![
-        ///             format!("{}={}", "session_path", happy::PATH),
-        ///             format!("{}={}", "session_package_hash", happy::PACKAGE_HASH),
+        ///             format!("{}={}", "session_path", PATH),
+        ///             format!("{}={}", "session_package_hash", PACKAGE_HASH),
         ///         ];
         ///         conflicting.sort();
         ///         assert!(matches!(
@@ -1456,40 +1186,40 @@ mod tests {
             session_str_params[
 
                 // path
-                test[session_path => happy::PATH, conflict: session_package_hash => happy::PACKAGE_HASH, requires[], path_conflicts_with_package_hash]
-                test[session_path => happy::PATH, conflict: session_package_name => happy::PACKAGE_NAME, requires[], path_conflicts_with_package_name]
-                test[session_path => happy::PATH, conflict: session_hash =>         happy::HASH,         requires[], path_conflicts_with_hash]
-                test[session_path => happy::PATH, conflict: session_name =>         happy::HASH,         requires[], path_conflicts_with_name]
-                test[session_path => happy::PATH, conflict: session_version =>      happy::VERSION,      requires[], path_conflicts_with_version]
-                test[session_path => happy::PATH, conflict: session_entry_point =>  happy::ENTRY_POINT,  requires[], path_conflicts_with_entry_point]
-                test[session_path => happy::PATH, conflict: is_session_transfer =>  happy::TRANSFER,     requires[], path_conflicts_with_transfer]
+                test[session_path => PATH, conflict: session_package_hash => PACKAGE_HASH, requires[], path_conflicts_with_package_hash]
+                test[session_path => PATH, conflict: session_package_name => PACKAGE_NAME, requires[], path_conflicts_with_package_name]
+                test[session_path => PATH, conflict: session_hash =>         HASH,         requires[], path_conflicts_with_hash]
+                test[session_path => PATH, conflict: session_name =>         HASH,         requires[], path_conflicts_with_name]
+                test[session_path => PATH, conflict: session_version =>      VERSION,      requires[], path_conflicts_with_version]
+                test[session_path => PATH, conflict: session_entry_point =>  ENTRY_POINT,  requires[], path_conflicts_with_entry_point]
+                test[session_path => PATH, conflict: is_session_transfer =>  TRANSFER,     requires[], path_conflicts_with_transfer]
 
                 // name
-                test[session_name => happy::NAME, conflict: session_package_hash => happy::PACKAGE_HASH, requires[session_entry_point => happy::ENTRY_POINT], name_conflicts_with_package_hash]
-                test[session_name => happy::NAME, conflict: session_package_name => happy::PACKAGE_NAME, requires[session_entry_point => happy::ENTRY_POINT], name_conflicts_with_package_name]
-                test[session_name => happy::NAME, conflict: session_hash =>         happy::HASH,         requires[session_entry_point => happy::ENTRY_POINT], name_conflicts_with_hash]
-                test[session_name => happy::NAME, conflict: session_version =>      happy::VERSION,      requires[session_entry_point => happy::ENTRY_POINT], name_conflicts_with_version]
-                test[session_name => happy::NAME, conflict: is_session_transfer =>  happy::TRANSFER,     requires[session_entry_point => happy::ENTRY_POINT], name_conflicts_with_transfer]
+                test[session_name => NAME, conflict: session_package_hash => PACKAGE_HASH, requires[session_entry_point => ENTRY_POINT], name_conflicts_with_package_hash]
+                test[session_name => NAME, conflict: session_package_name => PACKAGE_NAME, requires[session_entry_point => ENTRY_POINT], name_conflicts_with_package_name]
+                test[session_name => NAME, conflict: session_hash =>         HASH,         requires[session_entry_point => ENTRY_POINT], name_conflicts_with_hash]
+                test[session_name => NAME, conflict: session_version =>      VERSION,      requires[session_entry_point => ENTRY_POINT], name_conflicts_with_version]
+                test[session_name => NAME, conflict: is_session_transfer =>  TRANSFER,     requires[session_entry_point => ENTRY_POINT], name_conflicts_with_transfer]
 
                 // hash
-                test[session_hash => happy::HASH, conflict: session_package_hash => happy::PACKAGE_HASH, requires[session_entry_point => happy::ENTRY_POINT], hash_conflicts_with_package_hash]
-                test[session_hash => happy::HASH, conflict: session_package_name => happy::PACKAGE_NAME, requires[session_entry_point => happy::ENTRY_POINT], hash_conflicts_with_package_name]
-                test[session_hash => happy::HASH, conflict: session_version =>      happy::VERSION,      requires[session_entry_point => happy::ENTRY_POINT], hash_conflicts_with_version]
-                test[session_hash => happy::HASH, conflict: is_session_transfer =>  happy::TRANSFER,     requires[session_entry_point => happy::ENTRY_POINT], hash_conflicts_with_transfer]
+                test[session_hash => HASH, conflict: session_package_hash => PACKAGE_HASH, requires[session_entry_point => ENTRY_POINT], hash_conflicts_with_package_hash]
+                test[session_hash => HASH, conflict: session_package_name => PACKAGE_NAME, requires[session_entry_point => ENTRY_POINT], hash_conflicts_with_package_name]
+                test[session_hash => HASH, conflict: session_version =>      VERSION,      requires[session_entry_point => ENTRY_POINT], hash_conflicts_with_version]
+                test[session_hash => HASH, conflict: is_session_transfer =>  TRANSFER,     requires[session_entry_point => ENTRY_POINT], hash_conflicts_with_transfer]
                 // name <-> hash is already checked
                 // name <-> path is already checked
 
                 // package_name
                 // package_name + session_version is optional and allowed
-                test[session_package_name => happy::PACKAGE_NAME, conflict: session_package_hash => happy::PACKAGE_HASH, requires[session_entry_point => happy::ENTRY_POINT], package_name_conflicts_with_package_hash]
-                test[session_package_name => happy::VERSION, conflict: is_session_transfer => happy::TRANSFER, requires[session_entry_point => happy::ENTRY_POINT], package_name_conflicts_with_transfer]
+                test[session_package_name => PACKAGE_NAME, conflict: session_package_hash => PACKAGE_HASH, requires[session_entry_point => ENTRY_POINT], package_name_conflicts_with_package_hash]
+                test[session_package_name => VERSION, conflict: is_session_transfer => TRANSFER, requires[session_entry_point => ENTRY_POINT], package_name_conflicts_with_transfer]
                 // package_name <-> hash is already checked
                 // package_name <-> name is already checked
                 // package_name <-> path is already checked
 
                 // package_hash
                 // package_hash + session_version is optional and allowed
-                test[session_package_hash => happy::PACKAGE_HASH, conflict: is_session_transfer => happy::TRANSFER, requires[session_entry_point => happy::ENTRY_POINT], package_hash_conflicts_with_transfer]
+                test[session_package_hash => PACKAGE_HASH, conflict: is_session_transfer => TRANSFER, requires[session_entry_point => ENTRY_POINT], package_hash_conflicts_with_transfer]
                 // package_hash <-> package_name is already checked
                 // package_hash <-> hash is already checked
                 // package_hash <-> name is already checked
@@ -1504,40 +1234,40 @@ mod tests {
             payment_str_params[
 
                 // amount
-                test[payment_amount => happy::PATH, conflict: payment_package_hash => happy::PACKAGE_HASH, requires[], amount_conflicts_with_package_hash]
-                test[payment_amount => happy::PATH, conflict: payment_package_name => happy::PACKAGE_NAME, requires[], amount_conflicts_with_package_name]
-                test[payment_amount => happy::PATH, conflict: payment_hash =>         happy::HASH,         requires[], amount_conflicts_with_hash]
-                test[payment_amount => happy::PATH, conflict: payment_name =>         happy::HASH,         requires[], amount_conflicts_with_name]
-                test[payment_amount => happy::PATH, conflict: payment_version =>      happy::VERSION,      requires[], amount_conflicts_with_version]
-                test[payment_amount => happy::PATH, conflict: payment_entry_point =>  happy::ENTRY_POINT,  requires[], amount_conflicts_with_entry_point]
+                test[payment_amount => PATH, conflict: payment_package_hash => PACKAGE_HASH, requires[], amount_conflicts_with_package_hash]
+                test[payment_amount => PATH, conflict: payment_package_name => PACKAGE_NAME, requires[], amount_conflicts_with_package_name]
+                test[payment_amount => PATH, conflict: payment_hash =>         HASH,         requires[], amount_conflicts_with_hash]
+                test[payment_amount => PATH, conflict: payment_name =>         HASH,         requires[], amount_conflicts_with_name]
+                test[payment_amount => PATH, conflict: payment_version =>      VERSION,      requires[], amount_conflicts_with_version]
+                test[payment_amount => PATH, conflict: payment_entry_point =>  ENTRY_POINT,  requires[], amount_conflicts_with_entry_point]
 
                 // path
                 // amount <-> path is already checked
-                test[payment_path => happy::PATH, conflict: payment_package_hash => happy::PACKAGE_HASH, requires[], path_conflicts_with_package_hash]
-                test[payment_path => happy::PATH, conflict: payment_package_name => happy::PACKAGE_NAME, requires[], path_conflicts_with_package_name]
-                test[payment_path => happy::PATH, conflict: payment_hash =>         happy::HASH,         requires[], path_conflicts_with_hash]
-                test[payment_path => happy::PATH, conflict: payment_name =>         happy::HASH,         requires[], path_conflicts_with_name]
-                test[payment_path => happy::PATH, conflict: payment_version =>      happy::VERSION,      requires[], path_conflicts_with_version]
-                test[payment_path => happy::PATH, conflict: payment_entry_point =>  happy::ENTRY_POINT,  requires[], path_conflicts_with_entry_point]
+                test[payment_path => PATH, conflict: payment_package_hash => PACKAGE_HASH, requires[], path_conflicts_with_package_hash]
+                test[payment_path => PATH, conflict: payment_package_name => PACKAGE_NAME, requires[], path_conflicts_with_package_name]
+                test[payment_path => PATH, conflict: payment_hash =>         HASH,         requires[], path_conflicts_with_hash]
+                test[payment_path => PATH, conflict: payment_name =>         HASH,         requires[], path_conflicts_with_name]
+                test[payment_path => PATH, conflict: payment_version =>      VERSION,      requires[], path_conflicts_with_version]
+                test[payment_path => PATH, conflict: payment_entry_point =>  ENTRY_POINT,  requires[], path_conflicts_with_entry_point]
 
                 // name
                 // amount <-> path is already checked
-                test[payment_name => happy::NAME, conflict: payment_package_hash => happy::PACKAGE_HASH, requires[payment_entry_point => happy::ENTRY_POINT], name_conflicts_with_package_hash]
-                test[payment_name => happy::NAME, conflict: payment_package_name => happy::PACKAGE_NAME, requires[payment_entry_point => happy::ENTRY_POINT], name_conflicts_with_package_name]
-                test[payment_name => happy::NAME, conflict: payment_hash =>         happy::HASH,         requires[payment_entry_point => happy::ENTRY_POINT], name_conflicts_with_hash]
-                test[payment_name => happy::NAME, conflict: payment_version =>      happy::VERSION,      requires[payment_entry_point => happy::ENTRY_POINT], name_conflicts_with_version]
+                test[payment_name => NAME, conflict: payment_package_hash => PACKAGE_HASH, requires[payment_entry_point => ENTRY_POINT], name_conflicts_with_package_hash]
+                test[payment_name => NAME, conflict: payment_package_name => PACKAGE_NAME, requires[payment_entry_point => ENTRY_POINT], name_conflicts_with_package_name]
+                test[payment_name => NAME, conflict: payment_hash =>         HASH,         requires[payment_entry_point => ENTRY_POINT], name_conflicts_with_hash]
+                test[payment_name => NAME, conflict: payment_version =>      VERSION,      requires[payment_entry_point => ENTRY_POINT], name_conflicts_with_version]
 
                 // hash
                 // amount <-> hash is already checked
-                test[payment_hash => happy::HASH, conflict: payment_package_hash => happy::PACKAGE_HASH, requires[payment_entry_point => happy::ENTRY_POINT], hash_conflicts_with_package_hash]
-                test[payment_hash => happy::HASH, conflict: payment_package_name => happy::PACKAGE_NAME, requires[payment_entry_point => happy::ENTRY_POINT], hash_conflicts_with_package_name]
-                test[payment_hash => happy::HASH, conflict: payment_version =>      happy::VERSION,      requires[payment_entry_point => happy::ENTRY_POINT], hash_conflicts_with_version]
+                test[payment_hash => HASH, conflict: payment_package_hash => PACKAGE_HASH, requires[payment_entry_point => ENTRY_POINT], hash_conflicts_with_package_hash]
+                test[payment_hash => HASH, conflict: payment_package_name => PACKAGE_NAME, requires[payment_entry_point => ENTRY_POINT], hash_conflicts_with_package_name]
+                test[payment_hash => HASH, conflict: payment_version =>      VERSION,      requires[payment_entry_point => ENTRY_POINT], hash_conflicts_with_version]
                 // name <-> hash is already checked
                 // name <-> path is already checked
 
                 // package_name
                 // amount <-> package_name is already checked
-                test[payment_package_name => happy::PACKAGE_NAME, conflict: payment_package_hash => happy::PACKAGE_HASH, requires[payment_entry_point => happy::ENTRY_POINT], package_name_conflicts_with_package_hash]
+                test[payment_package_name => PACKAGE_NAME, conflict: payment_package_hash => PACKAGE_HASH, requires[payment_entry_point => ENTRY_POINT], package_name_conflicts_with_package_hash]
                 // package_name <-> hash is already checked
                 // package_name <-> name is already checked
                 // package_name <-> path is already checked

--- a/lib/cli/simple_args.rs
+++ b/lib/cli/simple_args.rs
@@ -1,165 +1,42 @@
-//! `CLType` and `CLValue` parsing and validation from "simple args" syntax.
+//! `CLValue` parsing and validation from "simple args" syntax.
 
-use std::str::FromStr;
+pub mod help;
+
+use std::{fmt::Debug, mem, str::FromStr};
+
+use num_traits::Num;
 
 use casper_types::{
-    account::AccountHash, bytesrepr::ToBytes, AsymmetricType, CLType, CLTyped, CLValue, Key,
-    PublicKey, URef, U128, U256, U512,
+    account::AccountHash,
+    bytesrepr::{Bytes, ToBytes, OPTION_NONE_TAG, OPTION_SOME_TAG},
+    AsymmetricType, CLType, CLTyped, CLValue, Key, PublicKey, RuntimeArgs, URef, U128, U256, U512,
 };
 
 use super::CliError;
 
-/// Parse a `CLType` from `&str`.
-pub(crate) fn parse_cl_type(strval: &str) -> Result<CLType, ()> {
-    let supported_types = supported_cl_types();
-    let cl_type = match strval.to_lowercase() {
-        t if t == supported_types[0].0 => supported_types[0].1.clone(),
-        t if t == supported_types[1].0 => supported_types[1].1.clone(),
-        t if t == supported_types[2].0 => supported_types[2].1.clone(),
-        t if t == supported_types[3].0 => supported_types[3].1.clone(),
-        t if t == supported_types[4].0 => supported_types[4].1.clone(),
-        t if t == supported_types[5].0 => supported_types[5].1.clone(),
-        t if t == supported_types[6].0 => supported_types[6].1.clone(),
-        t if t == supported_types[7].0 => supported_types[7].1.clone(),
-        t if t == supported_types[8].0 => supported_types[8].1.clone(),
-        t if t == supported_types[9].0 => supported_types[9].1.clone(),
-        t if t == supported_types[10].0 => supported_types[10].1.clone(),
-        t if t == supported_types[11].0 => supported_types[11].1.clone(),
-        t if t == supported_types[12].0 => supported_types[12].1.clone(),
-        t if t == supported_types[13].0 => supported_types[13].1.clone(),
-        t if t == supported_types[14].0 => supported_types[14].1.clone(),
-        t if t == supported_types[15].0 => supported_types[15].1.clone(),
-        t if t == supported_types[16].0 => supported_types[16].1.clone(),
-        t if t == supported_types[17].0 => supported_types[17].1.clone(),
-        t if t == supported_types[18].0 => supported_types[18].1.clone(),
-        t if t == supported_types[19].0 => supported_types[19].1.clone(),
-        t if t == supported_types[20].0 => supported_types[20].1.clone(),
-        t if t == supported_types[21].0 => supported_types[21].1.clone(),
-        t if t == supported_types[22].0 => supported_types[22].1.clone(),
-        t if t == supported_types[23].0 => supported_types[23].1.clone(),
-        t if t == supported_types[24].0 => supported_types[24].1.clone(),
-        t if t == supported_types[25].0 => supported_types[25].1.clone(),
-        t if t == supported_types[26].0 => supported_types[26].1.clone(),
-        t if t == supported_types[27].0 => supported_types[27].1.clone(),
-        t if t == supported_types[28].0 => supported_types[28].1.clone(),
-        t if t == supported_types[29].0 => supported_types[29].1.clone(),
-        _ => return Err(()),
-    };
-    Ok(cl_type)
-}
+type Parser = fn(&str, OptionalStatus, &str) -> Result<CLValue, CliError>;
 
-pub(crate) fn supported_cl_types() -> Vec<(&'static str, CLType)> {
-    vec![
-        ("bool", CLType::Bool),
-        ("i32", CLType::I32),
-        ("i64", CLType::I64),
-        ("u8", CLType::U8),
-        ("u32", CLType::U32),
-        ("u64", CLType::U64),
-        ("u128", CLType::U128),
-        ("u256", CLType::U256),
-        ("u512", CLType::U512),
-        ("unit", CLType::Unit),
-        ("string", CLType::String),
-        ("key", CLType::Key),
-        ("account_hash", AccountHash::cl_type()),
-        ("uref", CLType::URef),
-        ("public_key", CLType::PublicKey),
-        ("opt_bool", CLType::Option(Box::new(CLType::Bool))),
-        ("opt_i32", CLType::Option(Box::new(CLType::I32))),
-        ("opt_i64", CLType::Option(Box::new(CLType::I64))),
-        ("opt_u8", CLType::Option(Box::new(CLType::U8))),
-        ("opt_u32", CLType::Option(Box::new(CLType::U32))),
-        ("opt_u64", CLType::Option(Box::new(CLType::U64))),
-        ("opt_u128", CLType::Option(Box::new(CLType::U128))),
-        ("opt_u256", CLType::Option(Box::new(CLType::U256))),
-        ("opt_u512", CLType::Option(Box::new(CLType::U512))),
-        ("opt_unit", CLType::Option(Box::new(CLType::Unit))),
-        ("opt_string", CLType::Option(Box::new(CLType::String))),
-        ("opt_key", CLType::Option(Box::new(CLType::Key))),
-        (
-            "opt_account_hash",
-            CLType::Option(Box::new(AccountHash::cl_type())),
-        ),
-        ("opt_uref", CLType::Option(Box::new(CLType::URef))),
-        (
-            "opt_public_key",
-            CLType::Option(Box::new(CLType::PublicKey)),
-        ),
-    ]
-}
-
-/// Functions for use in help commands.
-pub mod help {
-    use std::convert::TryFrom;
-
-    use casper_types::{account::AccountHash, AccessRights, AsymmetricType, Key, PublicKey, URef};
-
-    /// Returns a list of `CLType`s able to be passed as a string for use as payment code or session
-    /// code args.
-    pub fn supported_cl_type_list() -> String {
-        let mut msg = String::new();
-        let supported_types = super::supported_cl_types();
-        for (index, item) in supported_types.iter().map(|(name, _)| name).enumerate() {
-            msg.push_str(item);
-            if index < supported_types.len() - 1 {
-                msg.push_str(", ")
-            }
-        }
-        msg
-    }
-
-    /// Returns a string listing examples of the format required when passing in payment code or
-    /// session code args.
-    pub fn supported_cl_type_examples() -> String {
-        let bytes = (1..33).collect::<Vec<_>>();
-        let array = <[u8; 32]>::try_from(bytes.as_ref()).unwrap();
-
-        format!(
-            r#""name_01:bool='false'"
-"name_02:i32='-1'"
-"name_03:i64='-2'"
-"name_04:u8='3'"
-"name_05:u32='4'"
-"name_06:u64='5'"
-"name_07:u128='6'"
-"name_08:u256='7'"
-"name_09:u512='8'"
-"name_10:unit=''"
-"name_11:string='a value'"
-"key_account_name:key='{}'"
-"key_hash_name:key='{}'"
-"key_uref_name:key='{}'"
-"account_hash_name:account_hash='{}'"
-"uref_name:uref='{}'"
-"public_key_name:public_key='{}'"
-
-Optional values of all of these types can also be specified.
-Prefix the type with "opt_" and use the term "null" without quotes to specify a None value:
-"name_01:opt_bool='true'"       # Some(true)
-"name_02:opt_bool='false'"      # Some(false)
-"name_03:opt_bool=null"         # None
-"name_04:opt_i32='-1'"          # Some(-1)
-"name_05:opt_i32=null"          # None
-"name_06:opt_unit=''"           # Some(())
-"name_07:opt_unit=null"         # None
-"name_08:opt_string='a value'"  # Some("a value".to_string())
-"name_09:opt_string='null'"     # Some("null".to_string())
-"name_10:opt_string=null"       # None
-"#,
-            Key::Account(AccountHash::new(array)).to_formatted_string(),
-            Key::Hash(array).to_formatted_string(),
-            Key::URef(URef::new(array, AccessRights::NONE)).to_formatted_string(),
-            AccountHash::new(array).to_formatted_string(),
-            URef::new(array, AccessRights::READ_ADD_WRITE).to_formatted_string(),
-            PublicKey::from_hex(
-                "0119bf44096984cdfe8541bac167dc3b96c85086aa30b6b6cb0c5c38ad703166e1"
-            )
-            .unwrap()
-            .to_hex(),
-        )
-    }
-}
+const PREFIX_FOR_OPTION: &str = "opt_";
+const BYTE_ARRAY_PREFIX: &str = "byte_array_";
+const SUPPORTED_TYPES: [(&str, Parser); 17] = [
+    ("bool", parse_bool),
+    ("i32", parse_int::<i32>),
+    ("i64", parse_int::<i64>),
+    ("u8", parse_int::<u8>),
+    ("u32", parse_int::<u32>),
+    ("u64", parse_int::<u64>),
+    ("u128", parse_int::<U128>),
+    ("u256", parse_int::<U256>),
+    ("u512", parse_int::<U512>),
+    ("unit", parse_unit),
+    ("string", parse_string),
+    ("key", parse_key),
+    ("account_hash", parse_account_hash),
+    ("uref", parse_uref),
+    ("public_key", parse_public_key),
+    ("byte_list", parse_byte_list),
+    ("byte_array_<NUM>", parse_byte_array),
+];
 
 #[derive(Debug, PartialEq, Eq)]
 enum OptionalStatus {
@@ -168,7 +45,7 @@ enum OptionalStatus {
     NotOptional,
 }
 
-/// Parses to a given CLValue taking into account whether the arg represents an optional type or
+/// Parses to a given `CLValue` taking into account whether the arg represents an optional type or
 /// not.
 fn parse_cl_value<T, F>(optional_status: OptionalStatus, parse: F) -> Result<CLValue, CliError>
 where
@@ -188,191 +65,648 @@ where
     })
 }
 
-/// Returns a value built from a single arg which has been split into its constituent parts.
-pub fn parts_to_cl_value(cl_type: CLType, value: &str) -> Result<CLValue, CliError> {
-    let (cl_type_to_parse, optional_status, trimmed_value) = match cl_type {
-        CLType::Option(inner_type) => {
-            if value == "null" {
-                (*inner_type, OptionalStatus::None, "")
-            } else {
-                (*inner_type, OptionalStatus::Some, value.trim_matches('\''))
-            }
-        }
-        _ => (
-            cl_type,
-            OptionalStatus::NotOptional,
-            value.trim_matches('\''),
-        ),
+fn parse_bool(
+    _simple_type: &str,
+    optional_status: OptionalStatus,
+    value: &str,
+) -> Result<CLValue, CliError> {
+    let parse = || match value.to_lowercase().as_str() {
+        "true" | "t" => Ok(true),
+        "false" | "f" => Ok(false),
+        invalid => Err(CliError::InvalidCLValue(format!(
+            "can't parse '{}' as a bool (should be 'true' or 'false')",
+            invalid
+        ))),
     };
+    parse_cl_value(optional_status, parse)
+}
+
+fn parse_int<T: CLTyped + ToBytes + Debug + Num>(
+    _simple_type: &str,
+    optional_status: OptionalStatus,
+    value: &str,
+) -> Result<CLValue, CliError> {
+    let parse = || {
+        let bit_width = mem::size_of::<T>() * 8;
+        if value.is_empty() {
+            return Err(CliError::InvalidCLValue(format!(
+                "can't parse '' as u{}",
+                bit_width,
+            )));
+        }
+        T::from_str_radix(value, 10).map_err(|_| {
+            CliError::InvalidCLValue(format!("can't parse '{}' as u{}", value, bit_width,))
+        })
+    };
+    parse_cl_value(optional_status, parse)
+}
+
+fn parse_unit(
+    _simple_type: &str,
+    optional_status: OptionalStatus,
+    value: &str,
+) -> Result<CLValue, CliError> {
+    let parse = || {
+        if !value.is_empty() {
+            return Err(CliError::InvalidCLValue(format!(
+                "can't parse '{}' as unit (should be '')",
+                value
+            )));
+        }
+        Ok(())
+    };
+    parse_cl_value(optional_status, parse)
+}
+
+fn parse_string(
+    _simple_type: &str,
+    optional_status: OptionalStatus,
+    value: &str,
+) -> Result<CLValue, CliError> {
+    let parse = || Ok(value.to_string());
+    parse_cl_value(optional_status, parse)
+}
+
+fn parse_key(
+    _simple_type: &str,
+    optional_status: OptionalStatus,
+    value: &str,
+) -> Result<CLValue, CliError> {
+    let parse = || {
+        Key::from_formatted_str(value).map_err(|error| {
+            CliError::InvalidCLValue(format!("can't parse '{}' as Key: {}", value, error))
+        })
+    };
+    parse_cl_value(optional_status, parse)
+}
+
+fn parse_account_hash(
+    _simple_type: &str,
+    optional_status: OptionalStatus,
+    value: &str,
+) -> Result<CLValue, CliError> {
+    let parse = || {
+        AccountHash::from_formatted_str(value).map_err(|error| {
+            CliError::InvalidCLValue(format!("can't parse '{}' as AccountHash: {}", value, error))
+        })
+    };
+    parse_cl_value(optional_status, parse)
+}
+
+fn parse_uref(
+    _simple_type: &str,
+    optional_status: OptionalStatus,
+    value: &str,
+) -> Result<CLValue, CliError> {
+    let parse = || {
+        URef::from_formatted_str(value).map_err(|error| {
+            CliError::InvalidCLValue(format!("can't parse '{}' as URef: {}", value, error))
+        })
+    };
+    parse_cl_value(optional_status, parse)
+}
+
+fn parse_public_key(
+    _simple_type: &str,
+    optional_status: OptionalStatus,
+    value: &str,
+) -> Result<CLValue, CliError> {
+    let parse = || {
+        let pub_key = PublicKey::from_hex(value).map_err(|error| {
+            CliError::InvalidCLValue(format!("can't parse '{}' as PublicKey: {}", value, error))
+        })?;
+        Ok(pub_key)
+    };
+    parse_cl_value(optional_status, parse)
+}
+
+fn parse_byte_list(
+    _simple_type: &str,
+    optional_status: OptionalStatus,
+    value: &str,
+) -> Result<CLValue, CliError> {
+    let parse = || {
+        base16::decode(value).map(Bytes::from).map_err(|error| {
+            CliError::InvalidCLValue(format!("can't parse '{}' as a byte_list: {}", value, error))
+        })
+    };
+    parse_cl_value(optional_status, parse)
+}
+
+fn parse_byte_array(
+    simple_type: &str,
+    optional_status: OptionalStatus,
+    value: &str,
+) -> Result<CLValue, CliError> {
+    // Safe to unwrap as we already matched on `t.starts_with(BYTE_ARRAY_PREFIX)` to get here.
+    let array_len_str = simple_type
+        .strip_prefix("byte_array_")
+        .expect("should have 'byte_array_' prefix");
+    let array_len = u32::from_str(array_len_str).map_err(|_| {
+        CliError::InvalidCLValue(format!(
+            "can't parse '{}' of '{}' as an integer",
+            array_len_str, simple_type,
+        ))
+    })?;
+
+    let is_some = match optional_status {
+        OptionalStatus::Some => true,
+        OptionalStatus::None => {
+            return Ok(CLValue::from_components(
+                CLType::Option(Box::new(CLType::ByteArray(array_len))),
+                vec![OPTION_NONE_TAG],
+            ))
+        }
+        OptionalStatus::NotOptional => false,
+    };
+
+    let mut bytes = base16::decode(value).map_err(|error| {
+        CliError::InvalidCLValue(format!(
+            "can't parse '{}' as a byte_array: {}",
+            value, error
+        ))
+    })?;
+    if bytes.len() != array_len as usize {
+        return Err(CliError::InvalidCLValue(format!(
+            "provided {} bytes but specified a byte_array of {} bytes",
+            bytes.len(),
+            array_len
+        )));
+    }
+
+    let cl_value = if is_some {
+        let mut all_bytes = vec![OPTION_SOME_TAG];
+        all_bytes.append(&mut bytes);
+        CLValue::from_components(
+            CLType::Option(Box::new(CLType::ByteArray(array_len))),
+            all_bytes,
+        )
+    } else {
+        CLValue::from_components(CLType::ByteArray(array_len), bytes)
+    };
+    Ok(cl_value)
+}
+
+/// Takes the input type and value and returns a tuple containing:
+///   * the simple type (i.e. the type with any "opt_" prefix removed)
+///   * the `OptionalStatus`: if there was an "opt_" prefix, then `None` or `Some` depending on
+///     whether the value is "null" or not, or `NotOptional` if there was no "opt_" prefix
+///   * the value, trimmed of leading and trailing single quotes
+fn get_simple_type_and_optional_status(
+    maybe_opt_type: &str,
+    value: &str,
+) -> Result<(String, OptionalStatus, String), CliError> {
+    let maybe_opt_type = maybe_opt_type.to_lowercase();
+    let (simple_type, optional_status, trimmed_value) =
+        match maybe_opt_type.strip_prefix(PREFIX_FOR_OPTION) {
+            Some(simple_type) => {
+                if value.to_lowercase() == "null" {
+                    (simple_type.to_string(), OptionalStatus::None, String::new())
+                } else {
+                    (
+                        simple_type.to_string(),
+                        OptionalStatus::Some,
+                        value.trim_matches('\'').to_string(),
+                    )
+                }
+            }
+            None => (
+                maybe_opt_type,
+                OptionalStatus::NotOptional,
+                value.trim_matches('\'').to_string(),
+            ),
+        };
 
     if value == trimmed_value {
         return Err(CliError::InvalidCLValue(format!(
             "value in simple arg should be surrounded by single quotes unless it's a null \
-                   optional value (value passed: {})",
+            optional value (value passed: {})",
             value
         )));
     }
 
-    match cl_type_to_parse {
-        CLType::Bool => {
-            let parse = || match trimmed_value.to_lowercase().as_str() {
-                "true" | "t" => Ok(true),
-                "false" | "f" => Ok(false),
-                invalid => Err(CliError::InvalidCLValue(format!(
-                    "can't parse {} as a bool. Should be 'true' or 'false'",
-                    invalid
-                ))),
-            };
-            parse_cl_value(optional_status, parse)
-        }
-        CLType::I32 => {
-            let parse = || {
-                i32::from_str(trimmed_value).map_err(|error| {
-                    CliError::InvalidCLValue(format!("can't parse {} as i32: {}", value, error))
-                })
-            };
-            parse_cl_value(optional_status, parse)
-        }
-        CLType::I64 => {
-            let parse = || {
-                i64::from_str(trimmed_value).map_err(|error| {
-                    CliError::InvalidCLValue(format!(
-                        "can't parse {} as i64: {}",
-                        trimmed_value, error
-                    ))
-                })
-            };
-            parse_cl_value(optional_status, parse)
-        }
-        CLType::U8 => {
-            let parse = || {
-                u8::from_str(trimmed_value).map_err(|error| {
-                    CliError::InvalidCLValue(format!(
-                        "can't parse {} as u8: {}",
-                        trimmed_value, error
-                    ))
-                })
-            };
-            parse_cl_value(optional_status, parse)
-        }
-        CLType::U32 => {
-            let parse = || {
-                u32::from_str(trimmed_value).map_err(|error| {
-                    CliError::InvalidCLValue(format!(
-                        "can't parse {} as u32: {}",
-                        trimmed_value, error
-                    ))
-                })
-            };
-            parse_cl_value(optional_status, parse)
-        }
-        CLType::U64 => {
-            let parse = || {
-                u64::from_str(trimmed_value).map_err(|error| {
-                    CliError::InvalidCLValue(format!(
-                        "can't parse {} as u64: {}",
-                        trimmed_value, error
-                    ))
-                })
-            };
-            parse_cl_value(optional_status, parse)
-        }
-        CLType::U128 => {
-            let parse = || {
-                U128::from_dec_str(trimmed_value).map_err(|error| {
-                    CliError::InvalidCLValue(format!(
-                        "can't parse {} as U128: {}",
-                        trimmed_value, error
-                    ))
-                })
-            };
-            parse_cl_value(optional_status, parse)
-        }
-        CLType::U256 => {
-            let parse = || {
-                U256::from_dec_str(trimmed_value).map_err(|error| {
-                    CliError::InvalidCLValue(format!(
-                        "can't parse {} as U256: {}",
-                        trimmed_value, error
-                    ))
-                })
-            };
-            parse_cl_value(optional_status, parse)
-        }
-        CLType::U512 => {
-            let parse = || {
-                U512::from_dec_str(trimmed_value).map_err(|error| {
-                    CliError::InvalidCLValue(format!(
-                        "can't parse {} as U512: {}",
-                        trimmed_value, error
-                    ))
-                })
-            };
-            parse_cl_value(optional_status, parse)
-        }
-        CLType::Unit => {
-            let parse = || {
-                if !trimmed_value.is_empty() {
-                    return Err(CliError::InvalidCLValue(format!(
-                        "can't parse {} as unit. Should be ''",
-                        trimmed_value
-                    )));
+    Ok((simple_type, optional_status, trimmed_value))
+}
+
+/// Returns a value built from a single arg which has been split into its constituent parts.
+fn parts_to_cl_value(
+    simple_type: &str,
+    optional_status: OptionalStatus,
+    trimmed_value: &str,
+) -> Result<CLValue, CliError> {
+    let parser = match simple_type {
+        t if t == SUPPORTED_TYPES[0].0 => SUPPORTED_TYPES[0].1,
+        t if t == SUPPORTED_TYPES[1].0 => SUPPORTED_TYPES[1].1,
+        t if t == SUPPORTED_TYPES[2].0 => SUPPORTED_TYPES[2].1,
+        t if t == SUPPORTED_TYPES[3].0 => SUPPORTED_TYPES[3].1,
+        t if t == SUPPORTED_TYPES[4].0 => SUPPORTED_TYPES[4].1,
+        t if t == SUPPORTED_TYPES[5].0 => SUPPORTED_TYPES[5].1,
+        t if t == SUPPORTED_TYPES[6].0 => SUPPORTED_TYPES[6].1,
+        t if t == SUPPORTED_TYPES[7].0 => SUPPORTED_TYPES[7].1,
+        t if t == SUPPORTED_TYPES[8].0 => SUPPORTED_TYPES[8].1,
+        t if t == SUPPORTED_TYPES[9].0 => SUPPORTED_TYPES[9].1,
+        t if t == SUPPORTED_TYPES[10].0 => SUPPORTED_TYPES[10].1,
+        t if t == SUPPORTED_TYPES[11].0 => SUPPORTED_TYPES[11].1,
+        t if t == SUPPORTED_TYPES[12].0 => SUPPORTED_TYPES[12].1,
+        t if t == SUPPORTED_TYPES[13].0 => SUPPORTED_TYPES[13].1,
+        t if t == SUPPORTED_TYPES[14].0 => SUPPORTED_TYPES[14].1,
+        t if t == SUPPORTED_TYPES[15].0 => SUPPORTED_TYPES[15].1,
+        t if t.starts_with(BYTE_ARRAY_PREFIX) => SUPPORTED_TYPES[16].1,
+        _ => {
+            let original_type = match optional_status {
+                OptionalStatus::Some | OptionalStatus::None => {
+                    PREFIX_FOR_OPTION.to_string() + simple_type
                 }
-                Ok(())
+                OptionalStatus::NotOptional => simple_type.to_string(),
             };
-            parse_cl_value(optional_status, parse)
+            return Err(CliError::InvalidCLValue(format!(
+                "unknown variant {}, expected one of {}",
+                original_type,
+                help::supported_cl_type_list()
+            )));
         }
-        CLType::String => {
-            let parse = || Ok(trimmed_value.to_string());
-            parse_cl_value(optional_status, parse)
+    };
+    parser(simple_type, optional_status, trimmed_value)
+}
+
+/// Splits a single arg of the form `NAME:TYPE='VALUE'` into its constituent parts.
+fn split_arg(arg: &str) -> Result<(&str, &str, &str), CliError> {
+    const ARG_VALUE_NAME: &str = r#""NAME:TYPE='VALUE'" OR "NAME:TYPE=null""#;
+
+    let parts: Vec<_> = arg.splitn(3, &[':', '='][..]).collect();
+    if parts.len() != 3 {
+        return Err(CliError::InvalidCLValue(format!(
+            "arg {} should be formatted as {}",
+            arg, ARG_VALUE_NAME
+        )));
+    }
+    Ok((parts[0], parts[1], parts[2]))
+}
+
+/// Insert a value built from a single arg into `runtime_args`.
+pub(super) fn insert_arg(arg: &str, runtime_args: &mut RuntimeArgs) -> Result<(), CliError> {
+    let (name, initial_type, value) = split_arg(arg)?;
+    let (simple_type, optional_status, trimmed_value) =
+        get_simple_type_and_optional_status(initial_type, value)?;
+    let cl_value = parts_to_cl_value(&simple_type, optional_status, &trimmed_value)?;
+    runtime_args.insert_cl_value(name, cl_value);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use casper_types::{
+        account::AccountHash, bytesrepr::ToBytes, AccessRights, CLTyped, CLValue, NamedArg,
+        PublicKey, RuntimeArgs, URef, U128, U256, U512,
+    };
+
+    use super::*;
+
+    fn check_insert_valid_arg<T: CLTyped + ToBytes>(cli_string: &str, expected: T) {
+        let expected = RuntimeArgs::from(vec![NamedArg::new(
+            "x".to_string(),
+            CLValue::from_t(expected).unwrap(),
+        )]);
+
+        let mut actual = RuntimeArgs::new();
+        insert_arg(cli_string, &mut actual).expect("should parse");
+        assert_eq!(actual, expected);
+    }
+
+    fn check_insert_invalid_arg(cli_string: &str) {
+        let mut runtime_args = RuntimeArgs::new();
+        let result = insert_arg(cli_string, &mut runtime_args);
+        assert!(result.is_err(), "{} should be an error", cli_string);
+    }
+
+    #[test]
+    fn should_insert_valid_bool_arg() {
+        check_insert_valid_arg("x:bool='f'", false);
+        check_insert_valid_arg("x:bool='F'", false);
+        check_insert_valid_arg("x:bool='false'", false);
+        check_insert_valid_arg("x:Bool='False'", false);
+        check_insert_valid_arg("x:BOOL='False'", false);
+        check_insert_valid_arg("x:bool='t'", true);
+        check_insert_valid_arg("x:bool='T'", true);
+        check_insert_valid_arg("x:bool='true'", true);
+        check_insert_valid_arg("x:Bool='True'", true);
+        check_insert_valid_arg("x:BOOL='TRUE'", true);
+        check_insert_valid_arg("x:opt_bool='f'", Some(false));
+        check_insert_valid_arg("x:Opt_Bool='t'", Some(true));
+        check_insert_valid_arg::<Option<bool>>("x:OPT_BOOL=null", None);
+    }
+
+    #[test]
+    fn should_fail_to_insert_invalid_bool_arg() {
+        check_insert_invalid_arg("x:bool='fa'");
+        check_insert_invalid_arg("x:opt_bool=''");
+    }
+
+    #[test]
+    fn should_insert_valid_i32_arg() {
+        check_insert_valid_arg("x:i32='2147483647'", i32::max_value());
+        check_insert_valid_arg("x:I32='0'", 0_i32);
+        check_insert_valid_arg("x:i32='-2147483648'", i32::min_value());
+        check_insert_valid_arg("x:opt_i32='-1'", Some(-1_i32));
+        check_insert_valid_arg::<Option<i32>>("x:OPT_I32=Null", None);
+    }
+
+    #[test]
+    fn should_fail_to_insert_invalid_i32_arg() {
+        check_insert_invalid_arg("x:i32='f'");
+        check_insert_invalid_arg("x:opt_i32=''");
+    }
+
+    #[test]
+    fn should_insert_valid_i64_arg() {
+        check_insert_valid_arg("x:i64='9223372036854775807'", i64::max_value());
+        check_insert_valid_arg("x:I64='0'", 0_i64);
+        check_insert_valid_arg("x:i64='-9223372036854775808'", i64::min_value());
+        check_insert_valid_arg("x:opt_i64='-1'", Some(-1_i64));
+        check_insert_valid_arg::<Option<i64>>("x:OPT_I64=NULL", None);
+    }
+
+    #[test]
+    fn should_fail_to_insert_invalid_i64_arg() {
+        check_insert_invalid_arg("x:i64='f'");
+        check_insert_invalid_arg("x:opt_i64=''");
+    }
+
+    #[test]
+    fn should_insert_valid_u8_arg() {
+        check_insert_valid_arg("x:u8='0'", 0_u8);
+        check_insert_valid_arg("x:U8='255'", u8::max_value());
+        check_insert_valid_arg("x:opt_u8='1'", Some(1_u8));
+        check_insert_valid_arg::<Option<u8>>("x:OPT_U8=null", None);
+    }
+
+    #[test]
+    fn should_fail_to_insert_invalid_u8_arg() {
+        check_insert_invalid_arg("x:u8='f'");
+        check_insert_invalid_arg("x:opt_u8=''");
+    }
+
+    #[test]
+    fn should_insert_valid_u32_arg() {
+        check_insert_valid_arg("x:u32='0'", 0_u32);
+        check_insert_valid_arg("x:U32='4294967295'", u32::max_value());
+        check_insert_valid_arg("x:opt_u32='1'", Some(1_u32));
+        check_insert_valid_arg::<Option<u32>>("x:OPT_U32=null", None);
+    }
+
+    #[test]
+    fn should_fail_to_insert_invalid_u32_arg() {
+        check_insert_invalid_arg("x:u32='f'");
+        check_insert_invalid_arg("x:opt_u32=''");
+    }
+
+    #[test]
+    fn should_insert_valid_u64_arg() {
+        check_insert_valid_arg("x:u64='0'", 0_u64);
+        check_insert_valid_arg("x:U64='18446744073709551615'", u64::max_value());
+        check_insert_valid_arg("x:opt_u64='1'", Some(1_u64));
+        check_insert_valid_arg::<Option<u64>>("x:OPT_U64=null", None);
+    }
+
+    #[test]
+    fn should_fail_to_insert_invalid_u64_arg() {
+        check_insert_invalid_arg("x:u64='f'");
+        check_insert_invalid_arg("x:opt_u64=''");
+    }
+
+    #[test]
+    fn should_insert_valid_u128_arg() {
+        check_insert_valid_arg("x:u128='0'", U128::zero());
+        check_insert_valid_arg(
+            "x:U128='340282366920938463463374607431768211455'",
+            U128::max_value(),
+        );
+        check_insert_valid_arg("x:opt_u128='1'", Some(U128::from(1)));
+        check_insert_valid_arg::<Option<U128>>("x:OPT_U128=null", None);
+    }
+
+    #[test]
+    fn should_fail_to_insert_invalid_u128_arg() {
+        check_insert_invalid_arg("x:u128='f'");
+        check_insert_invalid_arg("x:opt_u128=''");
+    }
+
+    #[test]
+    fn should_insert_valid_u256_arg() {
+        check_insert_valid_arg("x:u256='0'", U256::zero());
+        check_insert_valid_arg(
+            "x:U256='115792089237316195423570985008687907853269984665640564039457584007913129639935'",
+            U256::max_value(),
+        );
+        check_insert_valid_arg("x:opt_u256='1'", Some(U256::from(1)));
+        check_insert_valid_arg::<Option<U256>>("x:OPT_U256=null", None);
+    }
+
+    #[test]
+    fn should_fail_to_insert_invalid_u256_arg() {
+        check_insert_invalid_arg("x:u256='f'");
+        check_insert_invalid_arg("x:opt_u256=''");
+    }
+
+    #[test]
+    fn should_insert_valid_u512_arg() {
+        check_insert_valid_arg("x:u512='0'", U512::zero());
+        check_insert_valid_arg(
+            "x:U512='134078079299425970995740249982058461274793658205923933777235614437217640300735\
+            46976801874298166903427690031858186486050853753882811946569946433649006084095'",
+            U512::max_value(),
+        );
+        check_insert_valid_arg("x:opt_u512='1'", Some(U512::from(1)));
+        check_insert_valid_arg::<Option<U512>>("x:OPT_U512=null", None);
+    }
+
+    #[test]
+    fn should_fail_to_insert_invalid_u512_arg() {
+        check_insert_invalid_arg("x:u512='f'");
+        check_insert_invalid_arg("x:opt_u512=''");
+    }
+
+    #[test]
+    fn should_insert_valid_unit_arg() {
+        check_insert_valid_arg("x:unit=''", ());
+        check_insert_valid_arg("x:opt_unit=''", Some(()));
+        check_insert_valid_arg::<Option<()>>("x:OPT_UNIT=null", None);
+    }
+
+    #[test]
+    fn should_fail_to_insert_invalid_unit_arg() {
+        check_insert_invalid_arg("x:unit='f'");
+        check_insert_invalid_arg("x:opt_unit='1'");
+    }
+
+    #[test]
+    fn should_insert_valid_string_arg() {
+        let value = String::from("test \"string");
+        check_insert_valid_arg(&format!("x:string='{}'", value), value.clone());
+        check_insert_valid_arg(&format!("x:opt_string='{}'", value), Some(value));
+        check_insert_valid_arg::<Option<String>>("x:OPT_STRING=null", None);
+    }
+
+    #[test]
+    fn should_insert_valid_key_arg() {
+        let bytes = (1..33).collect::<Vec<_>>();
+        let array = <[u8; 32]>::try_from(bytes.as_ref()).unwrap();
+
+        let key_account = Key::Account(AccountHash::new(array));
+        let key_hash = Key::Hash(array);
+        let key_uref = Key::URef(URef::new(array, AccessRights::NONE));
+
+        for key in &[key_account, key_hash, key_uref] {
+            check_insert_valid_arg(&format!("x:key='{}'", key.to_formatted_string()), *key);
+            check_insert_valid_arg(
+                &format!("x:opt_key='{}'", key.to_formatted_string()),
+                Some(*key),
+            );
+            check_insert_valid_arg::<Option<Key>>("x:OPT_KEY=null", None);
         }
-        CLType::Key => {
-            let parse = || {
-                Key::from_formatted_str(trimmed_value).map_err(|error| {
-                    CliError::InvalidCLValue(format!(
-                        "can't parse {} as Key: {}",
-                        trimmed_value, error
-                    ))
-                })
-            };
-            parse_cl_value(optional_status, parse)
-        }
-        CLType::ByteArray(32) => {
-            let parse = || {
-                AccountHash::from_formatted_str(trimmed_value).map_err(|error| {
-                    CliError::InvalidCLValue(format!(
-                        "can't parse {} as AccountHash: {:?}.\
-                        AccountHash type values should start with 'account-hash-' prefix.",
-                        trimmed_value, error
-                    ))
-                })
-            };
-            parse_cl_value(optional_status, parse)
-        }
-        CLType::URef => {
-            let parse = || {
-                URef::from_formatted_str(trimmed_value).map_err(|error| {
-                    CliError::InvalidCLValue(format!(
-                        "can't parse {} as URef: {:?}. \
-                        URef type values should start with 'uref-' prefix.",
-                        trimmed_value, error
-                    ))
-                })
-            };
-            parse_cl_value(optional_status, parse)
-        }
-        CLType::PublicKey => {
-            let parse = || {
-                let pub_key = PublicKey::from_hex(trimmed_value).map_err(|error| {
-                    CliError::InvalidCLValue(format!(
-                        "can't parse {} as PublicKey: {:?}",
-                        trimmed_value, error
-                    ))
-                })?;
-                Ok(pub_key)
-            };
-            parse_cl_value(optional_status, parse)
-        }
-        _ => unreachable!(),
+    }
+
+    #[test]
+    fn should_fail_to_insert_invalid_key_arg() {
+        check_insert_invalid_arg("x:key='f'");
+        check_insert_invalid_arg("x:opt_key=''");
+    }
+
+    #[test]
+    fn should_insert_valid_account_hash_arg() {
+        let bytes = (1..33).collect::<Vec<_>>();
+        let array = <[u8; 32]>::try_from(bytes.as_ref()).unwrap();
+        let value = AccountHash::new(array);
+        check_insert_valid_arg(
+            &format!("x:account_hash='{}'", value.to_formatted_string()),
+            value,
+        );
+        check_insert_valid_arg(
+            &format!("x:opt_account_hash='{}'", value.to_formatted_string()),
+            Some(value),
+        );
+        check_insert_valid_arg::<Option<AccountHash>>("x:OPT_ACCOUNT_HASH=null", None);
+    }
+
+    #[test]
+    fn should_fail_to_insert_invalid_account_hash_arg() {
+        check_insert_invalid_arg("x:account_hash='f'");
+        check_insert_invalid_arg("x:account_hash='account-hash-f'");
+        check_insert_invalid_arg("x:opt_account_hash=''");
+    }
+
+    #[test]
+    fn should_insert_valid_uref_arg() {
+        let bytes = (1..33).collect::<Vec<_>>();
+        let array = <[u8; 32]>::try_from(bytes.as_ref()).unwrap();
+        let value = URef::new(array, AccessRights::READ_ADD_WRITE);
+        check_insert_valid_arg(&format!("x:uref='{}'", value.to_formatted_string()), value);
+        check_insert_valid_arg(
+            &format!("x:opt_uref='{}'", value.to_formatted_string()),
+            Some(value),
+        );
+        check_insert_valid_arg::<Option<URef>>("x:OPT_UREF=null", None);
+    }
+
+    #[test]
+    fn should_fail_to_insert_invalid_uref_arg() {
+        check_insert_invalid_arg("x:uref='f'");
+        check_insert_invalid_arg("x:uref='uref-f'");
+        check_insert_invalid_arg("x:opt_uref=''");
+    }
+
+    #[test]
+    fn should_insert_valid_public_key_arg() {
+        let hex_value = "0119bf44096984cdfe8541bac167dc3b96c85086aa30b6b6cb0c5c38ad703166e1";
+        let value = PublicKey::from_hex(hex_value).unwrap();
+        check_insert_valid_arg(&format!("x:public_key='{}'", hex_value), value.clone());
+        check_insert_valid_arg(&format!("x:opt_public_key='{}'", hex_value), Some(value));
+        check_insert_valid_arg::<Option<PublicKey>>("x:OPT_PUBLIC_KEY=null", None);
+    }
+
+    #[test]
+    fn should_fail_to_insert_invalid_public_key_arg() {
+        check_insert_invalid_arg("x:public_key='f'");
+        check_insert_invalid_arg("x:opt_public_key=''");
+    }
+
+    #[test]
+    fn should_insert_valid_byte_list_arg() {
+        check_insert_valid_arg("x:byte_list=''", Bytes::new());
+        check_insert_valid_arg("x:opt_byte_list=''", Some(Bytes::new()));
+        check_insert_valid_arg::<Option<Bytes>>("x:opt_byte_list=null", None);
+
+        let value = Bytes::from(vec![0_u8, 1, 2, 3, 4, 5]);
+        let hex_value = base16::encode_upper(&value);
+
+        check_insert_valid_arg(&format!("x:Byte_List='{}'", hex_value), value.clone());
+        check_insert_valid_arg(&format!("x:opt_byte_list='{}'", hex_value), Some(value));
+        check_insert_valid_arg::<Option<Bytes>>("x:OPT_BYTE_LIST=null", None);
+    }
+
+    #[test]
+    fn should_fail_to_insert_invalid_byte_list_arg() {
+        check_insert_invalid_arg("x:byte_list='fz'");
+    }
+
+    #[test]
+    fn should_insert_valid_byte_array_arg() {
+        check_insert_valid_arg("x:byte_array_0=''", []);
+        check_insert_valid_arg("x:opt_byte_array_0=''", Some([]));
+        check_insert_valid_arg::<Option<[u8; 0]>>("x:opt_byte_array_0=null", None);
+
+        let value = [0_u8, 1, 2, 3, 4, 5];
+        let hex_value = base16::encode_upper(&value);
+
+        check_insert_valid_arg(&format!("x:Byte_Array_6='{}'", hex_value), value);
+        check_insert_valid_arg(&format!("x:opt_byte_array_6='{}'", hex_value), Some(value));
+        check_insert_valid_arg::<Option<[u8; 6]>>("x:OPT_BYTE_ARRAY_6=null", None);
+    }
+
+    #[test]
+    fn should_fail_to_insert_invalid_byte_array_arg() {
+        check_insert_invalid_arg("x:byte_array_1='fz'");
+        check_insert_invalid_arg("x:byte_array_1=''");
+        check_insert_invalid_arg("x:byte_array_1='0102'");
+    }
+
+    #[test]
+    fn should_fail_to_insert_malformed_args() {
+        const ARG_BAD_TYPE: &str = "name:wat='false'";
+        const ARG_GIBBERISH: &str = "asdf|1234(..)";
+        const ARG_UNQUOTED: &str = "name:u32=0"; // value needs single quotes to be valid
+        const EMPTY: &str = "";
+        const LARGE_2K_INPUT: &str = r#"
+eJy2irIizK6zT0XOklyBAY1KVUsAbyF6eJUYBmRPHqX2rONbaEieJt4Ci1eZYjBdHdEq46oMBH0LeiQO8RIJb95
+SJGEp83RxakDj7trunJVvMbj2KZFnpJOyEauFa35dlaVG9Ki7hjFy4BLlDyA0Wgwk20RXFkbgKQIQVvR16RPffR
+WO86WqZ3gMuOh447svZRYfhbRF3NVBaWRz7SJ9Zm3w8djisvS0Y3GSnpzKnSEQirApqomfQTHTrU9ww2SMgdGuu
+EllGLsj3ze8WzIbXLlJvXdnJFz7UfsgX4xowG4d6xSiUVWCY4sVItNXlqs8adfZZHH7AjqLjlRRvWwjNCiWsiqx
+ICe9jlkdEVeRAO0BqF6FhjSxPt9X3y6WXAomB0YTIFQGyto4jMBOhWb96ny3DG3WISUSdaKWf8KaRuAQD4ao3ML
+jJZSXkTlovZTYQmYlkYo4s3635YLthuh0hSorRs0ju7ffeY3tu7VRvttgvbBLVjFJjYrwW1YAEOaxDdLnhiTIQn
+H0zRLWnCQ4Czk5BWsRLDdupJbKRWRZcQ7pehSgfc5qtXpJRFVtL2L82hxfBdiXqzXl3KdQ21CnGxTzcgEv0ptrs
+XGJwNgd04YiZzHrZL7iF3xFann6DJVyEZ0eEifTfY8rtxPCMDutjr68iFjnjy40c7SfhvsZLODuEjS4VQkIwfJc
+QP5fH3cQ2K4A4whpzTVc3yqig468Cjbxfobw4Z7YquZnuFw1TXSrM35ZBXpI4WKo9QLxmE2HkgMI1Uac2dWyG0U
+iCAxpHxC4uTIFEq2MUuGd7ZgYs8zoYpODvtAcZ8nUqKssdugQUGfXw9Cs1pcDZgEppYVVw1nYoHXKCjK3oItexs
+uIaZ0m1o91L9Js5lhaDybyDoye9zPFOnEIwKdcH0dO9cZmv6UyvVZS2oVKJm7nHQAJDARjVfC7GYAT2AQhFZxIQ
+DP9jjHCqxMJz6p499G5lk8cYAhnlUm7GCr4AwvjsEU7sEsJcZLDCLG6FaFMdLHJS5v2yPYzpuWebjcNCXbk4yER
+F9NsvlDBrLhoDt1GDgJPlRF8B5h5BSzPHsCjNVa9h2YWx1GVl6Yrrk04FSMSj0nRO8OoxkyU0ugtBQlUv3rQ833
+Vcs7jCGetaazcvaI45dRDGe6LyEPwojlC4IaB8PtljKo2zn0u91lQGJY7rj1qLUtFBRDCKERs7W1j9A2eGJ3ORY
+Db7Q3K7BY9XbANGoYiwtLoytopYCQs5RYHepkoQ19f1E9IcqCFQg9h0rWK494xb88GfSGKBpPHddrQYXFrr715u
+NkAj885V8Mnam5kSzsOmrg504QhPSOaqpkY36xyXUP13yWK4fEf39tJ2PN2DlAsxFAWJUec4CiS47rgrU87oESt
+KZJni3Jhccczlq1CaRKaYYV38joEzPL0UNKr5RiCodTWJmdN07JI5txtQqgc8kvHOrxgOASPQOPSbAUz33vZx3b
+eNsTYUD0Dxa4IkMUNHSy6mpaSOElO7wgUvWJEajnVWZJ5gWehyE4yqo6PkL3VBj51Jg2uozPa8xnbSfymlVVLFl
+EIfMyPwUj1J9ngQw0J3bn33IIOB3bkNfB50f1MkKkhyn1TMZJcnZ7IS16PXBH6DD7Sht1PVKhER2E3QS7z8YQ6B
+q27ktZZ33IcCnayahxHnyf2Wzab9ic5eSJLzsVi0VWP7DePt2GnCbz5D2tcAxgVVFmdIsEakytjmeEGyMu9k2R7
+Q8d1wPtqKgayVtgdIaMbvsnXMkRqITkf3o8Qh495pm1wkKArTGFGODXc1cCKheFUEtJWdK92DHH7OuRENHAb5KS
+PKzSUg2k18wyf9XCy1pQKv31wii3rWrWMCbxOWmhuzw1N9tqO8U97NsThRSoPAjpd05G2roia4m4CaPWTAUmVky
+RfiWoA7bglAh4Aoz2LN2ezFleTNJjjLw3n9bYPg5BdRL8n8wimhXDo9SW46A5YS62C08ZOVtvfn82YRaYkuKKz7
+3NJ25PnQG6diMm4Lm3wi22yR7lY7oYYJjLNcaLYOI6HOvaJ
+"#;
+
+        check_insert_invalid_arg(ARG_BAD_TYPE);
+        check_insert_invalid_arg(ARG_GIBBERISH);
+        check_insert_invalid_arg(ARG_UNQUOTED);
+        check_insert_invalid_arg(EMPTY);
+        check_insert_invalid_arg(LARGE_2K_INPUT);
     }
 }

--- a/lib/cli/simple_args/help.rs
+++ b/lib/cli/simple_args/help.rs
@@ -1,0 +1,78 @@
+//! Functions for use in help commands.
+
+use std::convert::TryFrom;
+
+use itertools::Itertools;
+
+use casper_types::{account::AccountHash, AccessRights, AsymmetricType, Key, PublicKey, URef};
+
+use super::{PREFIX_FOR_OPTION, SUPPORTED_TYPES};
+
+/// Returns a list of `CLType`s able to be passed as a string for use as payment code or session
+/// code args.
+pub fn supported_cl_type_list() -> String {
+    format!(
+        "{}, {}",
+        SUPPORTED_TYPES
+            .iter()
+            .map(|(simple_type, _parser)| simple_type)
+            .join(", "),
+        SUPPORTED_TYPES
+            .iter()
+            .map(|(simple_type, _parser)| PREFIX_FOR_OPTION.to_string() + simple_type)
+            .join(", ")
+    )
+}
+
+/// Returns a string listing examples of the format required when passing in payment code or
+/// session code args.
+pub fn supported_cl_type_examples() -> String {
+    let bytes = (1..33).collect::<Vec<_>>();
+    let array = <[u8; 32]>::try_from(bytes.as_ref()).unwrap();
+
+    format!(
+        r#""name_01:bool='false'"
+"name_02:i32='-1'"
+"name_03:i64='-2'"
+"name_04:u8='3'"
+"name_05:u32='4'"
+"name_06:u64='5'"
+"name_07:u128='6'"
+"name_08:u256='7'"
+"name_09:u512='8'"
+"name_10:unit=''"
+"name_11:string='a value'"
+"key_account_name:key='{}'"
+"key_hash_name:key='{}'"
+"key_uref_name:key='{}'"
+"account_hash_name:account_hash='{}'"
+"uref_name:uref='{}'"
+"public_key_name:public_key='{}'"
+"byte_list_name:byte_list='010203'"            # variable-length list of bytes, i.e. CLType::List(CLType::U8)
+"byte_array_5_name:byte_array_5='0102030405'"  # fixed-length array of bytes, in this example CLType::ByteArray(5)
+"byte_array_32_name:byte_array_32='{}'"
+
+Optional values of all of these types can also be specified.
+Prefix the type with "opt_" and use the term "null" without quotes to specify a None value:
+"name_01:opt_bool='true'"       # Some(true)
+"name_02:opt_bool='false'"      # Some(false)
+"name_03:opt_bool=null"         # None
+"name_04:opt_i32='-1'"          # Some(-1)
+"name_05:opt_i32=null"          # None
+"name_06:opt_unit=''"           # Some(())
+"name_07:opt_unit=null"         # None
+"name_08:opt_string='a value'"  # Some("a value".to_string())
+"name_09:opt_string='null'"     # Some("null".to_string())
+"name_10:opt_string=null"       # None
+"#,
+        Key::Account(AccountHash::new(array)).to_formatted_string(),
+        Key::Hash(array).to_formatted_string(),
+        Key::URef(URef::new(array, AccessRights::NONE)).to_formatted_string(),
+        AccountHash::new(array).to_formatted_string(),
+        URef::new(array, AccessRights::READ_ADD_WRITE).to_formatted_string(),
+        PublicKey::from_hex("0119bf44096984cdfe8541bac167dc3b96c85086aa30b6b6cb0c5c38ad703166e1")
+            .unwrap()
+            .to_hex(),
+        base16::encode_lower(&bytes),
+    )
+}

--- a/lib/rpcs/v1_4_5/list_rpcs.rs
+++ b/lib/rpcs/v1_4_5/list_rpcs.rs
@@ -69,7 +69,7 @@ pub struct ResponseResult {
 }
 
 /// An example request parameter.
-#[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 pub struct ExampleParam {
     /// Canonical name of the example parameter.
     pub name: String,
@@ -78,7 +78,7 @@ pub struct ExampleParam {
 }
 
 /// An example result.
-#[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 pub struct ExampleResult {
     /// Canonical name of the example result.
     pub name: String,
@@ -87,7 +87,7 @@ pub struct ExampleResult {
 }
 
 /// An example pair of request parameters and response result.
-#[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 pub struct Example {
     /// Name for the example pairing.
     pub name: String,

--- a/src/account_address.rs
+++ b/src/account_address.rs
@@ -23,7 +23,7 @@ impl ClientCommand for AccountAddress {
     const NAME: &'static str = "account-address";
     const ABOUT: &'static str = "Generate an account hash from a given public key";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)

--- a/src/block/get.rs
+++ b/src/block/get.rs
@@ -22,7 +22,7 @@ impl ClientCommand for GetBlock {
     const NAME: &'static str = "get-block";
     const ABOUT: &'static str = "Retrieve a block from the network";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)

--- a/src/block/transfers.rs
+++ b/src/block/transfers.rs
@@ -22,7 +22,7 @@ impl ClientCommand for GetBlockTransfers {
     const NAME: &'static str = "get-block-transfers";
     const ABOUT: &'static str = "Retrieve all transfers for a block from the network";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)

--- a/src/command.rs
+++ b/src/command.rs
@@ -24,7 +24,7 @@ pub trait ClientCommand {
     const NAME: &'static str;
     const ABOUT: &'static str;
     /// Constructs the clap subcommand.
-    fn build(display_order: usize) -> Command<'static>;
+    fn build(display_order: usize) -> Command;
 
     /// Parses the arg matches and runs the subcommand.
     async fn run(matches: &ArgMatches) -> Result<Success, CliError>;

--- a/src/common.rs
+++ b/src/common.rs
@@ -20,7 +20,7 @@ pub mod verbose {
         "Generates verbose output, e.g. prints the RPC request.  If repeated by using '-vv' then \
         all output will be extra verbose, meaning that large JSON strings will be shown in full";
 
-    pub fn arg(order: usize) -> Arg<'static> {
+    pub fn arg(order: usize) -> Arg {
         Arg::new(ARG_NAME)
             .short(ARG_NAME_SHORT)
             .required(false)
@@ -47,7 +47,7 @@ pub mod node_address {
     const ARG_DEFAULT: &str = "http://localhost:7777";
     const ARG_HELP: &str = "Hostname or IP and port of node on which HTTP service is running";
 
-    pub fn arg(order: usize) -> Arg<'static> {
+    pub fn arg(order: usize) -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -76,7 +76,7 @@ pub mod rpc_id {
         "JSON-RPC identifier, applied to the request and returned in the response. If not \
         provided, a random integer will be assigned";
 
-    pub fn arg(order: usize) -> Arg<'static> {
+    pub fn arg(order: usize) -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .required(false)
@@ -102,7 +102,7 @@ pub mod secret_key {
     const ARG_VALUE_NAME: &str = super::ARG_PATH;
     const ARG_HELP: &str = "Path to secret key file";
 
-    pub fn arg(order: usize) -> Arg<'static> {
+    pub fn arg(order: usize) -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -132,7 +132,7 @@ pub mod force {
         "If this flag is passed, any existing output files will be overwritten. Without this flag, \
         if any output file exists, no output files will be generated and the command will fail";
 
-    pub fn arg(order: usize, singular: bool) -> Arg<'static> {
+    pub fn arg(order: usize, singular: bool) -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -163,7 +163,7 @@ pub mod state_root_hash {
     const ARG_VALUE_NAME: &str = super::ARG_HEX_STRING;
     const ARG_HELP: &str = "Hex-encoded hash of the state root";
 
-    pub(crate) fn arg(order: usize, is_required: bool) -> Arg<'static> {
+    pub(crate) fn arg(order: usize, is_required: bool) -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -190,7 +190,7 @@ pub mod block_identifier {
         "Hex-encoded block hash or height of the block. If not given, the last block added to the \
         chain as known at the given node will be used";
 
-    pub(crate) fn arg(order: usize, extra_help_string: bool) -> Arg<'static> {
+    pub(crate) fn arg(order: usize, extra_help_string: bool) -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -228,7 +228,7 @@ pub(super) mod public_key {
         should be one of the two public key files generated via the `keygen` subcommand; \
         \"public_key_hex\" or \"public_key.pem\"";
 
-    pub fn arg(order: usize, is_required: bool) -> Arg<'static> {
+    pub fn arg(order: usize, is_required: bool) -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -298,7 +298,7 @@ pub(super) mod purse_identifier {
         be formatted as \"account-hash-<HEX STRING>\", or for a URef as \
         \"uref-<HEX STRING>-<THREE DIGIT INTEGER>\"";
 
-    pub fn arg(order: usize, is_required: bool) -> Arg<'static> {
+    pub fn arg(order: usize, is_required: bool) -> Arg {
         Arg::new(ARG_NAME)
             .alias(PURSE_IDENTIFIER_ALIAS)
             .long(ARG_NAME)
@@ -329,7 +329,7 @@ pub(super) mod purse_uref {
         "The URef under which the purse is stored. This must be a properly formatted URef \
         \"uref-<HEX STRING>-<THREE DIGIT INTEGER>\"";
 
-    pub fn arg(display_order: usize, is_required: bool) -> Arg<'static> {
+    pub fn arg(display_order: usize, is_required: bool) -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -358,7 +358,7 @@ pub(super) mod session_account {
         argument. The file should be one of the two public key files generated via the `keygen`
         subcommand; \"public_key_hex\" or \"public_key.pem\"";
 
-    pub fn arg(order: usize) -> Arg<'static> {
+    pub fn arg(order: usize) -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .required(false)

--- a/src/deploy/creation_common.rs
+++ b/src/deploy/creation_common.rs
@@ -62,7 +62,7 @@ pub(super) mod show_simple_arg_examples {
         "If passed, all other options are ignored and a set of examples of session-/payment-args \
         is printed";
 
-    pub(in crate::deploy) fn arg() -> Arg<'static> {
+    pub(in crate::deploy) fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .alias(ARG_ALIAS)
             .long(ARG_NAME)
@@ -93,7 +93,7 @@ pub(super) mod show_json_args_examples {
     const ARG_HELP: &str = "If passed, all other options are ignored and a set of examples of \
         session-/payment-args-json is printed";
 
-    pub(in crate::deploy) fn arg() -> Arg<'static> {
+    pub(in crate::deploy) fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -247,7 +247,7 @@ pub(super) mod timestamp {
         https://docs.rs/humantime/latest/humantime/fn.parse_rfc3339_weak.html for more \
         information.";
 
-    pub(in crate::deploy) fn arg() -> Arg<'static> {
+    pub(in crate::deploy) fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .required(false)
@@ -277,7 +277,7 @@ pub(super) mod ttl {
         '1day'. For all options, see \
         https://docs.rs/humantime/latest/humantime/fn.parse_duration.html";
 
-    pub(in crate::deploy) fn arg() -> Arg<'static> {
+    pub(in crate::deploy) fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .required(false)
@@ -305,7 +305,7 @@ pub(super) mod chain_name {
         "Name of the chain, to avoid the deploy from being accidentally or maliciously included in \
         a different chain";
 
-    pub(in crate::deploy) fn arg() -> Arg<'static> {
+    pub(in crate::deploy) fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .required_unless_present(show_simple_arg_examples::ARG_NAME)
@@ -332,7 +332,7 @@ pub(super) mod session_path {
     const ARG_VALUE_NAME: &str = common::ARG_PATH;
     const ARG_HELP: &str = "Path to the compiled Wasm session code";
 
-    pub(in crate::deploy) fn arg() -> Arg<'static> {
+    pub(in crate::deploy) fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .short(ARG_SHORT)
             .long(ARG_NAME)
@@ -370,7 +370,7 @@ pub(super) mod arg_simple {
         pub const ARG_NAME: &str = "session-arg";
         const ARG_SHORT: char = 'a';
 
-        pub fn arg() -> Arg<'static> {
+        pub fn arg() -> Arg {
             super::arg(ARG_NAME, DisplayOrder::SessionArgSimple as usize).short(ARG_SHORT)
         }
 
@@ -388,7 +388,7 @@ pub(super) mod arg_simple {
 
         pub const ARG_NAME: &str = "payment-arg";
 
-        pub fn arg() -> Arg<'static> {
+        pub fn arg() -> Arg {
             super::arg(ARG_NAME, DisplayOrder::PaymentArgSimple as usize)
         }
 
@@ -401,7 +401,7 @@ pub(super) mod arg_simple {
         }
     }
 
-    fn arg(name: &'static str, order: usize) -> Arg<'static> {
+    fn arg(name: &'static str, order: usize) -> Arg {
         Arg::new(name)
             .long(name)
             .required(false)
@@ -432,7 +432,7 @@ pub(super) mod args_json {
 
         pub const ARG_NAME: &str = "session-args-json";
 
-        pub fn arg() -> Arg<'static> {
+        pub fn arg() -> Arg {
             super::arg(ARG_NAME, DisplayOrder::SessionArgsJson as usize)
         }
 
@@ -449,7 +449,7 @@ pub(super) mod args_json {
 
         pub const ARG_NAME: &str = "payment-args-json";
 
-        pub fn arg() -> Arg<'static> {
+        pub fn arg() -> Arg {
             super::arg(ARG_NAME, DisplayOrder::PaymentArgsJson as usize)
         }
 
@@ -461,7 +461,7 @@ pub(super) mod args_json {
         }
     }
 
-    fn arg(name: &'static str, order: usize) -> Arg<'static> {
+    fn arg(name: &'static str, order: usize) -> Arg {
         Arg::new(name)
             .long(name)
             .required(false)
@@ -487,7 +487,7 @@ pub(super) mod args_complex {
 
         pub const ARG_NAME: &str = "session-args-complex";
 
-        pub fn arg() -> Arg<'static> {
+        pub fn arg() -> Arg {
             super::arg(ARG_NAME, DisplayOrder::SessionArgsComplex as usize)
                 .requires(super::session::ARG_NAME)
         }
@@ -505,7 +505,7 @@ pub(super) mod args_complex {
 
         pub const ARG_NAME: &str = "payment-args-complex";
 
-        pub fn arg() -> Arg<'static> {
+        pub fn arg() -> Arg {
             super::arg(ARG_NAME, DisplayOrder::PaymentArgsComplex as usize)
                 .requires(super::payment::ARG_NAME)
         }
@@ -518,7 +518,7 @@ pub(super) mod args_complex {
         }
     }
 
-    fn arg(name: &'static str, order: usize) -> Arg<'static> {
+    fn arg(name: &'static str, order: usize) -> Arg {
         Arg::new(name)
             .long(name)
             .required(false)
@@ -536,7 +536,7 @@ pub(super) mod payment_path {
     const ARG_VALUE_NAME: &str = common::ARG_PATH;
     const ARG_HELP: &str = "Path to the compiled Wasm payment code";
 
-    pub(in crate::deploy) fn arg() -> Arg<'static> {
+    pub(in crate::deploy) fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .required(false)
@@ -562,7 +562,7 @@ pub(super) mod standard_payment_amount {
         The value is the 'amount' arg of the standard-payment contract. This arg is incompatible \
         with all other --payment-xxx args";
 
-    pub(in crate::deploy) fn arg() -> Arg<'static> {
+    pub(in crate::deploy) fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -578,9 +578,9 @@ pub(super) mod standard_payment_amount {
 }
 
 pub(super) fn apply_common_creation_options(
-    subcommand: Command<'static>,
+    subcommand: Command,
     include_node_address: bool,
-) -> Command<'static> {
+) -> Command {
     let mut subcommand = subcommand
         .next_line_help(true)
         .arg(show_simple_arg_examples::arg())
@@ -609,7 +609,7 @@ pub(super) fn apply_common_creation_options(
     subcommand
 }
 
-pub(super) fn apply_common_session_options(subcommand: Command<'static>) -> Command<'static> {
+pub(super) fn apply_common_session_options(subcommand: Command) -> Command {
     subcommand
         .arg(session_path::arg())
         .arg(session_package_hash::arg())
@@ -644,7 +644,7 @@ pub(super) fn apply_common_session_options(subcommand: Command<'static>) -> Comm
         )
 }
 
-pub(crate) fn apply_common_payment_options(subcommand: Command<'static>) -> Command<'static> {
+pub(crate) fn apply_common_payment_options(subcommand: Command) -> Command {
     subcommand
         .arg(standard_payment_amount::arg())
         .arg(payment_path::arg())
@@ -703,7 +703,7 @@ pub(super) mod output {
         "Path to output deploy file. If omitted, defaults to stdout. If the file already exists, \
         the command will fail unless '--force' is also specified";
 
-    pub fn arg() -> Arg<'static> {
+    pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .required(false)
             .long(ARG_NAME)
@@ -726,7 +726,7 @@ pub(super) mod input {
     const ARG_VALUE_NAME: &str = common::ARG_PATH;
     const ARG_HELP: &str = "Path to input deploy file";
 
-    pub fn arg() -> Arg<'static> {
+    pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .required(true)
             .long(ARG_NAME)
@@ -751,7 +751,7 @@ pub(super) mod session_hash {
     const ARG_VALUE_NAME: &str = common::ARG_HEX_STRING;
     const ARG_HELP: &str = "Hex-encoded hash of the stored contract to be called as the session";
 
-    pub fn arg() -> Arg<'static> {
+    pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .value_name(ARG_VALUE_NAME)
@@ -773,7 +773,7 @@ pub(super) mod session_name {
     const ARG_VALUE_NAME: &str = "NAME";
     const ARG_HELP: &str = "Name of the stored contract (associated with the executing account) to be called as the session";
 
-    pub fn arg() -> Arg<'static> {
+    pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .value_name(ARG_VALUE_NAME)
@@ -794,7 +794,7 @@ pub(super) mod is_session_transfer {
     pub const ARG_NAME: &str = "is-session-transfer";
     const ARG_HELP: &str = "Use this flag if you want to make this a transfer.";
 
-    pub fn arg() -> Arg<'static> {
+    pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .action(ArgAction::SetTrue)
@@ -818,7 +818,7 @@ pub(super) mod session_package_hash {
     const ARG_VALUE_NAME: &str = common::ARG_HEX_STRING;
     const ARG_HELP: &str = "Hex-encoded hash of the stored package to be called as the session";
 
-    pub fn arg() -> Arg<'static> {
+    pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .value_name(ARG_VALUE_NAME)
@@ -840,7 +840,7 @@ pub(super) mod session_package_name {
     const ARG_VALUE_NAME: &str = "NAME";
     const ARG_HELP: &str = "Name of the stored package to be called as the session";
 
-    pub fn arg() -> Arg<'static> {
+    pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .value_name(ARG_VALUE_NAME)
@@ -862,7 +862,7 @@ pub(super) mod session_entry_point {
     const ARG_VALUE_NAME: &str = "NAME";
     const ARG_HELP: &str = "Name of the method that will be used when calling the session contract";
 
-    pub fn arg() -> Arg<'static> {
+    pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .value_name(ARG_VALUE_NAME)
@@ -886,7 +886,7 @@ pub(super) mod session_version {
     const ARG_VALUE_NAME: &str = common::ARG_INTEGER;
     const ARG_HELP: &str = "Version of the called session contract. Latest will be used by default";
 
-    pub fn arg() -> Arg<'static> {
+    pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .value_name(ARG_VALUE_NAME)
@@ -910,7 +910,7 @@ pub(super) mod payment_hash {
     const ARG_VALUE_NAME: &str = common::ARG_HEX_STRING;
     const ARG_HELP: &str = "Hex-encoded hash of the stored contract to be called as the payment";
 
-    pub fn arg() -> Arg<'static> {
+    pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .value_name(ARG_VALUE_NAME)
@@ -933,7 +933,7 @@ pub(super) mod payment_name {
     const ARG_HELP: &str = "Name of the stored contract (associated with the executing account) \
     to be called as the payment";
 
-    pub fn arg() -> Arg<'static> {
+    pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .value_name(ARG_VALUE_NAME)
@@ -955,7 +955,7 @@ pub(super) mod payment_package_hash {
     const ARG_VALUE_NAME: &str = common::ARG_HEX_STRING;
     const ARG_HELP: &str = "Hex-encoded hash of the stored package to be called as the payment";
 
-    pub fn arg() -> Arg<'static> {
+    pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .value_name(ARG_VALUE_NAME)
@@ -977,7 +977,7 @@ pub(super) mod payment_package_name {
     const ARG_VALUE_NAME: &str = "NAME";
     const ARG_HELP: &str = "Name of the stored package to be called as the payment";
 
-    pub fn arg() -> Arg<'static> {
+    pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .value_name(ARG_VALUE_NAME)
@@ -999,7 +999,7 @@ pub(super) mod payment_entry_point {
     const ARG_VALUE_NAME: &str = "NAME";
     const ARG_HELP: &str = "Name of the method that will be used when calling the payment contract";
 
-    pub fn arg() -> Arg<'static> {
+    pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .value_name(ARG_VALUE_NAME)
@@ -1023,7 +1023,7 @@ pub(super) mod payment_version {
     const ARG_VALUE_NAME: &str = common::ARG_INTEGER;
     const ARG_HELP: &str = "Version of the called payment contract. Latest will be used by default";
 
-    pub fn arg() -> Arg<'static> {
+    pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .value_name(ARG_VALUE_NAME)

--- a/src/deploy/get.rs
+++ b/src/deploy/get.rs
@@ -25,7 +25,7 @@ mod deploy_hash {
     const ARG_VALUE_NAME: &str = "HEX STRING";
     const ARG_HELP: &str = "Hex-encoded deploy hash";
 
-    pub(super) fn arg() -> Arg<'static> {
+    pub(super) fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .required(true)
             .value_name(ARG_VALUE_NAME)
@@ -46,7 +46,7 @@ impl ClientCommand for GetDeploy {
     const NAME: &'static str = "get-deploy";
     const ABOUT: &'static str = "Retrieve a deploy from the network";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)

--- a/src/deploy/list.rs
+++ b/src/deploy/list.rs
@@ -51,7 +51,7 @@ impl ClientCommand for ListDeploys {
     const NAME: &'static str = "list-deploys";
     const ABOUT: &'static str = "Retrieve the list of all deploy hashes in a given block";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)

--- a/src/deploy/make.rs
+++ b/src/deploy/make.rs
@@ -16,7 +16,7 @@ impl ClientCommand for MakeDeploy {
         be signed by other parties using the 'sign-deploy' subcommand and then sent to the network \
         for execution using the 'send-deploy' subcommand";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         let subcommand = Command::new(Self::NAME)
             .about(Self::ABOUT)
             .arg(creation_common::output::arg())

--- a/src/deploy/make_transfer.rs
+++ b/src/deploy/make_transfer.rs
@@ -16,7 +16,7 @@ impl ClientCommand for MakeTransfer {
         subsequently be signed by other parties using the 'sign-deploy' subcommand and then sent \
         to the network for execution using the 'send-deploy' subcommand";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         let subcommand = Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)

--- a/src/deploy/put.rs
+++ b/src/deploy/put.rs
@@ -13,7 +13,7 @@ impl ClientCommand for PutDeploy {
     const NAME: &'static str = "put-deploy";
     const ABOUT: &'static str = "Create a deploy and send it to the network for execution";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         let subcommand = Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)

--- a/src/deploy/send.rs
+++ b/src/deploy/send.rs
@@ -15,7 +15,7 @@ impl ClientCommand for SendDeploy {
     const ABOUT: &'static str =
         "Read a previously-saved deploy from a file and send it to the network for execution";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)

--- a/src/deploy/sign.rs
+++ b/src/deploy/sign.rs
@@ -15,7 +15,7 @@ impl ClientCommand for SignDeploy {
         "Read a previously-saved deploy from a file, cryptographically sign it, and output it to a \
         file or stdout";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)

--- a/src/deploy/transfer.rs
+++ b/src/deploy/transfer.rs
@@ -15,7 +15,7 @@ pub(super) mod amount {
     const ARG_VALUE_NAME: &str = "512-BIT INTEGER";
     const ARG_HELP: &str = "The number of motes to transfer";
 
-    pub(in crate::deploy) fn arg() -> Arg<'static> {
+    pub(in crate::deploy) fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -47,7 +47,7 @@ pub(super) mod target_account {
 
     // Conflicts with --target-purse, but that's handled via an `ArgGroup` in the subcommand. Don't
     // add a `conflicts_with()` to the arg or the `ArgGroup` fails to work correctly.
-    pub(in crate::deploy) fn arg() -> Arg<'static> {
+    pub(in crate::deploy) fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -75,7 +75,7 @@ pub(super) mod transfer_id {
     const ARG_VALUE_NAME: &str = "64-BIT INTEGER";
     const ARG_HELP: &str = "User-defined identifier, permanently associated with the transfer";
 
-    pub(in crate::deploy) fn arg() -> Arg<'static> {
+    pub(in crate::deploy) fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -101,7 +101,7 @@ impl ClientCommand for Transfer {
     const NAME: &'static str = "transfer";
     const ABOUT: &'static str = "Transfer funds between purses";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         let subcommand = Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)

--- a/src/generate_completion.rs
+++ b/src/generate_completion.rs
@@ -27,7 +27,7 @@ mod output_dir {
         normally requires running the command with sudo";
     const ARG_DEFAULT: &str = "/usr/share/bash-completion/completions";
 
-    pub(super) fn arg() -> Arg<'static> {
+    pub(super) fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -55,7 +55,7 @@ mod shell {
     const ARG_DEFAULT: &str = "bash";
     const ARG_HELP: &str = "The type of shell to generate the completion script for";
 
-    pub fn arg() -> Arg<'static> {
+    pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .required(false)
@@ -80,7 +80,7 @@ impl ClientCommand for GenerateCompletion {
     const NAME: &'static str = "generate-completion";
     const ABOUT: &'static str = "Generate a shell completion script";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)

--- a/src/get_account.rs
+++ b/src/get_account.rs
@@ -27,7 +27,7 @@ impl ClientCommand for GetAccount {
     const NAME: &'static str = "get-account";
     const ABOUT: &'static str = "Retrieve account information from the network";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
             .alias(COMMAND_ALIAS)
             .about(Self::ABOUT)

--- a/src/get_auction_info.rs
+++ b/src/get_auction_info.rs
@@ -23,7 +23,7 @@ impl ClientCommand for GetAuctionInfo {
     const ABOUT: &'static str =
         "Retrieve the bids and validators as of either a specific block (by height or hash), or the most recently added block";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)

--- a/src/get_balance.rs
+++ b/src/get_balance.rs
@@ -24,7 +24,7 @@ impl ClientCommand for GetBalance {
     const ABOUT: &'static str = "Retrieve a purse's balance from the network\n\
                                 NOTE: This command is deprecated; use `query-balance` instead.";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)

--- a/src/get_chainspec.rs
+++ b/src/get_chainspec.rs
@@ -22,7 +22,7 @@ impl ClientCommand for GetChainspec {
     const ABOUT: &'static str =
         "Retrieve the chainspec of the network (to print the full TOML, run with '-vv')";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)

--- a/src/get_dictionary_item.rs
+++ b/src/get_dictionary_item.rs
@@ -32,11 +32,7 @@ mod key {
 
     const ARG_VALUE_NAME: &str = "FORMATTED STRING or PATH";
 
-    pub(super) fn arg(
-        arg_name: &'static str,
-        arg_help: &'static str,
-        display_order: usize,
-    ) -> Arg<'static> {
+    pub(super) fn arg(arg_name: &'static str, arg_help: &'static str, display_order: usize) -> Arg {
         Arg::new(arg_name)
             .long(arg_name)
             .required(false)
@@ -84,7 +80,7 @@ mod account_hash {
         "This must be a properly formatted account hash. The format for account hash is \
         \"account-hash-<HEX STRING>\".";
 
-    pub(super) fn arg() -> Arg<'static> {
+    pub(super) fn arg() -> Arg {
         key::arg(ARG_NAME, ARG_HELP, DisplayOrder::AccountHash as usize)
     }
 
@@ -101,7 +97,7 @@ mod contract_hash {
         "This must be a properly formatted contract hash. The format for contract hash is \
         \"hash-<HEX STRING>\".";
 
-    pub(super) fn arg() -> Arg<'static> {
+    pub(super) fn arg() -> Arg {
         key::arg(ARG_NAME, ARG_HELP, DisplayOrder::ContractHash as usize)
     }
 
@@ -118,7 +114,7 @@ mod dictionary_name {
     const ARG_VALUE_NAME: &str = "STRING";
     const ARG_HELP: &str = "The named key under which the dictionary seed URef is stored.";
 
-    pub(super) fn arg() -> Arg<'static> {
+    pub(super) fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .required(false)
@@ -143,7 +139,7 @@ mod dictionary_item_key {
     const ARG_VALUE_NAME: &str = "STRING";
     const ARG_HELP: &str = "The dictionary item key formatted as a string.";
 
-    pub(super) fn arg() -> Arg<'static> {
+    pub(super) fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .required(true)
@@ -169,7 +165,7 @@ mod seed_uref {
     const ARG_HELP: &str = "The dictionary's seed URef. This must be a properly formatted URef \
         \"uref-<HEX STRING>-<THREE DIGIT INTEGER>\"";
 
-    pub(super) fn arg() -> Arg<'static> {
+    pub(super) fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .required(false)
@@ -194,7 +190,7 @@ mod dictionary_address {
     const ARG_VALUE_NAME: &str = "FORMATTED STRING";
     const ARG_HELP: &str = "The dictionary item's unique key.";
 
-    pub(super) fn arg() -> Arg<'static> {
+    pub(super) fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .required(false)
@@ -216,7 +212,7 @@ impl ClientCommand for GetDictionaryItem {
     const NAME: &'static str = "get-dictionary-item";
     const ABOUT: &'static str = "Retrieve a stored value from a dictionary";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)

--- a/src/get_era_info.rs
+++ b/src/get_era_info.rs
@@ -25,7 +25,7 @@ impl ClientCommand for GetEraInfo {
     const NAME: &'static str = "get-era-info";
     const ABOUT: &'static str = "Retrieve era information from the network";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
             .alias(COMMAND_ALIAS)
             .about(Self::ABOUT)

--- a/src/get_node_status.rs
+++ b/src/get_node_status.rs
@@ -21,7 +21,7 @@ impl ClientCommand for GetNodeStatus {
     const NAME: &'static str = "get-node-status";
     const ABOUT: &'static str = "Retrieve status of the specified node";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)

--- a/src/get_peers.rs
+++ b/src/get_peers.rs
@@ -22,7 +22,7 @@ impl ClientCommand for GetPeers {
     const ABOUT: &'static str =
         "Retrieve network identity and address of each of the specified node's peers";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)

--- a/src/get_state_root_hash.rs
+++ b/src/get_state_root_hash.rs
@@ -22,7 +22,7 @@ impl ClientCommand for GetStateRootHash {
     const NAME: &'static str = "get-state-root-hash";
     const ABOUT: &'static str = "Retrieve a state root hash at a given block";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)

--- a/src/get_validator_changes.rs
+++ b/src/get_validator_changes.rs
@@ -21,7 +21,7 @@ impl ClientCommand for GetValidatorChanges {
     const NAME: &'static str = "get-validator-changes";
     const ABOUT: &'static str = "Retrieve status changes of active validators";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -36,7 +36,7 @@ mod output_dir {
         "Path to output directory where key files will be created. If the path doesn't exist, it \
         will be created. If not set, the current working directory will be used";
 
-    pub(super) fn arg() -> Arg<'static> {
+    pub(super) fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .required(false)
             .value_name(ARG_VALUE_NAME)
@@ -61,7 +61,7 @@ mod algorithm {
     const ARG_VALUE_NAME: &str = common::ARG_STRING;
     const ARG_HELP: &str = "The type of keys to generate";
 
-    pub fn arg() -> Arg<'static> {
+    pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -91,7 +91,7 @@ impl ClientCommand for Keygen {
     const NAME: &'static str = "keygen";
     const ABOUT: &'static str = "Generate account key files in the given directory";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
             .about(Self::ABOUT)
             .long_about(MORE_ABOUT.as_str())

--- a/src/list_rpcs.rs
+++ b/src/list_rpcs.rs
@@ -21,7 +21,7 @@ impl ClientCommand for ListRpcs {
     const NAME: &'static str = "list-rpcs";
     const ABOUT: &'static str = "List all currently supported RPCs";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,7 +94,7 @@ enum DisplayOrder {
     GenerateCompletion,
 }
 
-fn cli() -> Command<'static> {
+fn cli() -> Command {
     Command::new(APP_NAME)
         .version(VERSION.as_str())
         .about("A client for interacting with the Casper network")

--- a/src/query_balance.rs
+++ b/src/query_balance.rs
@@ -30,7 +30,7 @@ impl ClientCommand for QueryBalance {
     const NAME: &'static str = "query-balance";
     const ABOUT: &'static str = "Retrieve a purse's balance from the network";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
             .about(Self::ABOUT)
             .after_help(AFTER_HELP)

--- a/src/query_global_state.rs
+++ b/src/query_global_state.rs
@@ -48,7 +48,7 @@ mod key {
         enter the path to the file as the --key argument. The file should be one of the two public \
         key files generated via the `keygen` subcommand; \"public_key_hex\" or \"public_key.pem\"";
 
-    pub(crate) fn arg(order: usize) -> Arg<'static> {
+    pub(crate) fn arg(order: usize) -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -98,7 +98,7 @@ mod path {
     const ARG_VALUE_NAME: &str = "PATH/FROM/KEY";
     const ARG_HELP: &str = "The path from the key of the query";
 
-    pub(crate) fn arg(order: usize) -> Arg<'static> {
+    pub(crate) fn arg(order: usize) -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -121,7 +121,7 @@ impl ClientCommand for QueryGlobalState {
     const NAME: &'static str = "query-global-state";
     const ABOUT: &'static str = "Retrieve a stored value from the network";
 
-    fn build(display_order: usize) -> Command<'static> {
+    fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
             .alias(COMMAND_ALIAS)
             .about(Self::ABOUT)


### PR DESCRIPTION
This PR adds support for providing variable- or fixed-length byte strings via the "simple args" used when taking session or payment args for constructing a Deploy.

Existing unit tests for parsing simple args have been moved to the `simple_args` module, and extended to cover invalid cases.

Closes [#3323](https://github.com/casper-network/casper-node/issues/3323).