### PR TITLE
Update dev

### DIFF
--- a/.github/workflows/publish-casper-client-deb.yml
+++ b/.github/workflows/publish-casper-client-deb.yml
@@ -12,8 +12,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            code_name: bionic
-          - os: ubuntu-20.04
             code_name: focal
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/publish-dev-repo.yml
+++ b/.github/workflows/publish-dev-repo.yml
@@ -11,8 +11,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            code_name: bionic
-          - os: ubuntu-20.04
             code_name: focal
 
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,16 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## [1.6.0]
+
+### Add
+* Added a new subcommand `get-era-summary` which optionally takes a block identifier and returns an era summary from a Casper network.
+
+### Changed
+* Update dependencies.
+
+
+
 ## [1.5.1] - 2023-03-08
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ base16 = "0.2.1"
 base64 = "0.13.1"
 casper-hashing = "*"
 casper-types = { version = "*", features = ["std"] }
-clap = { version = "4", features = ["cargo", "deprecated"] }
+clap = { version = "4", features = ["cargo", "deprecated", "wrap_help"] }
 clap_complete = "4"
 derp = "0.0.14"
 ed25519-dalek = { version = "1", default-features = false }
@@ -54,8 +54,8 @@ untrusted = "0.9.0"
 vergen = { version = "7", default-features = false, features = ["git"] }
 
 [patch.crates-io]
-casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "feat-fast-sync-v2" }
-casper-types = { git = "https://github.com/casper-network/casper-node", branch = "feat-fast-sync-v2" }
+casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "release-1.5.0-rc.1" }
+casper-types = { git = "https://github.com/casper-network/casper-node", branch = "release-1.5.0-rc.1" }
 
 [package.metadata.deb]
 features = ["vendored-openssl"]

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -45,9 +45,9 @@ use crate::{
         results::{
             GetAccountResult, GetAuctionInfoResult, GetBalanceResult, GetBlockResult,
             GetBlockTransfersResult, GetChainspecResult, GetDeployResult, GetDictionaryItemResult,
-            GetEraInfoResult, GetNodeStatusResult, GetPeersResult, GetStateRootHashResult,
-            GetValidatorChangesResult, ListRpcsResult, PutDeployResult, QueryBalanceResult,
-            QueryGlobalStateResult, SpeculativeExecResult,
+            GetEraInfoResult, GetEraSummaryResult, GetNodeStatusResult, GetPeersResult,
+            GetStateRootHashResult, GetValidatorChangesResult, ListRpcsResult, PutDeployResult,
+            QueryBalanceResult, QueryGlobalStateResult, SpeculativeExecResult,
         },
         DictionaryItemIdentifier,
     },
@@ -359,16 +359,16 @@ pub async fn get_state_root_hash(
 /// Retrieves era information from the network at a given [`Block`].
 ///
 /// For details of the parameters, see [the module docs](crate::cli#common-parameters).
-pub async fn get_era_info(
+pub async fn get_era_summary(
     maybe_rpc_id: &str,
     node_address: &str,
     verbosity_level: u64,
     maybe_block_id: &str,
-) -> Result<SuccessResponse<GetEraInfoResult>, CliError> {
+) -> Result<SuccessResponse<GetEraSummaryResult>, CliError> {
     let rpc_id = parse::rpc_id(maybe_rpc_id);
     let verbosity = parse::verbosity(verbosity_level);
     let maybe_block_id = parse::block_identifier(maybe_block_id)?;
-    crate::get_era_info(rpc_id, node_address, verbosity, maybe_block_id)
+    crate::get_era_summary(rpc_id, node_address, verbosity, maybe_block_id)
         .await
         .map_err(CliError::from)
 }
@@ -654,4 +654,26 @@ pub fn json_pretty_print<T: ?Sized + Serialize>(
 ) -> Result<(), CliError> {
     let verbosity = parse::verbosity(verbosity_level);
     crate::json_pretty_print(value, verbosity).map_err(CliError::from)
+}
+
+/// Retrieves era information from the network at a given switch [`Block`].
+///
+/// For details of the parameters, see [the module docs](crate::cli#common-parameters).
+#[deprecated(
+    since = "2.0.0",
+    note = "prefer 'get_era_summary' as it doesn't require a switch block"
+)]
+pub async fn get_era_info(
+    maybe_rpc_id: &str,
+    node_address: &str,
+    verbosity_level: u64,
+    maybe_block_id: &str,
+) -> Result<SuccessResponse<GetEraInfoResult>, CliError> {
+    let rpc_id = parse::rpc_id(maybe_rpc_id);
+    let verbosity = parse::verbosity(verbosity_level);
+    let maybe_block_id = parse::block_identifier(maybe_block_id)?;
+    #[allow(deprecated)]
+    crate::get_era_info(rpc_id, node_address, verbosity, maybe_block_id)
+        .await
+        .map_err(CliError::from)
 }

--- a/lib/rpcs/results.rs
+++ b/lib/rpcs/results.rs
@@ -9,6 +9,7 @@ pub use super::v1_5_0::get_chainspec::{ChainspecRawBytes, GetChainspecResult};
 pub use super::v1_5_0::get_deploy::GetDeployResult;
 pub use super::v1_5_0::get_dictionary_item::GetDictionaryItemResult;
 pub use super::v1_5_0::get_era_info::{EraSummary, GetEraInfoResult};
