### PR TITLE
Add flag to get finalized approvals

### DIFF
--- a/.github/workflows/publish-casper-client-rpm.yml
+++ b/.github/workflows/publish-casper-client-rpm.yml
@@ -1,10 +1,11 @@
 ---
 name: publish-casper-client-rpm
 
+# Need to re-enable rpm once we debug issues.
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "disabled_for_now*.*.*"
 
 jobs:
   publish-rpm:

--- a/.github/workflows/publish-casper-client-rs.yml
+++ b/.github/workflows/publish-casper-client-rs.yml
@@ -2,8 +2,9 @@
 name: publish-casper-client-rs
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*.*.*"
 
 jobs:
   publish:

--- a/.github/workflows/publish-casper-client-rs.yml
+++ b/.github/workflows/publish-casper-client-rs.yml
@@ -8,8 +8,9 @@ on:
 
 jobs:
   publish:
+
     runs-on: ubuntu-latest
-    needs: [publish-deb, publish-rpm]
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,31 +14,7 @@ All notable changes to this project will be documented in this file.  The format
 ## Unreleased
 
 ### Added
-* Add module to support node 2.0.0 RPCs.
-
-### Changed
-* Update to match change to node RPC `info_get_deploy`.
-* Improve multisig support for `make-deploy`, and `make-transfer` subcommands.
-
-### Removed
-* Remove following public types which are now available in `casper_types`:
-  * `Account` and its related types `ActionThresholds` and `AssociatedKey`
-  * `Bid`
-  * `BidderAndBid`
-  * `Block` and its related types `BlockBody`, `BlockHash`, `BlockHashAndHeight` and `BlockHeader`
-  * `ChainspecRawBytes`
-  * `Contract`
-  * `ContractPackage` and its related types `ContractPackageStatus`, `ContractVersion`, `DisabledVersion` and `Group`
-  * `Delegator`
-  * `Deploy` and its related types `Approval`, `DeployBuilder`, `DeployHash` and `DeployHeader`
-  * `EraEnd` and its related types `EraReport`, `Reward` and `ValidatorWeight`
-  * `ExecutableDeployItem`
-  * `NamedKey`
-  * `Proof`
-  * `StoredValue`
-  * `TimeDiff`
-  * `Timestamp`
-  * `TransferTarget`
+* Add support for crafting unsigned deploys and transfers by providing an account, but not seccret key, to the `make-deploy` and `make-transfer` subcommands.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add support for new node RPC method `info_get_status`, used in the binary's new `get-node-status` subcommand.
 * Add support for new node RPC method `info_get_peers`, used in the binary's new `get-peers` subcommand.
 * Add support for new node RPC method `query_balance`, used in the binary's new `query-balance` subcommand.
+* Add support for new node RPC method `speculative_exec`, by adding a flag in the Deploy related subcommands.
 * Add support for passing variable-length byte lists as simple args in payment and session args.
 * Add support for passing fixed-length byte arrays as simple args in payment and session args.
 * Add support for passing payment and session args as JSON.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
-## [Unreleased]
+## [2.0.0] - 2023-06-28
 
 ### Added
 * Add new general-purpose API to library, not specific to CLI consumers.
@@ -195,7 +195,9 @@ No changes.
 
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0
-[unreleased]: https://github.com/casper-ecosystem/casper-client-rs/compare/v1.5.1...main
+[unreleased]: https://github.com/casper-ecosystem/casper-client-rs/compare/v2.0.0...main
+[2.0.0]: https://github.com/casper-ecosystem/casper-client-rs/compare/v1.6.0...v2.0.0
+[1.6.0]: https://github.com/casper-ecosystem/casper-client-rs/compare/v1.5.1...v1.6.0
 [1.5.1]: https://github.com/casper-ecosystem/casper-client-rs/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/casper-ecosystem/casper-client-rs/compare/v1.4.4...v1.5.0
 [1.4.4]: https://github.com/casper-ecosystem/casper-client-rs/compare/v1.4.3...v1.4.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,37 @@ All notable changes to this project will be documented in this file.  The format
 
 
 
+## Unreleased
+
+### Added
+* Add module to support node 2.0.0 RPCs.
+
+### Changed
+* Update to match change to node RPC `info_get_deploy`.
+* Improve multisig support for `make-deploy`, and `make-transfer` subcommands.
+
+### Removed
+* Remove following public types which are now available in `casper_types`:
+  * `Account` and its related types `ActionThresholds` and `AssociatedKey`
+  * `Bid`
+  * `BidderAndBid`
+  * `Block` and its related types `BlockBody`, `BlockHash`, `BlockHashAndHeight` and `BlockHeader`
+  * `ChainspecRawBytes`
+  * `Contract`
+  * `ContractPackage` and its related types `ContractPackageStatus`, `ContractVersion`, `DisabledVersion` and `Group`
+  * `Delegator`
+  * `Deploy` and its related types `Approval`, `DeployBuilder`, `DeployHash` and `DeployHeader`
+  * `EraEnd` and its related types `EraReport`, `Reward` and `ValidatorWeight`
+  * `ExecutableDeployItem`
+  * `NamedKey`
+  * `Proof`
+  * `StoredValue`
+  * `TimeDiff`
+  * `Timestamp`
+  * `TransferTarget`
+
+
+
 ## [2.0.0] - 2023-06-28
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ async-trait = "0.1.59"
 base16 = "0.2.1"
 base64 = "0.13.1"
 casper-hashing = "2.0.0"
-casper-types = { version = "3.0.0", features = ["std"] }
+casper-types = { version = "3.0.0", features = ["std", "json-schema"] }
 clap = { version = "4", features = ["cargo", "deprecated", "wrap_help"] }
 clap_complete = "4"
 derp = "0.0.14"
@@ -60,7 +60,7 @@ tokio = { version = "1.23.0", features = [
     "rt-multi-thread",
     "sync",
     "time",
-], optional = true }
+]}
 uint = "0.9.4"
 untrusted = "0.9.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-client"
-version = "1.5.1" # when updating, also update 'html_root_url' in lib.rs
+version = "2.0.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2021"
 description = "A client library and binary for interacting with the Casper network"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "casper-client"
 version = "2.0.0" # when updating, also update 'html_root_url' in lib.rs
-authors = [
-    "Marc Brinkmann <marc@casperlabs.io>",
-    "Fraser Hutchison <fraser@casperlabs.io>",
-]
+authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>",]
 edition = "2021"
 description = "A client library and binary for interacting with the Casper network"
 documentation = "https://docs.rs/casper-client"
@@ -37,12 +34,7 @@ hex-buffer-serde = "0.4.0"
 humantime = "2"
 itertools = "0.10.5"
 jsonrpc-lite = "0.6.0"
-k256 = { version = "0.7.3", features = [
-    "arithmetic",
-    "ecdsa",
-    "sha256",
-    "zeroize",
-] }
+k256 = { version = "0.7.3", features = ["arithmetic", "ecdsa", "sha256", "zeroize", ] }
 num-traits = "0.2.15"
 once_cell = "1"
 pem = "1"
@@ -54,13 +46,7 @@ serde_json = { version = "1", features = ["preserve_order"] }
 signature = "1"
 tempfile = "3"
 thiserror = "=1.0.34"
-tokio = { version = "1.23.0", features = [
-    "macros",
-    "net",
-    "rt-multi-thread",
-    "sync",
-    "time",
-]}
+tokio = { version = "1.23.0", features = ["macros", "net", "rt-multi-thread", "sync", "time", ]}
 uint = "0.9.4"
 untrusted = "0.9.0"
 
