### PR TITLE
Update all CI matrices to use ubuntu-20.04 exclusively

### DIFF
--- a/.github/workflows/ci-casper-client-rs.yml
+++ b/.github/workflows/ci-casper-client-rs.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         #https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/nightly-scheduled-test.yml
+++ b/.github/workflows/nightly-scheduled-test.yml
@@ -13,7 +13,7 @@ jobs:
   nightly-cargo-test:
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04]
         branch: [main, dev]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/publish-casper-client-deb.yml
+++ b/.github/workflows/publish-casper-client-deb.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             code_name: bionic
           - os: ubuntu-20.04
             code_name: focal

--- a/.github/workflows/publish-casper-client-rpm.yml
+++ b/.github/workflows/publish-casper-client-rpm.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   publish-rpm:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish-dev-repo.yml
+++ b/.github/workflows/publish-dev-repo.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             code_name: bionic
           - os: ubuntu-20.04
             code_name: focal


### PR DESCRIPTION
This PR removes all usages of `ubuntu-18.04` in CI scripts, as support for this OS has been dropped by GitHub Actions.