### PR TITLE
Provide purse identifier to generalize public key in get-account

### DIFF
--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -38,7 +38,7 @@ use serde::Serialize;
 use casper_hashing::Digest;
 #[cfg(doc)]
 use casper_types::{account::AccountHash, Key};
-use casper_types::{crypto, AsymmetricType, PublicKey, URef};
+use casper_types::URef;
 
 use crate::{
     rpcs::{
@@ -528,23 +528,19 @@ pub async fn get_account(
     node_address: &str,
     verbosity_level: u64,
     maybe_block_id: &str,
-    public_key: &str,
+    purse_id: &str,
 ) -> Result<SuccessResponse<GetAccountResult>, CliError> {
     let rpc_id = parse::rpc_id(maybe_rpc_id);
     let verbosity = parse::verbosity(verbosity_level);
     let maybe_block_id = parse::block_identifier(maybe_block_id)?;
-    let account_identifier =
-        PublicKey::from_hex(public_key).map_err(|error| crate::Error::CryptoError {
-            context: "public key in get_account",
-            error: crypto::ErrorExt::from(error),
-        })?;
+    let purse_identifier = parse::purse_identifier(purse_id)?;
 
     crate::get_account(
         rpc_id,
         node_address,
         verbosity,
         maybe_block_id,
-        account_identifier,
+        purse_identifier,
     )
     .await
     .map_err(CliError::from)

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -14,8 +14,9 @@ use casper_types::{
 
 use super::{simple_args, CliError, PaymentStrParams, SessionStrParams};
 use crate::{
+    rpcs::common::PurseIdentifier, 
     types::{BlockHash, DeployHash, ExecutableDeployItem, TimeDiff, Timestamp},
-    BlockIdentifier, GlobalStateIdentifier, JsonRpcId, OutputKind, PurseIdentifier, Verbosity,
+    BlockIdentifier, GlobalStateIdentifier, JsonRpcId, OutputKind, Verbosity,
 };
 
 pub(super) fn rpc_id(maybe_rpc_id: &str) -> JsonRpcId {

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -57,14 +57,14 @@ use serde::Serialize;
 use casper_hashing::Digest;
 #[cfg(doc)]
 use casper_types::Transfer;
-use casper_types::{Key, PublicKey, SecretKey, URef};
+use casper_types::{Key, SecretKey, URef};
 
 pub use error::Error;
 use json_rpc::JsonRpcCall;
 pub use json_rpc::{JsonRpcId, SuccessResponse};
 pub use output_kind::OutputKind;
 use rpcs::{
-    common::{BlockIdentifier, GlobalStateIdentifier},
+    common::{BlockIdentifier, GlobalStateIdentifier, PurseIdentifier},
     results::{
         GetAccountResult, GetAuctionInfoResult, GetBalanceResult, GetBlockResult,
         GetBlockTransfersResult, GetChainspecResult, GetDeployResult, GetDictionaryItemResult,
@@ -89,7 +89,7 @@ use rpcs::{
         get_validator_changes::GET_VALIDATOR_CHANGES_METHOD,
         list_rpcs::LIST_RPCS_METHOD,
         put_deploy::{PutDeployParams, PUT_DEPLOY_METHOD},
-        query_balance::{PurseIdentifier, QueryBalanceParams, QUERY_BALANCE_METHOD},
+        query_balance::{QueryBalanceParams, QUERY_BALANCE_METHOD},
         query_global_state::{QueryGlobalStateParams, QUERY_GLOBAL_STATE_METHOD},
         speculative_exec::{SpeculativeExecParams, SPECULATIVE_EXEC_METHOD},
     },
@@ -370,9 +370,9 @@ pub async fn get_account(
     node_address: &str,
     verbosity: Verbosity,
     maybe_block_identifier: Option<BlockIdentifier>,
-    account_identifier: PublicKey,
+    purse_identifier: PurseIdentifier,
 ) -> Result<SuccessResponse<GetAccountResult>, Error> {
-    let params = GetAccountParams::new(account_identifier, maybe_block_identifier);
+    let params = GetAccountParams::new(purse_identifier, maybe_block_identifier);
     JsonRpcCall::new(rpc_id, node_address, verbosity)
         .send_request(GET_ACCOUNT_METHOD, Some(params))
         .await

--- a/lib/rpcs.rs
+++ b/lib/rpcs.rs
@@ -6,7 +6,7 @@ pub mod results;
 pub(crate) mod v1_4_5;
 /// RPCs provided by the v1.5.0 node.
 pub(crate) mod v1_5_0;
+pub use common::PurseIdentifier;
 pub use v1_5_0::{
-    get_dictionary_item::DictionaryItemIdentifier, query_balance::PurseIdentifier,
-    query_global_state::GlobalStateIdentifier,
+    get_dictionary_item::DictionaryItemIdentifier, query_global_state::GlobalStateIdentifier,
 };

--- a/lib/rpcs/common.rs
+++ b/lib/rpcs/common.rs
@@ -7,6 +7,7 @@ use crate::types::BlockHash;
 use serde::{Deserialize, Serialize};
 
 use casper_hashing::Digest;
+use casper_types::{account::AccountHash, PublicKey, URef};
 
 /// Enum of possible ways to identify a [`Block`].
 #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
@@ -31,3 +32,16 @@ pub enum GlobalStateIdentifier {
     /// Query using the state root hash.
     StateRootHash(Digest),
 }
+
+/// Identifier of a purse.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum PurseIdentifier {
+    /// The main purse of the account identified by this public key.
+    MainPurseUnderPublicKey(PublicKey),
+    /// The main purse of the account identified by this account hash.
+    MainPurseUnderAccountHash(AccountHash),
+    /// The purse identified by this URef.
+    PurseUref(URef),
+}
+

--- a/lib/rpcs/v1_4_5/get_account.rs
+++ b/lib/rpcs/v1_4_5/get_account.rs
@@ -4,22 +4,11 @@ use casper_types::{ProtocolVersion, PublicKey};
 
 use crate::{rpcs::common::BlockIdentifier, types::Account};
 
-pub(crate) const GET_ACCOUNT_METHOD: &str = "state_get_account_info";
-
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct GetAccountParams {
     public_key: PublicKey,
     block_identifier: Option<BlockIdentifier>,
-}
-
-impl GetAccountParams {
-    pub(crate) fn new(public_key: PublicKey, block_identifier: Option<BlockIdentifier>) -> Self {
-        GetAccountParams {
-            public_key,
-            block_identifier,
-        }
-    }
 }
 
 /// The `result` field of a successful JSON-RPC response to a `state_get_account_info` request.

--- a/lib/rpcs/v1_5_0.rs
+++ b/lib/rpcs/v1_5_0.rs
@@ -1,5 +1,6 @@
 //! The JSON-RPC request and response types at v1.5.0 of casper-node.
 
+pub(crate) mod get_account;
 pub(crate) mod get_chainspec;
 pub(crate) mod get_deploy;
 pub(crate) mod get_era_summary;
@@ -8,11 +9,6 @@ pub(crate) mod query_balance;
 pub(crate) mod speculative_exec;
 
 // The following RPCs are all unchanged from v1.4.5, so we just re-export them.
-
-pub(crate) mod get_account {
-    pub use crate::rpcs::v1_4_5::get_account::GetAccountResult;
-    pub(crate) use crate::rpcs::v1_4_5::get_account::{GetAccountParams, GET_ACCOUNT_METHOD};
-}
 
 pub(crate) mod get_auction_info {
     pub use crate::rpcs::v1_4_5::get_auction_info::GetAuctionInfoResult;

--- a/lib/rpcs/v1_5_0/get_account.rs
+++ b/lib/rpcs/v1_5_0/get_account.rs
@@ -1,0 +1,24 @@
+use serde::{Deserialize, Serialize};
+
+use crate::rpcs::common::{BlockIdentifier, PurseIdentifier};
+
+pub use crate::rpcs::v1_4_5::get_account::GetAccountResult;
+
+pub(crate) const GET_ACCOUNT_METHOD: &str = "state_get_account_info";
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct GetAccountParams {
+    purse_identifier: PurseIdentifier,
+    block_identifier: Option<BlockIdentifier>,
+}
+
+impl GetAccountParams {
+    pub(crate) fn new(purse_identifier: PurseIdentifier, block_identifier: Option<BlockIdentifier>) -> Self {
+        GetAccountParams {
+            purse_identifier,
+            block_identifier,
+        }
+    }
+}
+

--- a/lib/rpcs/v1_5_0/query_balance.rs
+++ b/lib/rpcs/v1_5_0/query_balance.rs
@@ -1,22 +1,10 @@
 use serde::{Deserialize, Serialize};
 
-use casper_types::{account::AccountHash, ProtocolVersion, PublicKey, URef, U512};
+use casper_types::{ProtocolVersion, U512};
 
-use crate::rpcs::common::GlobalStateIdentifier;
+use crate::rpcs::common::{GlobalStateIdentifier, PurseIdentifier};
 
 pub(crate) const QUERY_BALANCE_METHOD: &str = "query_balance";
-
-/// Identifier of a purse.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
-pub enum PurseIdentifier {
-    /// The main purse of the account identified by this public key.
-    MainPurseUnderPublicKey(PublicKey),
-    /// The main purse of the account identified by this account hash.
-    MainPurseUnderAccountHash(AccountHash),
-    /// The purse identified by this URef.
-    PurseUref(URef),
-}
 
 /// Params for "query_balance" RPC request.
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/get_account.rs
+++ b/src/get_account.rs
@@ -9,7 +9,6 @@ use crate::{command::ClientCommand, common, Success};
 
 /// Legacy name of command.
 const COMMAND_ALIAS: &str = "get-account-info";
-const PUBLIC_KEY_IS_REQUIRED: bool = true;
 
 pub struct GetAccount;
 
@@ -19,7 +18,7 @@ enum DisplayOrder {
     NodeAddress,
     RpcId,
     BlockIdentifier,
-    PublicKey,
+    PurseIdentifier,
 }
 
 #[async_trait]
@@ -41,9 +40,9 @@ impl ClientCommand for GetAccount {
                 DisplayOrder::BlockIdentifier as usize,
                 true,
             ))
-            .arg(common::public_key::arg(
-                DisplayOrder::PublicKey as usize,
-                PUBLIC_KEY_IS_REQUIRED,
+            .arg(common::purse_identifier::arg(
+                DisplayOrder::PurseIdentifier as usize,
+                true,
             ))
     }
 
@@ -52,14 +51,14 @@ impl ClientCommand for GetAccount {
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);
         let block_identifier = common::block_identifier::get(matches);
-        let public_key = common::public_key::get(matches, PUBLIC_KEY_IS_REQUIRED)?;
+        let purse_id = common::purse_identifier::get(matches)?;
 
         casper_client::cli::get_account(
             maybe_rpc_id,
             node_address,
             verbosity_level,
             block_identifier,
-            &public_key,
+            purse_id.as_str(),
         )
         .await
         .map(Success::from)


### PR DESCRIPTION
For this to work we should have

1. A change in casper-node ./node/src/components/rpc_server/rpcs/state.rs, where GetAccountInfoParams is defined, to handle the logic of a PurseIdentifier instead of a public key. 

2. Doc and maybe other changeto support a modified client api, and JSON rpc call, if we're changing state_get_acount_info, which is the JSONrpc call by get-account.

I've already made all of the changes in client, here for review. I don't know the process for getting the rest done.