+pub use super::v1_5_0::get_era_summary::GetEraSummaryResult;
 pub use super::v1_5_0::get_node_status::{
     ActivationPoint, AvailableBlockRange, GetNodeStatusResult, MinimalBlockInfo, NextUpgrade,
     ReactorState,

--- a/lib/rpcs/v1_5_0.rs
+++ b/lib/rpcs/v1_5_0.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod get_chainspec;
 pub(crate) mod get_deploy;
+pub(crate) mod get_era_summary;
 pub(crate) mod get_node_status;
 pub(crate) mod query_balance;
 pub(crate) mod speculative_exec;

--- a/lib/rpcs/v1_5_0/get_era_summary.rs
+++ b/lib/rpcs/v1_5_0/get_era_summary.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+
+use casper_types::ProtocolVersion;
+
+use crate::rpcs::{common::BlockIdentifier, results::EraSummary};
+
+pub(crate) const GET_ERA_SUMMARY_METHOD: &str = "chain_get_era_summary";
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct GetEraSummaryParams {
+    block_identifier: BlockIdentifier,
+}
+
+impl GetEraSummaryParams {
+    pub(crate) fn new(block_identifier: BlockIdentifier) -> Self {
+        GetEraSummaryParams { block_identifier }
+    }
+}
+
+/// The `result` field of a successful JSON-RPC response to a `chain_get_era_summary` request.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct GetEraSummaryResult {
+    /// The JSON-RPC server version.
+    pub api_version: ProtocolVersion,
+    /// The era summary.
+    pub era_summary: EraSummary,
+}

--- a/src/get_era_summary.rs
+++ b/src/get_era_summary.rs
@@ -7,12 +7,8 @@ use casper_client::cli::CliError;
 
 use crate::{command::ClientCommand, common, Success};
 
-/// Legacy name of command.
-const COMMAND_ALIAS: &str = "get-era-info-by-switch-block";
+pub struct GetEraSummary;
 
-pub struct GetEraInfo;
-
-/// This struct defines the order in which the args are shown for this subcommand's help message.
 enum DisplayOrder {
     Verbose,
     NodeAddress,
@@ -21,14 +17,12 @@ enum DisplayOrder {
 }
 
 #[async_trait]
-impl ClientCommand for GetEraInfo {
-    const NAME: &'static str = "get-era-info";
-    const ABOUT: &'static str = "Retrieve era information at a given switch block";
+impl ClientCommand for GetEraSummary {
+    const NAME: &'static str = "get-era-summary";
+    const ABOUT: &'static str = "Retrieve era information at a given block";
 
     fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
-            .hide(true)
-            .alias(COMMAND_ALIAS)
             .about(Self::ABOUT)
             .display_order(display_order)
             .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
@@ -48,8 +42,7 @@ impl ClientCommand for GetEraInfo {
         let verbosity_level = common::verbose::get(matches);
         let maybe_block_id = common::block_identifier::get(matches);
 
-        #[allow(deprecated)]
-        casper_client::cli::get_era_info(
+        casper_client::cli::get_era_summary(
             maybe_rpc_id,
             node_address,
             verbosity_level,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod get_balance;
 mod get_chainspec;
 mod get_dictionary_item;
 mod get_era_info;
+mod get_era_summary;
 mod get_node_status;
 mod get_peers;
 mod get_state_root_hash;
@@ -39,6 +40,7 @@ use get_auction_info::GetAuctionInfo;
 use get_chainspec::GetChainspec;
 use get_dictionary_item::GetDictionaryItem;
 use get_era_info::GetEraInfo;
+use get_era_summary::GetEraSummary;
 use get_node_status::GetNodeStatus;
 use get_peers::GetPeers;
 use get_state_root_hash::GetStateRootHash;
@@ -78,6 +80,7 @@ enum DisplayOrder {
     GetBlockTransfers,
     ListDeploys,
     GetStateRootHash,
+    GetEraSummary,
     GetEraInfo,
     QueryGlobalState,
     QueryBalance,
@@ -114,6 +117,7 @@ fn cli() -> Command {
         .subcommand(GetStateRootHash::build(
             DisplayOrder::GetStateRootHash as usize,
         ))
+        .subcommand(GetEraSummary::build(DisplayOrder::GetEraSummary as usize))
         .subcommand(GetEraInfo::build(DisplayOrder::GetEraInfo as usize))
         .subcommand(QueryGlobalState::build(
             DisplayOrder::QueryGlobalState as usize,
@@ -160,6 +164,7 @@ async fn main() {
         GetBlockTransfers::NAME => GetBlockTransfers::run(matches).await,
         ListDeploys::NAME => ListDeploys::run(matches).await,
         GetStateRootHash::NAME => GetStateRootHash::run(matches).await,
+        GetEraSummary::NAME => GetEraSummary::run(matches).await,
         GetEraInfo::NAME => GetEraInfo::run(matches).await,
         QueryGlobalState::NAME => QueryGlobalState::run(matches).await,
         QueryBalance::NAME => QueryBalance::run(matches).await,


### PR DESCRIPTION
This brings changes from `main` over to `dev`, primarily support for `get-era-summary` subcommand.

The PR also deprecates library support for `get_era_info` and hides the `get-era-info` subcommand from the general `--help` output of the binary.