@@ -74,9 +60,7 @@ casper-types = { git = "https://github.com/casper-network/casper-node", branch =
 [package.metadata.deb]
 features = ["vendored-openssl"]
 revision = "0"
-assets = [
-    ["./target/release/casper-client", "/usr/bin/casper-client", "755"],
-]
+assets = [["./target/release/casper-client", "/usr/bin/casper-client", "755"], ]
 extended-description = """
 Package for Casper Client to connect to Casper Node.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "casper-client"
 version = "2.0.0" # when updating, also update 'html_root_url' in lib.rs
-authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
+authors = [
+    "Marc Brinkmann <marc@casperlabs.io>",
+    "Fraser Hutchison <fraser@casperlabs.io>",
+]
 edition = "2021"
 description = "A client library and binary for interacting with the Casper network"
 documentation = "https://docs.rs/casper-client"
@@ -29,12 +32,17 @@ clap = { version = "4", features = ["cargo", "deprecated", "wrap_help"] }
 clap_complete = "4"
 derp = "0.0.14"
 ed25519-dalek = { version = "1", default-features = false }
-getrandom = "0.2.8"
+getrandom = "0.2.10"
 hex-buffer-serde = "0.4.0"
 humantime = "2"
 itertools = "0.10.5"
 jsonrpc-lite = "0.6.0"
-k256 = { version = "0.7.3", features = ["arithmetic", "ecdsa", "sha256", "zeroize"] }
+k256 = { version = "0.7.3", features = [
+    "arithmetic",
+    "ecdsa",
+    "sha256",
+    "zeroize",
+] }
 num-traits = "0.2.15"
 once_cell = "1"
 pem = "1"
@@ -46,7 +54,13 @@ serde_json = { version = "1", features = ["preserve_order"] }
 signature = "1"
 tempfile = "3"
 thiserror = "=1.0.34"
-tokio = { version = "1.23.0", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.23.0", features = [
+    "macros",
+    "net",
+    "rt-multi-thread",
+    "sync",
+    "time",
+], optional = true }
 uint = "0.9.4"
 untrusted = "0.9.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ async-trait = "0.1.59"
 base16 = "0.2.1"
 base64 = "0.13.1"
 casper-hashing = "2.0.0"
-casper-types = { version = "3.0.0", features = ["std"] }
+casper-types = { version = "3.0.0", features = ["std", "json-schema"] }
 clap = { version = "4", features = ["cargo", "deprecated", "wrap_help"] }
 clap_complete = "4"
 derp = "0.0.14"
@@ -55,7 +55,7 @@ vergen = { version = "7", default-features = false, features = ["git"] }
 
 [patch.crates-io]
 casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "release-1.5.0-rc.1" }
-casper-types = { git = "https://github.com/casper-network/casper-node", branch = "release-1.5.0-rc.1" }
+casper-types = { git = "https://github.com/casper-network/casper-node", branch = "release-1.5.0-rc.1"}
 
 [package.metadata.deb]
 features = ["vendored-openssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ doc = false
 async-trait = "0.1.59"
 base16 = "0.2.1"
 base64 = "0.13.1"
-casper-hashing = "*"
-casper-types = { version = "*", features = ["std"] }
+casper-hashing = "2.0.0"
+casper-types = { version = "3.0.0", features = ["std"] }
 clap = { version = "4", features = ["cargo", "deprecated", "wrap_help"] }
 clap_complete = "4"
 derp = "0.0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ async-trait = "0.1.59"
 base16 = "0.2.1"
 base64 = "0.13.1"
 casper-hashing = "2.0.0"
-casper-types = { version = "3.0.0", features = ["std", "json-schema"] }
+casper-types = { version = "3.0.0", features = ["std"] }
 clap = { version = "4", features = ["cargo", "deprecated", "wrap_help"] }
 clap_complete = "4"
 derp = "0.0.14"

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -541,16 +541,12 @@ pub async fn get_account(
     node_address: &str,
     verbosity_level: u64,
     maybe_block_id: &str,
-    public_key: &str,
+    account_identifier: &str,
 ) -> Result<SuccessResponse<GetAccountResult>, CliError> {
     let rpc_id = parse::rpc_id(maybe_rpc_id);
     let verbosity = parse::verbosity(verbosity_level);
     let maybe_block_id = parse::block_identifier(maybe_block_id)?;
-    let account_identifier =
-        PublicKey::from_hex(public_key).map_err(|error| crate::Error::CryptoError {
-            context: "public key in get_account",
-            error: crypto::ErrorExt::from(error),
-        })?;
+    let account_identifier = parse::account_identifier(account_identifier)?;
 
     crate::get_account(
         rpc_id,

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -307,9 +307,15 @@ pub async fn get_deploy(
     let rpc_id = parse::rpc_id(maybe_rpc_id);
     let verbosity = parse::verbosity(verbosity_level);
     let deploy_hash = parse::deploy_hash(deploy_hash)?;
-    crate::get_deploy(rpc_id, node_address, verbosity, deploy_hash, finalized_approvals)
-        .await
-        .map_err(CliError::from)
+    crate::get_deploy(
+        rpc_id,
+        node_address,
+        verbosity,
+        deploy_hash,
+        finalized_approvals,
+    )
+    .await
+    .map_err(CliError::from)
 }
 
 /// Retrieves a [`Block`] from the network.

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -302,11 +302,12 @@ pub async fn get_deploy(
     node_address: &str,
     verbosity_level: u64,
     deploy_hash: &str,
+    finalized_approvals: bool,
 ) -> Result<SuccessResponse<GetDeployResult>, CliError> {
     let rpc_id = parse::rpc_id(maybe_rpc_id);
     let verbosity = parse::verbosity(verbosity_level);
     let deploy_hash = parse::deploy_hash(deploy_hash)?;
-    crate::get_deploy(rpc_id, node_address, verbosity, deploy_hash, false)
+    crate::get_deploy(rpc_id, node_address, verbosity, deploy_hash, finalized_approvals)
         .await
         .map_err(CliError::from)
 }

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -301,9 +301,15 @@ pub async fn get_deploy(
     let rpc_id = parse::rpc_id(maybe_rpc_id);
     let verbosity = parse::verbosity(verbosity_level);
     let deploy_hash = parse::deploy_hash(deploy_hash)?;
-    crate::get_deploy(rpc_id, node_address, verbosity, deploy_hash, finalized_approvals)
-        .await
-        .map_err(CliError::from)
+    crate::get_deploy(
+        rpc_id,
+        node_address,
+        verbosity,
+        deploy_hash,
+        finalized_approvals,
+    )
+    .await
+    .map_err(CliError::from)
 }
 
 /// Retrieves a [`Block`] from the network.

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -296,11 +296,12 @@ pub async fn get_deploy(
     node_address: &str,
     verbosity_level: u64,
     deploy_hash: &str,
+    finalized_approvals: bool,
 ) -> Result<SuccessResponse<GetDeployResult>, CliError> {
     let rpc_id = parse::rpc_id(maybe_rpc_id);
     let verbosity = parse::verbosity(verbosity_level);
     let deploy_hash = parse::deploy_hash(deploy_hash)?;
-    crate::get_deploy(rpc_id, node_address, verbosity, deploy_hash, false)
+    crate::get_deploy(rpc_id, node_address, verbosity, deploy_hash, finalized_approvals)
         .await
         .map_err(CliError::from)
 }

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -80,7 +80,8 @@ pub async fn put_deploy(
 ) -> Result<SuccessResponse<PutDeployResult>, CliError> {
     let rpc_id = parse::rpc_id(maybe_rpc_id);
     let verbosity = parse::verbosity(verbosity_level);
-    let deploy = deploy::with_payment_and_session(deploy_params, payment_params, session_params)?;
+    let deploy =
+        deploy::with_payment_and_session(deploy_params, payment_params, session_params, false)?;
     crate::put_deploy(rpc_id, node_address, verbosity, deploy)
         .await
         .map_err(CliError::from)
@@ -101,7 +102,8 @@ pub async fn speculative_put_deploy(
 ) -> Result<SuccessResponse<SpeculativeExecResult>, CliError> {
     let rpc_id = parse::rpc_id(maybe_rpc_id);
     let verbosity = parse::verbosity(verbosity_level);
-    let deploy = deploy::with_payment_and_session(deploy_params, payment_params, session_params)?;
+    let deploy =
+        deploy::with_payment_and_session(deploy_params, payment_params, session_params, false)?;
     let speculative_exec = parse::block_identifier(maybe_block_id)?;
     crate::speculative_exec(rpc_id, node_address, speculative_exec, verbosity, deploy)
         .await
@@ -124,7 +126,8 @@ pub fn make_deploy(
     force: bool,
 ) -> Result<(), CliError> {
     let output = parse::output_kind(maybe_output_path, force);
-    let deploy = deploy::with_payment_and_session(deploy_params, payment_params, session_params)?;
+    let deploy =
+        deploy::with_payment_and_session(deploy_params, payment_params, session_params, true)?;
     crate::output_deploy(output, &deploy).map_err(CliError::from)
 }
 
@@ -212,6 +215,7 @@ pub async fn transfer(
         transfer_id,
         deploy_params,
         payment_params,
+        false,
     )?;
     crate::put_deploy(rpc_id, node_address, verbosity, deploy)
         .await
@@ -250,6 +254,7 @@ pub async fn speculative_transfer(
         transfer_id,
         deploy_params,
         payment_params,
+        false,
     )?;
     let speculative_exec = parse::block_identifier(maybe_block_id)?;
     crate::speculative_exec(rpc_id, node_address, speculative_exec, verbosity, deploy)
@@ -283,6 +288,7 @@ pub fn make_transfer(
         transfer_id,
         deploy_params,
         payment_params,
+        true,
     )?;
     crate::output_deploy(output, &deploy).map_err(CliError::from)
 }

--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -1,34 +1,46 @@
-use casper_types::{account::AccountHash, AsymmetricType, PublicKey, UIntParseError, URef, U512};
+use casper_types::{
+    account::AccountHash, AsymmetricType, Deploy, DeployBuilder, PublicKey, TransferTarget,
+    UIntParseError, URef, U512,
+};
 
 use super::{parse, CliError, DeployStrParams, PaymentStrParams, SessionStrParams};
-use crate::{
-    types::{Deploy, DeployBuilder, MAX_SERIALIZED_SIZE_OF_DEPLOY},
-    TransferTarget,
-};
+use crate::MAX_SERIALIZED_SIZE_OF_DEPLOY;
 
 /// Creates new Deploy with specified payment and session data.
 pub fn with_payment_and_session(
     deploy_params: DeployStrParams,
     payment_params: PaymentStrParams,
     session_params: SessionStrParams,
+    allow_unsigned_deploy: bool,
 ) -> Result<Deploy, CliError> {
     let chain_name = deploy_params.chain_name.to_string();
     let session = parse::session_executable_deploy_item(session_params)?;
-    let secret_key = parse::secret_key_from_file(deploy_params.secret_key)?;
+    let maybe_secret_key = if allow_unsigned_deploy && deploy_params.secret_key.is_empty() {
+        None
+    } else {
+        Some(parse::secret_key_from_file(deploy_params.secret_key)?)
+    };
     let payment = parse::payment_executable_deploy_item(payment_params)?;
     let timestamp = parse::timestamp(deploy_params.timestamp)?;
     let ttl = parse::ttl(deploy_params.ttl)?;
-    let session_account = parse::session_account(deploy_params.session_account)?;
+    let maybe_session_account = parse::session_account(deploy_params.session_account)?;
 
-    let mut deploy_builder = DeployBuilder::new(chain_name, session, &secret_key)
+    let mut deploy_builder = DeployBuilder::new(chain_name, session)
         .with_payment(payment)
         .with_timestamp(timestamp)
         .with_ttl(ttl);
-    if let Some(account) = session_account {
+
+    if let Some(secret_key) = &maybe_secret_key {
+        deploy_builder = deploy_builder.with_secret_key(secret_key);
+    }
+    if let Some(account) = maybe_session_account {
         deploy_builder = deploy_builder.with_account(account);
     }
-    let deploy = deploy_builder.build()?;
-    deploy.is_valid_size(MAX_SERIALIZED_SIZE_OF_DEPLOY)?;
+
+    let deploy = deploy_builder.build().map_err(crate::Error::from)?;
+    deploy
+        .is_valid_size(MAX_SERIALIZED_SIZE_OF_DEPLOY)
+        .map_err(crate::Error::from)?;
     Ok(deploy)
 }
 
@@ -40,9 +52,14 @@ pub fn new_transfer(
     transfer_id: &str,
     deploy_params: DeployStrParams,
     payment_params: PaymentStrParams,
+    allow_unsigned_deploy: bool,
 ) -> Result<Deploy, CliError> {
     let chain_name = deploy_params.chain_name.to_string();
-    let secret_key = parse::secret_key_from_file(deploy_params.secret_key)?;
+    let maybe_secret_key = if allow_unsigned_deploy && deploy_params.secret_key.is_empty() {
+        None
+    } else {
+        Some(parse::secret_key_from_file(deploy_params.secret_key)?)
+    };
     let payment = parse::payment_executable_deploy_item(payment_params)?;
 
     let amount = U512::from_dec_str(amount).map_err(|err| CliError::FailedToParseUint {
@@ -71,23 +88,22 @@ pub fn new_transfer(
 
     let timestamp = parse::timestamp(deploy_params.timestamp)?;
     let ttl = parse::ttl(deploy_params.ttl)?;
-    let session_account = parse::session_account(deploy_params.session_account)?;
+    let maybe_session_account = parse::session_account(deploy_params.session_account)?;
 
-    let mut deploy_builder = DeployBuilder::new_transfer(
-        chain_name,
-        amount,
-        source_purse,
-        target,
-        maybe_transfer_id,
-        &secret_key,
-    )
-    .with_payment(payment)
-    .with_timestamp(timestamp)
-    .with_ttl(ttl);
-    if let Some(account) = session_account {
+    let mut deploy_builder =
+        DeployBuilder::new_transfer(chain_name, amount, source_purse, target, maybe_transfer_id)
+            .with_payment(payment)
+            .with_timestamp(timestamp)
+            .with_ttl(ttl);
+    if let Some(secret_key) = &maybe_secret_key {
+        deploy_builder = deploy_builder.with_secret_key(secret_key);
+    }
+    if let Some(account) = maybe_session_account {
         deploy_builder = deploy_builder.with_account(account);
     }
-    let deploy = deploy_builder.build()?;
-    deploy.is_valid_size(MAX_SERIALIZED_SIZE_OF_DEPLOY)?;
+    let deploy = deploy_builder.build().map_err(crate::Error::from)?;
+    deploy
+        .is_valid_size(MAX_SERIALIZED_SIZE_OF_DEPLOY)
+        .map_err(crate::Error::from)?;
     Ok(deploy)
 }

--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -17,6 +17,14 @@ pub fn with_payment_and_session(
     let session = parse::session_executable_deploy_item(session_params)?;
     let maybe_secret_key = if allow_unsigned_deploy && deploy_params.secret_key.is_empty() {
         None
+    } else if deploy_params.secret_key.is_empty() && !allow_unsigned_deploy {
+        return Err(CliError::InvalidArgument {
+            context: "with_payment_and_session (secret_key, allow_unsigned_deploy)",
+            error: format!(
+                "allow_unsigned_deploy was {}, but no secret key was provided",
+                allow_unsigned_deploy
+            ),
+        });
     } else {
         Some(parse::secret_key_from_file(deploy_params.secret_key)?)
     };
@@ -31,6 +39,7 @@ pub fn with_payment_and_session(
         .with_ttl(ttl);
 
     if let Some(secret_key) = &maybe_secret_key {
+        println!("secret key: {:?}", secret_key);
         deploy_builder = deploy_builder.with_secret_key(secret_key);
     }
     if let Some(account) = maybe_session_account {
@@ -57,6 +66,14 @@ pub fn new_transfer(
     let chain_name = deploy_params.chain_name.to_string();
     let maybe_secret_key = if allow_unsigned_deploy && deploy_params.secret_key.is_empty() {
         None
+    } else if deploy_params.secret_key.is_empty() && !allow_unsigned_deploy {
+        return Err(CliError::InvalidArgument {
+            context: "new_transfer (secret_key, allow_unsigned_deploy)",
+            error: format!(
+                "allow_unsigned_deploy was {}, but no secret key was provided",
+                allow_unsigned_deploy
+            ),
+        });
     } else {
         Some(parse::secret_key_from_file(deploy_params.secret_key)?)
     };

--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -1,10 +1,10 @@
-use casper_types::{
-    account::AccountHash, AsymmetricType, Deploy, DeployBuilder, PublicKey, TransferTarget,
-    UIntParseError, URef, U512,
-};
+use casper_types::{account::AccountHash, AsymmetricType, PublicKey, UIntParseError, URef, U512};
 
 use super::{parse, CliError, DeployStrParams, PaymentStrParams, SessionStrParams};
-use crate::MAX_SERIALIZED_SIZE_OF_DEPLOY;
+use crate::{
+    types::{Deploy, DeployBuilder, MAX_SERIALIZED_SIZE_OF_DEPLOY},
+    TransferTarget,
+};
 
 /// Creates new Deploy with specified payment and session data.
 pub fn with_payment_and_session(

--- a/lib/cli/deploy_str_params.rs
+++ b/lib/cli/deploy_str_params.rs
@@ -4,7 +4,7 @@ pub struct DeployStrParams<'a> {
     /// Path to secret key file.
     ///
     /// If `secret_key` is empty, the new deploy will not be signed and will need to be signed (e.g.
-    /// via [`sign_deploy_file`]) at least once in order to be made valid.
+    /// via [`sign_deploy_file`](super::sign_deploy_file)) at least once in order to be made valid.
     pub secret_key: &'a str,
     /// RFC3339-like formatted timestamp. e.g. `2018-02-16T00:31:37Z`.
     ///

--- a/lib/cli/deploy_str_params.rs
+++ b/lib/cli/deploy_str_params.rs
@@ -2,6 +2,9 @@
 #[derive(Default, Debug)]
 pub struct DeployStrParams<'a> {
     /// Path to secret key file.
+    ///
+    /// If `secret_key` is empty, the new deploy will not be signed and will need to be signed (e.g.
+    /// via [`sign_deploy_file`]) at least once in order to be made valid.
     pub secret_key: &'a str,
     /// RFC3339-like formatted timestamp. e.g. `2018-02-16T00:31:37Z`.
     ///
@@ -22,5 +25,8 @@ pub struct DeployStrParams<'a> {
     pub chain_name: &'a str,
     /// The hex-encoded public key of the account context under which the session code will be
     /// executed.
+    ///
+    /// If `session_account` is empty, the account's public key will be derived from the provided
+    /// `secret_key`.  It is an error for both fields to be empty.
     pub session_account: &'a str,
 }

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -469,7 +469,7 @@ pub(super) fn session_executable_deploy_item(
         });
     }
 
-    let version = version(session_version).ok();
+    let version = version(session_version)?;
     if let Some(package_name) = name(session_package_name) {
         return Ok(ExecutableDeployItem::StoredVersionedContractByName {
             name: package_name,
@@ -572,7 +572,7 @@ pub(super) fn payment_executable_deploy_item(
         });
     }
 
-    let version = version(payment_version).ok();
+    let version = version(payment_version)?;
     if let Some(package_name) = name(payment_package_name) {
         return Ok(ExecutableDeployItem::StoredVersionedContractByName {
             name: package_name,
@@ -634,13 +634,17 @@ fn entry_point(value: &str) -> Option<String> {
     Some(value.to_string())
 }
 
-fn version(value: &str) -> Result<u32, CliError> {
-    value
+fn version(value: &str) -> Result<Option<u32>, CliError> {
+    if value.is_empty() {
+        return Ok(None);
+    }
+    let parsed = value
         .parse::<u32>()
         .map_err(|error| CliError::FailedToParseInt {
             context: "version",
             error,
-        })
+        })?;
+    Ok(Some(parsed))
 }
 
 pub(super) fn transfer_id(value: &str) -> Result<u64, CliError> {
@@ -779,7 +783,7 @@ mod tests {
     const PACKAGE_NAME: &str = "package_name";
     const PATH: &str = "./session.wasm";
     const ENTRY_POINT: &str = "entrypoint";
-    const VERSION: &str = "1.0.0";
+    const VERSION: &str = "3";
     const TRANSFER: bool = true;
 
     impl<'a> TryFrom<SessionStrParams<'a>> for ExecutableDeployItem {
@@ -1291,7 +1295,7 @@ mod tests {
         const PKG_NAME: &str = "pkg_name";
         const PKG_HASH: &str = "09dcee4b212cfd53642ab323fbef07dafafc6f945a80a00147f62910a915c4e6";
         const ENTRYPOINT: &str = "entrypoint";
-        const VERSION: &str = "0.1.0";
+        const VERSION: &str = "4";
 
         fn args_simple() -> Vec<&'static str> {
             vec!["name_01:bool='false'", "name_02:u32='42'"]

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -15,7 +15,7 @@ use casper_types::{
 use super::{simple_args, CliError, PaymentStrParams, SessionStrParams};
 use crate::{
     types::{BlockHash, DeployHash, ExecutableDeployItem, TimeDiff, Timestamp},
-    BlockIdentifier, GlobalStateIdentifier, JsonRpcId, OutputKind, PurseIdentifier, Verbosity,
+    BlockIdentifier, GlobalStateIdentifier, JsonRpcId, OutputKind, PurseIdentifier, Verbosity, AccountIdentifier
 };
 
 pub(super) fn rpc_id(maybe_rpc_id: &str) -> JsonRpcId {

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -770,6 +770,32 @@ pub(super) fn purse_identifier(purse_id: &str) -> Result<PurseIdentifier, CliErr
         })?;
     Ok(PurseIdentifier::MainPurseUnderPublicKey(public_key))
 }
+pub(super) fn account_identifier(account_identifier: &str) -> Result<AccountIdentifier, CliError> {
+    const ACCOUNT_HASH_PREFIX: &str = "account-hash-";
+
+    if account_identifier.is_empty() {
+           return Err(CliError::InvalidArgument {
+            context: "account_identifier",
+            error: "cannot be empty string".to_string()});
+    }
+
+    if account_identifier.starts_with(ACCOUNT_HASH_PREFIX) {
+        let account_hash = AccountHash::from_formatted_str(account_identifier).map_err(|error| {
+            CliError::FailedToParseAccountHash {
+                context: "account_identifier",
+                error,
+            }
+        })?;
+        return Ok(AccountIdentifier::AccountHash(account_hash));
+    }
+
+    let public_key =
+        PublicKey::from_hex(account_identifier).map_err(|error| CliError::FailedToParsePublicKey {
+            context: "account_identifier".to_string(),
+            error,
+        })?;
+    return Ok(AccountIdentifier::PublicKey(public_key))
+}
 
 #[cfg(test)]
 mod tests {

--- a/lib/cli/tests.rs
+++ b/lib/cli/tests.rs
@@ -357,6 +357,7 @@ fn should_fail_to_create_transfer_without_account() {
     // with public key.
     let secret_key = SecretKey::generate_ed25519().unwrap();
     let public_key = PublicKey::from(&secret_key).to_hex();
+
     let transfer_deploy = deploy::new_transfer(
         "10000",
         None,
@@ -379,10 +380,14 @@ fn should_fail_to_create_transfer_with_no_secret_key_while_not_allowing_unsigned
     let payment_params =
         PaymentStrParams::with_package_hash(PKG_HASH, VERSION, ENTRYPOINT, args_simple(), "", "");
 
+    // with public key.
+    let secret_key = SecretKey::generate_ed25519().unwrap();
+    let public_key = PublicKey::from(&secret_key).to_hex();
+
     let transfer_deploy = deploy::new_transfer(
         "10000",
         None,
-        "bad public key.",
+        &public_key,
         "1",
         deploy_params,
         payment_params,

--- a/lib/cli/tests.rs
+++ b/lib/cli/tests.rs
@@ -1,90 +1,106 @@
-use casper_types::SecretKey;
+use casper_types::DeployBuilderError::DeployMissingSessionAccount;
+use casper_types::{DeployExcessiveSizeError, ExecutableDeployItem, SecretKey};
 
-use crate::{
-    types::{ExecutableDeployItem, MAX_SERIALIZED_SIZE_OF_DEPLOY},
-    Error, OutputKind,
-};
+use crate::Error::DeployBuild;
+use crate::{Error, OutputKind, MAX_SERIALIZED_SIZE_OF_DEPLOY};
 
 use super::*;
 
+const SAMPLE_ACCOUNT: &str = "01722e1b3d31bef0ba832121bd2941aae6a246d0d05ac95aa16dd587cc5469871d";
 const PKG_HASH: &str = "09dcee4b212cfd53642ab323fbef07dafafc6f945a80a00147f62910a915c4e6";
 const ENTRYPOINT: &str = "entrypoint";
-const VERSION: &str = "0.1.0";
+const VERSION: &str = "2";
 const SAMPLE_DEPLOY: &str = r#"{
-      "hash": "4858bbd79ab7b825244c4e6959cbcd588a05608168ef36518bc6590937191d55",
-      "header": {
-        "account": "01f60bce2bb1059c41910eac1e7ee6c3ef4c8fcc63a901eb9603c1524cadfb0c18",
-        "timestamp": "2021-01-19T01:18:19.120Z",
-        "ttl": "10s",
-        "gas_price": 1,
-        "body_hash": "95f2f2358c4864f01f8b073ae6f5ae67baeaf7747fc0799d0078743c513bc1de",
-        "dependencies": [
-          "be5fdeea0240e999e376f8ecbce1bd4fd9336f58dae4a5842558a4da6ad35aa8",
-          "168d7ea9c88e76b3eef72759f2a7af24663cc871a469c7ba1387ca479e82fb41"
+  "hash": "1053f767f1734e3b5b31253ea680778ac53f134f7c24518bf2c4cbb204852617",
+  "header": {
+    "account": "01f60bce2bb1059c41910eac1e7ee6c3ef4c8fcc63a901eb9603c1524cadfb0c18",
+    "timestamp": "2022-12-11T18:37:06.901Z",
+    "ttl": "10s",
+    "gas_price": 1,
+    "body_hash": "0a80edb81389ead7fb3d6a783355d821313c8baa68718fa7478aa0ca6a6b3b59",
+    "dependencies": [],
+    "chain_name": "casper-test-chain-name-1"
+  },
+  "payment": {
+    "StoredVersionedContractByHash": {
+      "hash": "09dcee4b212cfd53642ab323fbef07dafafc6f945a80a00147f62910a915c4e6",
+      "version": 2,
+      "entry_point": "entrypoint",
+      "args": [
+        [
+          "name_01",
+          {
+            "cl_type": "Bool",
+            "bytes": "00",
+            "parsed": false
+          }
         ],
-        "chain_name": "casper-test-chain-name-1"
-      },
-      "payment": {
-        "StoredVersionedContractByHash": {
-          "hash": "09dcee4b212cfd53642ab323fbef07dafafc6f945a80a00147f62910a915c4e6",
-          "version": null,
-          "entry_point": "entrypoint",
-          "args": [
-            [
-              "name_01",
-              {
-                "cl_type": "Bool",
-                "bytes": "00",
-                "parsed": false
-              }
-            ],
-            [
-              "name_02",
-              {
-                "cl_type": "I32",
-                "bytes": "2a000000",
-                "parsed": 42
-              }
-            ]
-          ]
-        }
-      },
-      "session": {
-        "StoredVersionedContractByHash": {
-          "hash": "09dcee4b212cfd53642ab323fbef07dafafc6f945a80a00147f62910a915c4e6",
-          "version": null,
-          "entry_point": "entrypoint",
-          "args": [
-            [
-              "name_01",
-              {
-                "cl_type": "Bool",
-                "bytes": "00",
-                "parsed": false
-              }
-            ],
-            [
-              "name_02",
-              {
-                "cl_type": "I32",
-                "bytes": "2a000000",
-                "parsed": 42
-              }
-            ]
-          ]
-        }
-      },
-      "approvals": [
-        {
-          "signer": "01f60bce2bb1059c41910eac1e7ee6c3ef4c8fcc63a901eb9603c1524cadfb0c18",
-          "signature": "010f538ef188770cdbf608bc2d7aa9460108b419b2b629f5e0714204a7f29149809a1d52776b0c514e3320494fdf6f9e9747f06f2c14ddf6f924ce218148e2840a"
-        },
-        {
-          "signer": "01e67d6e56ae07eca98b07ecec8cfbe826b4d5bc51f3a86590c0882cdafbd72fcc",
-          "signature": "01c4f58d7f6145c1e4397efce766149cde5450cbe74991269161e5e1f30a397e6bc4c484f3c72a645cefd42c55cfde0294bfd91de55ca977798c3c8d2a7e43a40c"
-        }
+	[
+          "name_02",
+          {
+            "cl_type": "I32",
+            "bytes": "2a000000",
+            "parsed": 42
+          }
+        ]
       ]
-    }"#;
+    }
+  },
+  "session": {
+    "StoredVersionedContractByHash": {
+      "hash": "09dcee4b212cfd53642ab323fbef07dafafc6f945a80a00147f62910a915c4e6",
+      "version": 2,
+      "entry_point": "entrypoint",
+      "args": [
+        [
+          "name_01",
+          {
+            "cl_type": "Bool",
+            "bytes": "00",
+            "parsed": false
+          }
+        ],
+        [
+          "name_02",
+          {
+            "cl_type": "I32",
+            "bytes": "2a000000",
+            "parsed": 42
+          }
+        ]
+      ]
+ }
+  },
+  "approvals": [
+    {
+      "signer": "01f60bce2bb1059c41910eac1e7ee6c3ef4c8fcc63a901eb9603c1524cadfb0c18",
+      "signature": "01d701c27d7dc36b48fa457e4c7cc9999b444d7efb4a118c805b82d1f1af337437d00f9a9562694a7dd707abc01fa0158428a365a970853327d70d6d8f15aeea00"
+    },
+    {
+      "signer": "016e3725ffd940bddb56e692e6309c6c82d2def515421219ddfd1ea0952e52491a",
+      "signature": "010a973a45b72208b18da27b25ea62c6be31cd1b53b723b74cdd7e9f356d83df821b6431c973e2f6e24d10fdb213dc5e02d552ba113254e610992b6942ff76390e"
+    }
+  ]
+}"#;
+
+pub fn deploy_params_without_account() -> DeployStrParams<'static>{
+    DeployStrParams{
+        secret_key: "",
+        ttl:"10s",
+        chain_name: "casper-test-chain-name-1",
+        ..Default::default()
+    }
+}
+
+pub fn deploy_params_without_secret_key() -> DeployStrParams<'static> {
+    DeployStrParams {
+        secret_key: "",
+        ttl: "10s",
+        chain_name: "casper-test-chain-name-1",
+        session_account: SAMPLE_ACCOUNT,
+        ..Default::default()
+    }
+}
 
 pub fn deploy_params() -> DeployStrParams<'static> {
     DeployStrParams {
@@ -110,7 +126,8 @@ fn should_create_deploy() {
     let mut output = Vec::new();
 
     let deploy =
-        deploy::with_payment_and_session(deploy_params, payment_params, session_params).unwrap();
+        deploy::with_payment_and_session(deploy_params, payment_params, session_params, false)
+            .unwrap();
     crate::write_deploy(&deploy, &mut output).unwrap();
 
     // The test output can be used to generate data for SAMPLE_DEPLOY:
@@ -149,11 +166,11 @@ fn should_fail_to_create_large_deploy() {
         "",
     );
 
-    match deploy::with_payment_and_session(deploy_params, payment_params, session_params) {
-        Err(CliError::Core(Error::DeploySizeTooLarge {
+    match deploy::with_payment_and_session(deploy_params, payment_params, session_params, false) {
+        Err(CliError::Core(Error::DeploySize(DeployExcessiveSizeError {
             max_deploy_size,
             actual_deploy_size,
-        })) => {
+        }))) => {
             assert_eq!(max_deploy_size, MAX_SERIALIZED_SIZE_OF_DEPLOY);
             assert!(actual_deploy_size > MAX_SERIALIZED_SIZE_OF_DEPLOY as usize);
         }
@@ -207,6 +224,7 @@ fn should_create_transfer() {
         "1",
         deploy_params(),
         PaymentStrParams::with_amount("100"),
+        false,
     );
 
     assert!(transfer_deploy.is_ok());
@@ -225,6 +243,7 @@ fn should_create_transfer() {
         "1",
         deploy_params(),
         PaymentStrParams::with_amount("100"),
+        false,
     );
 
     assert!(transfer_deploy.is_ok());
@@ -242,6 +261,7 @@ fn should_create_transfer() {
         "1",
         deploy_params(),
         PaymentStrParams::with_amount("100"),
+        false,
     );
 
     assert!(transfer_deploy.is_ok());
@@ -260,6 +280,7 @@ fn should_fail_to_create_transfer_with_bad_args() {
         "1",
         deploy_params(),
         PaymentStrParams::with_amount("100"),
+        false,
     );
 
     println!("{:?}", transfer_deploy);
@@ -270,5 +291,80 @@ fn should_fail_to_create_transfer_with_bad_args() {
             context: "new_transfer target_account",
             error: _
         })
+    ));
+}
+
+#[test]
+fn should_create_unsigned_deploy() {
+    let deploy_params = deploy_params_without_secret_key();
+    let payment_params =
+        PaymentStrParams::with_package_hash(PKG_HASH, VERSION, ENTRYPOINT, args_simple(), "", "");
+    let session_params =
+        SessionStrParams::with_package_hash(PKG_HASH, VERSION, ENTRYPOINT, args_simple(), "", "");
+
+    let deploy =
+        deploy::with_payment_and_session(deploy_params, payment_params, session_params, true)
+            .unwrap();
+
+    assert!(deploy.approvals().is_empty());
+    assert_eq!(*deploy.account(), PublicKey::from_hex(SAMPLE_ACCOUNT).unwrap());
+}
+
+#[test]
+fn should_fail_to_create_deploy_with_no_session_account() {
+    let deploy_params = deploy_params_without_account();
+    let payment_params =
+        PaymentStrParams::with_package_hash(PKG_HASH, VERSION, ENTRYPOINT, args_simple(), "", "");
+    let session_params =
+        SessionStrParams::with_package_hash(PKG_HASH, VERSION, ENTRYPOINT, args_simple(), "", "");
+
+    let deploy =
+        deploy::with_payment_and_session(deploy_params, payment_params, session_params, true);
+    assert!(deploy.is_err());
+    assert!(matches!(
+        deploy.unwrap_err(),
+        CliError::Core(DeployBuild(DeployMissingSessionAccount))
+    ));
+}
+
+#[test]
+fn should_create_unsigned_transfer() {
+    use casper_types::{AsymmetricType, PublicKey};
+
+    // with public key.
+    let secret_key = SecretKey::generate_ed25519().unwrap();
+    let public_key = PublicKey::from(&secret_key).to_hex();
+    let transfer_deploy = deploy::new_transfer(
+        "10000",
+        None,
+        &public_key,
+        "1",
+        deploy_params_without_secret_key(),
+        PaymentStrParams::with_amount("100"),
+        true,
+    ).unwrap();
+    assert!(transfer_deploy.approvals().is_empty());
+}
+
+#[test]
+fn should_fail_to_create_transfer_without_account() {
+    use casper_types::{AsymmetricType, PublicKey};
+
+    // with public key.
+    let secret_key = SecretKey::generate_ed25519().unwrap();
+    let public_key = PublicKey::from(&secret_key).to_hex();
+    let transfer_deploy = deploy::new_transfer(
+        "10000",
+        None,
+        &public_key,
+        "1",
+        deploy_params_without_account(),
+        PaymentStrParams::with_amount("100"),
+        true,
+    );
+    assert!(transfer_deploy.is_err());
+    assert!(matches!(
+        transfer_deploy.unwrap_err(),
+        CliError::Core(DeployBuild(DeployMissingSessionAccount))
     ));
 }

--- a/lib/error.rs
+++ b/lib/error.rs
@@ -22,6 +22,13 @@ pub enum Error {
         actual_deploy_size: usize,
     },
 
+    /// Failed to build [`Deploy`] due to missing session account.
+    ///
+    /// Call [`DeployBuilder::with_account`] or [`DeployBuilder::with_secret_key`] before
+    /// calling [`DeployBuilder::build`].
+    #[error("deploy requires session account - use `with_account` or `with_secret_key`")]
+    DeployMissingSessionAccount,
+
     /// Failed to build [`Deploy`] due to missing payment code.
     ///
     /// Call [`DeployBuilder::with_standard_payment`] or [`DeployBuilder::with_payment`] before

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -73,7 +73,7 @@ use rpcs::{
         QueryBalanceResult, QueryGlobalStateResult, SpeculativeExecResult,
     },
     v1_5_0::{
-        get_account::{GetAccountParams, GET_ACCOUNT_METHOD},
+        get_account::{AccountIdentifier, GetAccountParams, GET_ACCOUNT_METHOD},
         get_auction_info::{GetAuctionInfoParams, GET_AUCTION_INFO_METHOD},
         get_balance::{GetBalanceParams, GET_BALANCE_METHOD},
         get_block::{GetBlockParams, GET_BLOCK_METHOD},
@@ -370,7 +370,7 @@ pub async fn get_account(
     node_address: &str,
     verbosity: Verbosity,
     maybe_block_identifier: Option<BlockIdentifier>,
-    account_identifier: PublicKey,
+    account_identifier: AccountIdentifier,
 ) -> Result<SuccessResponse<GetAccountResult>, Error> {
     let params = GetAccountParams::new(account_identifier, maybe_block_identifier);
     JsonRpcCall::new(rpc_id, node_address, verbosity)

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -23,7 +23,7 @@
 //!   latest `Block` known on the server will be used.
 
 #![doc(
-    html_root_url = "https://docs.rs/casper-client/1.5.1",
+    html_root_url = "https://docs.rs/casper-client/2.0.0",
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",
     test(attr(forbid(warnings)))

--- a/lib/rpcs/v1_4_5/get_account.rs
+++ b/lib/rpcs/v1_4_5/get_account.rs
@@ -1,22 +1,36 @@
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use casper_types::{ProtocolVersion, PublicKey};
+use casper_types::account::AccountHash;
 
 use crate::{rpcs::common::BlockIdentifier, types::Account};
 
 pub(crate) const GET_ACCOUNT_METHOD: &str = "state_get_account_info";
 
+/// Identifier of an account.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum AccountIdentifier {
+    /// The public key of an account
+    PublicKey(PublicKey),
+    /// The account hash of an account
+    AccountHash(AccountHash),
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct GetAccountParams {
-    public_key: PublicKey,
+    ///The identifier of an Account.
+    account_identifier: AccountIdentifier,
+    /// The block identifier.
     block_identifier: Option<BlockIdentifier>,
 }
 
 impl GetAccountParams {
-    pub(crate) fn new(public_key: PublicKey, block_identifier: Option<BlockIdentifier>) -> Self {
+    pub(crate) fn new(account_identifier: AccountIdentifier, block_identifier: Option<BlockIdentifier>) -> Self {
         GetAccountParams {
-            public_key,
+            account_identifier,
             block_identifier,
         }
     }

--- a/lib/rpcs/v1_5_0.rs
+++ b/lib/rpcs/v1_5_0.rs
@@ -11,6 +11,7 @@ pub(crate) mod speculative_exec;
 
 pub(crate) mod get_account {
     pub use crate::rpcs::v1_4_5::get_account::GetAccountResult;
+    pub use crate::rpcs::v1_4_5::get_account::AccountIdentifier;
     pub(crate) use crate::rpcs::v1_4_5::get_account::{GetAccountParams, GET_ACCOUNT_METHOD};
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -98,25 +98,22 @@ pub mod rpc_id {
 pub mod secret_key {
     use super::*;
 
-    const ARG_NAME: &str = "secret-key";
+    pub(crate) const ARG_NAME: &str = "secret-key";
     const ARG_SHORT: char = 'k';
-    const ARG_VALUE_NAME: &str = super::ARG_PATH;
+    const ARG_VALUE_NAME: &str = ARG_PATH;
     const ARG_HELP: &str = "Path to secret key file";
 
-    pub fn arg(order: usize) -> Arg {
+    pub fn arg(order: usize, extended_help: &str) -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
             .value_name(ARG_VALUE_NAME)
-            .help(ARG_HELP)
+            .help(format!("{}{}", ARG_HELP, extended_help))
             .display_order(order)
     }
 
-    pub fn get(matches: &ArgMatches) -> &str {
-        matches
-            .get_one::<String>(ARG_NAME)
-            .map(String::as_str)
-            .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME))
+    pub fn get(matches: &ArgMatches) -> Option<&str> {
+        matches.get_one::<String>(ARG_NAME).map(String::as_str)
     }
 }
 
@@ -342,37 +339,5 @@ pub(super) mod purse_uref {
 
     pub fn get(matches: &ArgMatches) -> Option<&str> {
         matches.get_one::<String>(ARG_NAME).map(String::as_str)
-    }
-}
-
-/// Handles providing the arg for and retrieval of the session account arg when specifying an
-/// account for a Deploy.
-pub(super) mod session_account {
-    use super::*;
-
-    pub const ARG_NAME: &str = "session-account";
-    const ARG_VALUE_NAME: &str = "FORMATTED STRING or PATH";
-    const ARG_HELP: &str =
-        "The hex-encoded public key of the account context under which the session code will be
-        executed. This must be a properly formatted public key. The public key may instead be read
-        in from a file, in which case enter the path to the file as the --session-account
-        argument. The file should be one of the two public key files generated via the `keygen`
-        subcommand; \"public_key_hex\" or \"public_key.pem\"";
-
-    pub fn arg(order: usize) -> Arg {
-        Arg::new(ARG_NAME)
-            .long(ARG_NAME)
-            .required(false)
-            .value_name(ARG_VALUE_NAME)
-            .help(ARG_HELP)
-            .display_order(order)
-    }
-
-    pub fn get(matches: &ArgMatches) -> Result<String, CliError> {
-        let value = matches
-            .get_one::<String>(ARG_NAME)
-            .map(String::as_str)
-            .unwrap_or_default();
-        super::public_key::try_read_from_file(value)
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -9,6 +9,7 @@ pub const ARG_PATH: &str = "PATH";
 pub const ARG_HEX_STRING: &str = "HEX STRING";
 pub const ARG_STRING: &str = "STRING";
 pub const ARG_INTEGER: &str = "INTEGER";
+pub const DEFAULT_TRANSFER_PAYMENT_AMOUNT: &'static str = "2500000000";
 
 /// Handles the arg for whether verbose output is required or not.
 pub mod verbose {

--- a/src/common.rs
+++ b/src/common.rs
@@ -9,7 +9,7 @@ pub const ARG_PATH: &str = "PATH";
 pub const ARG_HEX_STRING: &str = "HEX STRING";
 pub const ARG_STRING: &str = "STRING";
 pub const ARG_INTEGER: &str = "INTEGER";
-pub const DEFAULT_TRANSFER_PAYMENT_AMOUNT: &'static str = "2500000000";
+pub const DEFAULT_TRANSFER_PAYMENT_AMOUNT: &str = "2500000000";
 
 /// Handles the arg for whether verbose output is required or not.
 pub mod verbose {

--- a/src/deploy/creation_common.rs
+++ b/src/deploy/creation_common.rs
@@ -598,7 +598,7 @@ pub(super) mod standard_payment_amount {
         The value is the 'amount' arg of the standard-payment contract. This arg is incompatible \
         with all other --payment-xxx args";
 
-    pub(in crate::deploy) fn arg() -> Arg {
+    pub(in crate::deploy) fn arg(maybe_default_value: Option<&str>) -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -606,6 +606,7 @@ pub(super) mod standard_payment_amount {
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
             .display_order(DisplayOrder::StandardPayment as usize)
+            .default_value(maybe_default_value.unwrap())
     }
 
     pub fn get(matches: &ArgMatches) -> Option<&str> {
@@ -680,9 +681,9 @@ pub(super) fn apply_common_session_options(subcommand: Command) -> Command {
         )
 }
 
-pub(crate) fn apply_common_payment_options(subcommand: Command) -> Command {
+pub(crate) fn apply_common_payment_options(subcommand: Command, default_amount: Option<&str>) -> Command {
     subcommand
-        .arg(standard_payment_amount::arg())
+        .arg(standard_payment_amount::arg(default_amount))
         .arg(payment_path::arg())
         .arg(payment_package_hash::arg())
         .arg(payment_package_name::arg())
@@ -711,7 +712,7 @@ pub(crate) fn apply_common_payment_options(subcommand: Command) -> Command {
                 .arg(payment_name::ARG_NAME)
                 .arg(show_simple_arg_examples::ARG_NAME)
                 .arg(show_json_args_examples::ARG_NAME)
-                .required(true),
+                .required(default_amount.is_some()),
         )
 }
 

--- a/src/deploy/creation_common.rs
+++ b/src/deploy/creation_common.rs
@@ -9,6 +9,8 @@ use casper_client::cli::{json_args_help, simple_args_help, PaymentStrParams, Ses
 
 use crate::common;
 
+const SESSION_ARG_GROUP: &str = "session-args";
+
 /// This struct defines the order in which the args are shown for this subcommand's help message.
 pub(super) enum DisplayOrder {
     ShowSimpleArgExamples,
@@ -616,12 +618,18 @@ pub(super) mod standard_payment_amount {
 
 pub(super) fn apply_common_creation_options(
     subcommand: Command,
+    require_secret_key: bool,
     include_node_address: bool,
 ) -> Command {
     let mut subcommand = subcommand
         .next_line_help(true)
         .arg(show_simple_arg_examples::arg())
-        .arg(show_json_args_examples::arg());
+        .arg(show_json_args_examples::arg())
+        .group(
+            ArgGroup::new("show-examples")
+                .arg(show_simple_arg_examples::ARG_NAME)
+                .arg(show_json_args_examples::ARG_NAME),
+        );
 
     if include_node_address {
         subcommand = subcommand.arg(
@@ -631,42 +639,48 @@ pub(super) fn apply_common_creation_options(
         );
     }
 
-    subcommand = subcommand
-        .arg(
-            common::secret_key::arg(DisplayOrder::SecretKey as usize)
-                .required_unless_present(show_simple_arg_examples::ARG_NAME)
-                .required_unless_present(show_json_args_examples::ARG_NAME),
+    let secret_key_arg = if require_secret_key {
+        common::secret_key::arg(DisplayOrder::SecretKey as usize, "")
+            .required_unless_present(show_simple_arg_examples::ARG_NAME)
+            .required_unless_present(show_json_args_examples::ARG_NAME)
+    } else {
+        common::secret_key::arg(
+            DisplayOrder::SecretKey as usize,
+            ". If not provided, the deploy will not be signed and will remain invalid until \
+            signed, for example by running the `sign-deploy` subcommand.",
         )
+    };
+
+    subcommand = subcommand
+        .arg(secret_key_arg)
         .arg(timestamp::arg())
         .arg(ttl::arg())
         .arg(chain_name::arg())
-        .arg(common::session_account::arg(
-            DisplayOrder::SessionAccount as usize,
-        ));
+        .arg(session_account::arg(DisplayOrder::SessionAccount as usize));
     subcommand
 }
 
 pub(super) fn apply_common_session_options(subcommand: Command) -> Command {
     subcommand
-        .arg(session_path::arg())
-        .arg(session_package_hash::arg())
-        .arg(session_package_name::arg())
-        .arg(is_session_transfer::arg())
-        .arg(session_hash::arg())
-        .arg(session_name::arg())
         .arg(arg_simple::session::arg())
         .arg(args_json::session::arg())
         .arg(args_complex::session::arg())
         // Group the session-arg args so only one style is used to ensure consistent ordering.
         .group(
-            ArgGroup::new("session-args")
+            ArgGroup::new(SESSION_ARG_GROUP)
                 .arg(arg_simple::session::ARG_NAME)
                 .arg(args_json::session::ARG_NAME)
                 .arg(args_complex::session::ARG_NAME)
                 .required(false),
         )
+        .arg(is_session_transfer::arg())
+        .arg(session_path::arg())
         .arg(session_entry_point::arg())
+        .arg(session_hash::arg())
+        .arg(session_name::arg())
         .arg(session_version::arg())
+        .arg(session_package_hash::arg())
+        .arg(session_package_name::arg())
         .group(
             ArgGroup::new("session")
                 .arg(session_path::ARG_NAME)
@@ -677,6 +691,21 @@ pub(super) fn apply_common_session_options(subcommand: Command) -> Command {
                 .arg(session_name::ARG_NAME)
                 .arg(show_simple_arg_examples::ARG_NAME)
                 .arg(show_json_args_examples::ARG_NAME)
+                .required(false),
+        )
+        .group(
+            // This group duplicates all the args in the "session" and "show-examples" groups, but
+            // ensures at least one of them are provided.
+            ArgGroup::new("session-and-show-examples")
+                .arg(is_session_transfer::ARG_NAME)
+                .arg(session_path::ARG_NAME)
+                .arg(session_hash::ARG_NAME)
+                .arg(session_name::ARG_NAME)
+                .arg(session_package_hash::ARG_NAME)
+                .arg(session_package_name::ARG_NAME)
+                .arg(show_simple_arg_examples::ARG_NAME)
+                .arg(show_json_args_examples::ARG_NAME)
+                .multiple(true)
                 .required(true),
         )
 }
@@ -686,25 +715,25 @@ pub(crate) fn apply_common_payment_options(
     default_amount: Option<&'static str>,
 ) -> Command {
     subcommand
-        .arg(standard_payment_amount::arg(default_amount))
-        .arg(payment_path::arg())
-        .arg(payment_package_hash::arg())
-        .arg(payment_package_name::arg())
-        .arg(payment_hash::arg())
-        .arg(payment_name::arg())
         .arg(arg_simple::payment::arg())
         .arg(args_json::payment::arg())
         .arg(args_complex::payment::arg())
-        // Group the payment-arg args so only one style is used to ensure consistent ordering.
         .group(
+            // Ensure these three forms of inputting payment-args are mutually exclusive.
             ArgGroup::new("payment-args")
                 .arg(arg_simple::payment::ARG_NAME)
                 .arg(args_json::payment::ARG_NAME)
                 .arg(args_complex::payment::ARG_NAME)
                 .required(false),
         )
+        .arg(standard_payment_amount::arg(default_amount))
+        .arg(payment_path::arg())
         .arg(payment_entry_point::arg())
+        .arg(payment_hash::arg())
+        .arg(payment_name::arg())
         .arg(payment_version::arg())
+        .arg(payment_package_hash::arg())
+        .arg(payment_package_name::arg())
         .group(
             ArgGroup::new("payment")
                 .arg(standard_payment_amount::ARG_NAME)
@@ -715,7 +744,22 @@ pub(crate) fn apply_common_payment_options(
                 .arg(payment_name::ARG_NAME)
                 .arg(show_simple_arg_examples::ARG_NAME)
                 .arg(show_json_args_examples::ARG_NAME)
-                .required(default_amount.is_none()),
+                .required(false),
+        )
+        .group(
+            // This group duplicates all the args in the "payment" and "show-examples" groups, but
+            // ensures at least one of them are provided.
+            ArgGroup::new("payment-and-show-example")
+                .arg(standard_payment_amount::ARG_NAME)
+                .arg(payment_path::ARG_NAME)
+                .arg(payment_hash::ARG_NAME)
+                .arg(payment_name::ARG_NAME)
+                .arg(payment_package_hash::ARG_NAME)
+                .arg(payment_package_name::ARG_NAME)
+                .arg(show_simple_arg_examples::ARG_NAME)
+                .arg(show_json_args_examples::ARG_NAME)
+                .multiple(true)
+                .required(true),
         )
 }
 
@@ -784,25 +828,39 @@ pub(super) mod input {
     }
 }
 
-pub(super) mod session_hash {
+pub(super) mod session_account {
     use super::*;
+    use casper_client::cli::CliError;
 
-    pub const ARG_NAME: &str = "session-hash";
-    const ARG_VALUE_NAME: &str = common::ARG_HEX_STRING;
-    const ARG_HELP: &str = "Hex-encoded hash of the stored contract to be called as the session";
+    pub const ARG_NAME: &str = "session-account";
+    const ARG_VALUE_NAME: &str = "FORMATTED STRING or PATH";
+    const ARG_HELP: &str =
+        "The hex-encoded public key of the account context under which the session code will be \
+        executed. This must be a properly formatted public key. The public key may instead be read \
+        in from a file, in which case enter the path to the file as the --session-account \
+        argument. The file should be one of the two public key files generated via the `keygen` \
+        subcommand; \"public_key_hex\" or \"public_key.pem\".  If not provided, the public key of \
+        the account will be derived from the key passed via --secret-key";
 
-    pub fn arg() -> Arg {
+    pub fn arg(order: usize) -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
+            .required_unless_present_any([
+                common::secret_key::ARG_NAME,
+                show_simple_arg_examples::ARG_NAME,
+                show_json_args_examples::ARG_NAME,
+            ])
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
-            .required(false)
-            .requires(session_entry_point::ARG_NAME)
-            .display_order(DisplayOrder::SessionHash as usize)
+            .display_order(order)
     }
 
-    pub fn get(matches: &ArgMatches) -> Option<&str> {
-        matches.get_one::<String>(ARG_NAME).map(String::as_str)
+    pub fn get(matches: &ArgMatches) -> Result<String, CliError> {
+        let value = matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_default();
+        common::public_key::try_read_from_file(value)
     }
 }
 
@@ -811,7 +869,9 @@ pub(super) mod session_name {
 
     pub const ARG_NAME: &str = "session-name";
     const ARG_VALUE_NAME: &str = "NAME";
-    const ARG_HELP: &str = "Name of the stored contract (associated with the executing account) to be called as the session";
+    const ARG_HELP: &str =
+        "Name of the stored contract (associated with the executing account) to be called as the \
+     session";
 
     pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
@@ -840,6 +900,7 @@ pub(super) mod is_session_transfer {
             .action(ArgAction::SetTrue)
             .help(ARG_HELP)
             .required(false)
+            .requires(SESSION_ARG_GROUP)
             .display_order(DisplayOrder::SessionTransfer as usize)
     }
 
@@ -848,6 +909,28 @@ pub(super) mod is_session_transfer {
             .get_one::<bool>(ARG_NAME)
             .copied()
             .unwrap_or_default()
+    }
+}
+
+pub(super) mod session_hash {
+    use super::*;
+
+    pub const ARG_NAME: &str = "session-hash";
+    const ARG_VALUE_NAME: &str = common::ARG_HEX_STRING;
+    const ARG_HELP: &str = "Hex-encoded hash of the stored contract to be called as the session";
+
+    pub fn arg() -> Arg {
+        Arg::new(ARG_NAME)
+            .long(ARG_NAME)
+            .value_name(ARG_VALUE_NAME)
+            .help(ARG_HELP)
+            .required(false)
+            .requires(session_entry_point::ARG_NAME)
+            .display_order(DisplayOrder::SessionHash as usize)
+    }
+
+    pub fn get(matches: &ArgMatches) -> Option<&str> {
+        matches.get_one::<String>(ARG_NAME).map(String::as_str)
     }
 }
 

--- a/src/deploy/creation_common.rs
+++ b/src/deploy/creation_common.rs
@@ -598,7 +598,7 @@ pub(super) mod standard_payment_amount {
         The value is the 'amount' arg of the standard-payment contract. This arg is incompatible \
         with all other --payment-xxx args";
 
-    pub(in crate::deploy) fn arg(maybe_default_value: Option<&'static str>) -> Arg {
+    pub(in crate::deploy) fn arg(default_value: Option<&'static str>) -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -606,7 +606,7 @@ pub(super) mod standard_payment_amount {
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
             .display_order(DisplayOrder::StandardPayment as usize)
-            .default_value(maybe_default_value)
+            .default_value(default_value)
     }
 
     pub fn get(matches: &ArgMatches) -> Option<&str> {

--- a/src/deploy/creation_common.rs
+++ b/src/deploy/creation_common.rs
@@ -598,7 +598,7 @@ pub(super) mod standard_payment_amount {
         The value is the 'amount' arg of the standard-payment contract. This arg is incompatible \
         with all other --payment-xxx args";
 
-    pub(in crate::deploy) fn arg(maybe_default_value: Option<&str>) -> Arg {
+    pub(in crate::deploy) fn arg(maybe_default_value: Option<&'static str>) -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -606,7 +606,7 @@ pub(super) mod standard_payment_amount {
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
             .display_order(DisplayOrder::StandardPayment as usize)
-            .default_value(maybe_default_value.unwrap())
+            .default_value(maybe_default_value)
     }
 
     pub fn get(matches: &ArgMatches) -> Option<&str> {
@@ -681,7 +681,7 @@ pub(super) fn apply_common_session_options(subcommand: Command) -> Command {
         )
 }
 
-pub(crate) fn apply_common_payment_options(subcommand: Command, default_amount: Option<&str>) -> Command {
+pub(crate) fn apply_common_payment_options(subcommand: Command, default_amount: Option<&'static str>) -> Command {
     subcommand
         .arg(standard_payment_amount::arg(default_amount))
         .arg(payment_path::arg())
@@ -712,7 +712,7 @@ pub(crate) fn apply_common_payment_options(subcommand: Command, default_amount: 
                 .arg(payment_name::ARG_NAME)
                 .arg(show_simple_arg_examples::ARG_NAME)
                 .arg(show_json_args_examples::ARG_NAME)
-                .required(default_amount.is_some()),
+                .required(default_amount.is_none()),
         )
 }
 

--- a/src/deploy/creation_common.rs
+++ b/src/deploy/creation_common.rs
@@ -681,7 +681,10 @@ pub(super) fn apply_common_session_options(subcommand: Command) -> Command {
         )
 }
 
-pub(crate) fn apply_common_payment_options(subcommand: Command, default_amount: Option<&'static str>) -> Command {
+pub(crate) fn apply_common_payment_options(
+    subcommand: Command,
+    default_amount: Option<&'static str>,
+) -> Command {
     subcommand
         .arg(standard_payment_amount::arg(default_amount))
         .arg(payment_path::arg())

--- a/src/deploy/get.rs
+++ b/src/deploy/get.rs
@@ -15,6 +15,7 @@ enum DisplayOrder {
     NodeAddress,
     RpcId,
     DeployHash,
+    FinalizedApprovals
 }
 
 /// Handles providing the arg for and retrieval of the deploy hash.
@@ -41,6 +42,31 @@ mod deploy_hash {
     }
 }
 
+/// Handles providing the arg for the retrieval of the finalized approvals.
+mod finalized_approvals {
+    use super::*;
+
+    const ARG_NAME: &str = "get-finalized-approvals";
+    const ARG_VALUE_NAME: &str = "BOOLEAN";
+    const ARG_HELP: &str = "An optional flag specifying whether the finalized approvals are retrieved";
+
+    pub(super) fn arg() -> Arg {
+        Arg::new(ARG_NAME)
+            .required(false)
+            .value_name(ARG_VALUE_NAME)
+            .help(ARG_HELP)
+            .display_order(DisplayOrder::FinalizedApprovals as usize)
+    }
+
+    pub(super) fn get(matches: &ArgMatches) -> bool {
+        matches
+            .get_one::<bool>(ARG_NAME)
+            .copied()
+            .unwrap_or_default()
+    }
+
+}
+
 #[async_trait]
 impl ClientCommand for GetDeploy {
     const NAME: &'static str = "get-deploy";
@@ -56,6 +82,7 @@ impl ClientCommand for GetDeploy {
             ))
             .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
             .arg(deploy_hash::arg())
+            .arg(finalized_approvals::arg())
     }
 
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
@@ -63,8 +90,9 @@ impl ClientCommand for GetDeploy {
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);
         let deploy_hash = deploy_hash::get(matches);
+        let finalized_approvals = finalized_approvals::get(matches);
 
-        casper_client::cli::get_deploy(maybe_rpc_id, node_address, verbosity_level, deploy_hash)
+        casper_client::cli::get_deploy(maybe_rpc_id, node_address, verbosity_level, deploy_hash, finalized_approvals)
             .await
             .map(Success::from)
     }

--- a/src/deploy/get.rs
+++ b/src/deploy/get.rs
@@ -1,7 +1,7 @@
 use std::str;
 
 use async_trait::async_trait;
-use clap::{Arg, ArgMatches, Command, ArgAction};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 
 use casper_client::cli::CliError;
 
@@ -15,7 +15,7 @@ enum DisplayOrder {
     NodeAddress,
     RpcId,
     DeployHash,
-    FinalizedApprovals
+    FinalizedApprovals,
 }
 
 /// Handles providing the arg for and retrieval of the deploy hash.
@@ -49,7 +49,8 @@ mod finalized_approvals {
     const ARG_NAME: &str = "get-finalized-approvals";
     const ARG_SHORT: char = 'a';
     const ARG_VALUE_NAME: &str = "BOOLEAN";
-    const ARG_HELP: &str = "An optional flag specifying whether the finalized approvals are retrieved";
+    const ARG_HELP: &str =
+        "An optional flag specifying whether the finalized approvals are retrieved";
 
     pub(super) fn arg() -> Arg {
         Arg::new(ARG_NAME)
@@ -68,7 +69,6 @@ mod finalized_approvals {
             .copied()
             .unwrap_or_default()
     }
-
 }
 
 #[async_trait]
@@ -96,8 +96,14 @@ impl ClientCommand for GetDeploy {
         let deploy_hash = deploy_hash::get(matches);
         let finalized_approvals = finalized_approvals::get(matches);
 
-        casper_client::cli::get_deploy(maybe_rpc_id, node_address, verbosity_level, deploy_hash, finalized_approvals)
-            .await
-            .map(Success::from)
+        casper_client::cli::get_deploy(
+            maybe_rpc_id,
+            node_address,
+            verbosity_level,
+            deploy_hash,
+            finalized_approvals,
+        )
+        .await
+        .map(Success::from)
     }
 }

--- a/src/deploy/get.rs
+++ b/src/deploy/get.rs
@@ -1,7 +1,7 @@
 use std::str;
 
 use async_trait::async_trait;
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgMatches, Command, ArgAction};
 
 use casper_client::cli::CliError;
 
@@ -47,13 +47,17 @@ mod finalized_approvals {
     use super::*;
 
     const ARG_NAME: &str = "get-finalized-approvals";
+    const ARG_SHORT: char = 'a';
     const ARG_VALUE_NAME: &str = "BOOLEAN";
     const ARG_HELP: &str = "An optional flag specifying whether the finalized approvals are retrieved";
 
     pub(super) fn arg() -> Arg {
         Arg::new(ARG_NAME)
+            .long(ARG_NAME)
+            .short(ARG_SHORT)
             .required(false)
             .value_name(ARG_VALUE_NAME)
+            .action(ArgAction::SetTrue)
             .help(ARG_HELP)
             .display_order(DisplayOrder::FinalizedApprovals as usize)
     }

--- a/src/deploy/make.rs
+++ b/src/deploy/make.rs
@@ -27,14 +27,14 @@ impl ClientCommand for MakeDeploy {
             .display_order(display_order);
         let subcommand = creation_common::apply_common_session_options(subcommand);
         let subcommand = creation_common::apply_common_payment_options(subcommand, None);
-        creation_common::apply_common_creation_options(subcommand, false)
+        creation_common::apply_common_creation_options(subcommand, false, false)
     }
 
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
         creation_common::show_simple_arg_examples_and_exit_if_required(matches);
         creation_common::show_json_args_examples_and_exit_if_required(matches);
 
-        let secret_key = common::secret_key::get(matches);
+        let secret_key = common::secret_key::get(matches).unwrap_or_default();
         let timestamp = creation_common::timestamp::get(matches);
         let ttl = creation_common::ttl::get(matches);
         let chain_name = creation_common::chain_name::get(matches);
@@ -43,7 +43,7 @@ impl ClientCommand for MakeDeploy {
         let payment_str_params = creation_common::payment_str_params(matches);
 
         let maybe_output_path = creation_common::output::get(matches).unwrap_or_default();
-        let session_account = common::session_account::get(matches).unwrap_or_default();
+        let session_account = creation_common::session_account::get(matches).unwrap_or_default();
 
         let force = common::force::get(matches);
 

--- a/src/deploy/make.rs
+++ b/src/deploy/make.rs
@@ -26,7 +26,7 @@ impl ClientCommand for MakeDeploy {
             ))
             .display_order(display_order);
         let subcommand = creation_common::apply_common_session_options(subcommand);
-        let subcommand = creation_common::apply_common_payment_options(subcommand);
+        let subcommand = creation_common::apply_common_payment_options(subcommand, None);
         creation_common::apply_common_creation_options(subcommand, false)
     }
 

--- a/src/deploy/make_transfer.rs
+++ b/src/deploy/make_transfer.rs
@@ -28,7 +28,7 @@ impl ClientCommand for MakeTransfer {
                 creation_common::DisplayOrder::Force as usize,
                 true,
             ));
-        let subcommand = creation_common::apply_common_payment_options(subcommand, Some("2500"));
+        let subcommand = creation_common::apply_common_payment_options(subcommand, Some("2500000000"));
         creation_common::apply_common_creation_options(subcommand, false)
     }
 

--- a/src/deploy/make_transfer.rs
+++ b/src/deploy/make_transfer.rs
@@ -28,7 +28,10 @@ impl ClientCommand for MakeTransfer {
                 creation_common::DisplayOrder::Force as usize,
                 true,
             ));
-        let subcommand = creation_common::apply_common_payment_options(subcommand, Some("2500000000"));
+        let subcommand = creation_common::apply_common_payment_options(
+            subcommand,
+            Some(common::DEFAULT_TRANSFER_PAYMENT_AMOUNT),
+        );
         creation_common::apply_common_creation_options(subcommand, false)
     }
 

--- a/src/deploy/make_transfer.rs
+++ b/src/deploy/make_transfer.rs
@@ -32,7 +32,7 @@ impl ClientCommand for MakeTransfer {
             subcommand,
             Some(common::DEFAULT_TRANSFER_PAYMENT_AMOUNT),
         );
-        creation_common::apply_common_creation_options(subcommand, false)
+        creation_common::apply_common_creation_options(subcommand, false, false)
     }
 
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
@@ -43,7 +43,7 @@ impl ClientCommand for MakeTransfer {
         let target_account = transfer::target_account::get(matches);
         let transfer_id = transfer::transfer_id::get(matches);
 
-        let secret_key = common::secret_key::get(matches);
+        let secret_key = common::secret_key::get(matches).unwrap_or_default();
         let timestamp = creation_common::timestamp::get(matches);
         let ttl = creation_common::ttl::get(matches);
         let chain_name = creation_common::chain_name::get(matches);
@@ -51,7 +51,7 @@ impl ClientCommand for MakeTransfer {
         let payment_str_params = creation_common::payment_str_params(matches);
 
         let maybe_output_path = creation_common::output::get(matches).unwrap_or_default();
-        let session_account = common::session_account::get(matches)?;
+        let session_account = creation_common::session_account::get(matches)?;
         let force = common::force::get(matches);
 
         casper_client::cli::make_transfer(

--- a/src/deploy/make_transfer.rs
+++ b/src/deploy/make_transfer.rs
@@ -28,7 +28,7 @@ impl ClientCommand for MakeTransfer {
                 creation_common::DisplayOrder::Force as usize,
                 true,
             ));
-        let subcommand = creation_common::apply_common_payment_options(subcommand);
+        let subcommand = creation_common::apply_common_payment_options(subcommand, Some("2500"));
         creation_common::apply_common_creation_options(subcommand, false)
     }
 

--- a/src/deploy/put.rs
+++ b/src/deploy/put.rs
@@ -22,7 +22,7 @@ impl ClientCommand for PutDeploy {
             .arg(creation_common::speculative_exec::arg());
         let subcommand = creation_common::apply_common_session_options(subcommand);
         let subcommand = creation_common::apply_common_payment_options(subcommand, None);
-        creation_common::apply_common_creation_options(subcommand, true)
+        creation_common::apply_common_creation_options(subcommand, true, true)
     }
 
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
@@ -33,12 +33,12 @@ impl ClientCommand for PutDeploy {
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);
 
-        let secret_key = common::secret_key::get(matches);
+        let secret_key = common::secret_key::get(matches).unwrap_or_default();
         let maybe_speculative_exec = creation_common::speculative_exec::get(matches);
         let timestamp = creation_common::timestamp::get(matches);
         let ttl = creation_common::ttl::get(matches);
         let chain_name = creation_common::chain_name::get(matches);
-        let session_account = common::session_account::get(matches)?;
+        let session_account = creation_common::session_account::get(matches)?;
 
         let session_str_params = creation_common::session_str_params(matches);
         let payment_str_params = creation_common::payment_str_params(matches);

--- a/src/deploy/put.rs
+++ b/src/deploy/put.rs
@@ -21,7 +21,7 @@ impl ClientCommand for PutDeploy {
             .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
             .arg(creation_common::speculative_exec::arg());
         let subcommand = creation_common::apply_common_session_options(subcommand);
-        let subcommand = creation_common::apply_common_payment_options(subcommand);
+        let subcommand = creation_common::apply_common_payment_options(subcommand, None);
         creation_common::apply_common_creation_options(subcommand, true)
     }
 

--- a/src/deploy/sign.rs
+++ b/src/deploy/sign.rs
@@ -20,7 +20,7 @@ impl ClientCommand for SignDeploy {
             .about(Self::ABOUT)
             .display_order(display_order)
             .arg(
-                common::secret_key::arg(creation_common::DisplayOrder::SecretKey as usize)
+                common::secret_key::arg(creation_common::DisplayOrder::SecretKey as usize, "")
                     .required(true),
             )
             .arg(creation_common::input::arg())
@@ -33,7 +33,7 @@ impl ClientCommand for SignDeploy {
 
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
         let input_path = creation_common::input::get(matches);
-        let secret_key = common::secret_key::get(matches);
+        let secret_key = common::secret_key::get(matches).unwrap_or_default();
         let maybe_output_path = creation_common::output::get(matches).unwrap_or_default();
         let force = common::force::get(matches);
         casper_client::cli::sign_deploy_file(input_path, secret_key, maybe_output_path, force).map(

--- a/src/deploy/transfer.rs
+++ b/src/deploy/transfer.rs
@@ -111,7 +111,10 @@ impl ClientCommand for Transfer {
             .arg(amount::arg())
             .arg(target_account::arg())
             .arg(transfer_id::arg());
-        let subcommand = creation_common::apply_common_payment_options(subcommand, Some("2500000000"));
+        let subcommand = creation_common::apply_common_payment_options(
+            subcommand,
+            Some(common::DEFAULT_TRANSFER_PAYMENT_AMOUNT),
+        );
         creation_common::apply_common_creation_options(subcommand, true)
     }
 

--- a/src/deploy/transfer.rs
+++ b/src/deploy/transfer.rs
@@ -111,7 +111,7 @@ impl ClientCommand for Transfer {
             .arg(amount::arg())
             .arg(target_account::arg())
             .arg(transfer_id::arg());
-        let subcommand = creation_common::apply_common_payment_options(subcommand);
+        let subcommand = creation_common::apply_common_payment_options(subcommand, Some("2500000000"));
         creation_common::apply_common_creation_options(subcommand, true)
     }
 

--- a/src/deploy/transfer.rs
+++ b/src/deploy/transfer.rs
@@ -42,8 +42,8 @@ pub(super) mod target_account {
     const ARG_SHORT: char = 't';
     const ARG_VALUE_NAME: &str = "FORMATTED STRING";
     const ARG_HELP: &str =
-        "Account hash, uref or hex-encoded public key of the account from which the main purse will be used as the \
-        target";
+        "Account hash, uref or hex-encoded public key of the account from which the main purse \
+         will be used as the target";
 
     // Conflicts with --target-purse, but that's handled via an `ArgGroup` in the subcommand. Don't
     // add a `conflicts_with()` to the arg or the `ArgGroup` fails to work correctly.
@@ -115,7 +115,7 @@ impl ClientCommand for Transfer {
             subcommand,
             Some(common::DEFAULT_TRANSFER_PAYMENT_AMOUNT),
         );
-        creation_common::apply_common_creation_options(subcommand, true)
+        creation_common::apply_common_creation_options(subcommand, true, true)
     }
 
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
@@ -130,12 +130,12 @@ impl ClientCommand for Transfer {
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);
 
-        let secret_key = common::secret_key::get(matches);
+        let secret_key = common::secret_key::get(matches).unwrap_or_default();
         let maybe_speculative_exec = creation_common::speculative_exec::get(matches);
         let timestamp = creation_common::timestamp::get(matches);
         let ttl = creation_common::ttl::get(matches);
         let chain_name = creation_common::chain_name::get(matches);
-        let session_account = common::session_account::get(matches)?;
+        let session_account = creation_common::session_account::get(matches)?;
 
         let payment_str_params = creation_common::payment_str_params(matches);
 


### PR DESCRIPTION
CHANGELOG:

- Added an optional flag to retrieve finalized approvals for `info-get-deploy`

Sample output

```
casper-client get-deploy -n 'http://localhost:11104' 019686892b61c710d1da583efd87dca84a0c870150f70d4e273db0c1f2843974 --get-finalized-approvals -v
```

```
casper-client get-deploy -n http://localhost:11104 019686892b61c710d1da583efd87dca84a0c870150f70d4e273db0c1f2843974 -a -v
```

```
{
  "jsonrpc": "2.0",
  "method": "info_get_deploy",
  "params": {
    "deploy_hash": "019686892b61c710d1da583efd87dca84a0c870150f70d4e273db0c1f2843974",
    "finalized_approvals": true
  },
  "id": -8222935797003964137
}
```

Closes #58 