### PR TITLE
Payment-amount is optional for both native transfers

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -9,6 +9,7 @@ pub const ARG_PATH: &str = "PATH";
 pub const ARG_HEX_STRING: &str = "HEX STRING";
 pub const ARG_STRING: &str = "STRING";
 pub const ARG_INTEGER: &str = "INTEGER";
+pub const DEFAULT_TRANSFER_PAYMENT_AMOUNT: &'static str = "2500000000";
 
 /// Handles the arg for whether verbose output is required or not.
 pub mod verbose {

--- a/src/common.rs
+++ b/src/common.rs
@@ -9,7 +9,7 @@ pub const ARG_PATH: &str = "PATH";
 pub const ARG_HEX_STRING: &str = "HEX STRING";
 pub const ARG_STRING: &str = "STRING";
 pub const ARG_INTEGER: &str = "INTEGER";
-pub const DEFAULT_TRANSFER_PAYMENT_AMOUNT: &'static str = "2500000000";
+pub const DEFAULT_TRANSFER_PAYMENT_AMOUNT: &str = "2500000000";
 
 /// Handles the arg for whether verbose output is required or not.
 pub mod verbose {

--- a/src/deploy/creation_common.rs
+++ b/src/deploy/creation_common.rs
@@ -598,7 +598,7 @@ pub(super) mod standard_payment_amount {
         The value is the 'amount' arg of the standard-payment contract. This arg is incompatible \
         with all other --payment-xxx args";
 
-    pub(in crate::deploy) fn arg() -> Arg {
+    pub(in crate::deploy) fn arg(maybe_default_value: Option<&str>) -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -606,6 +606,7 @@ pub(super) mod standard_payment_amount {
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
             .display_order(DisplayOrder::StandardPayment as usize)
+            .default_value(maybe_default_value.unwrap())
     }
 
     pub fn get(matches: &ArgMatches) -> Option<&str> {
@@ -680,9 +681,9 @@ pub(super) fn apply_common_session_options(subcommand: Command) -> Command {
         )
 }
 
-pub(crate) fn apply_common_payment_options(subcommand: Command) -> Command {
+pub(crate) fn apply_common_payment_options(subcommand: Command, default_amount: Option<&str>) -> Command {
     subcommand
-        .arg(standard_payment_amount::arg())
+        .arg(standard_payment_amount::arg(default_amount))
         .arg(payment_path::arg())
         .arg(payment_package_hash::arg())
         .arg(payment_package_name::arg())
@@ -711,7 +712,7 @@ pub(crate) fn apply_common_payment_options(subcommand: Command) -> Command {
                 .arg(payment_name::ARG_NAME)
                 .arg(show_simple_arg_examples::ARG_NAME)
                 .arg(show_json_args_examples::ARG_NAME)
-                .required(true),
+                .required(default_amount.is_some()),
         )
 }
 

--- a/src/deploy/creation_common.rs
+++ b/src/deploy/creation_common.rs
@@ -598,7 +598,7 @@ pub(super) mod standard_payment_amount {
         The value is the 'amount' arg of the standard-payment contract. This arg is incompatible \
         with all other --payment-xxx args";
 
-    pub(in crate::deploy) fn arg(maybe_default_value: Option<&'static str>) -> Arg {
+    pub(in crate::deploy) fn arg(default_value: Option<&'static str>) -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -606,7 +606,7 @@ pub(super) mod standard_payment_amount {
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
             .display_order(DisplayOrder::StandardPayment as usize)
-            .default_value(maybe_default_value)
+            .default_value(default_value)
     }
 
     pub fn get(matches: &ArgMatches) -> Option<&str> {

--- a/src/deploy/creation_common.rs
+++ b/src/deploy/creation_common.rs
@@ -598,7 +598,7 @@ pub(super) mod standard_payment_amount {
         The value is the 'amount' arg of the standard-payment contract. This arg is incompatible \
         with all other --payment-xxx args";
 
-    pub(in crate::deploy) fn arg(maybe_default_value: Option<&str>) -> Arg {
+    pub(in crate::deploy) fn arg(maybe_default_value: Option<&'static str>) -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
@@ -606,7 +606,7 @@ pub(super) mod standard_payment_amount {
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
             .display_order(DisplayOrder::StandardPayment as usize)
-            .default_value(maybe_default_value.unwrap())
+            .default_value(maybe_default_value)
     }
 
     pub fn get(matches: &ArgMatches) -> Option<&str> {
@@ -681,7 +681,7 @@ pub(super) fn apply_common_session_options(subcommand: Command) -> Command {
         )
 }
 
-pub(crate) fn apply_common_payment_options(subcommand: Command, default_amount: Option<&str>) -> Command {
+pub(crate) fn apply_common_payment_options(subcommand: Command, default_amount: Option<&'static str>) -> Command {
     subcommand
         .arg(standard_payment_amount::arg(default_amount))
         .arg(payment_path::arg())
@@ -712,7 +712,7 @@ pub(crate) fn apply_common_payment_options(subcommand: Command, default_amount: 
                 .arg(payment_name::ARG_NAME)
                 .arg(show_simple_arg_examples::ARG_NAME)
                 .arg(show_json_args_examples::ARG_NAME)
-                .required(default_amount.is_some()),
+                .required(default_amount.is_none()),
         )
 }
 

--- a/src/deploy/creation_common.rs
+++ b/src/deploy/creation_common.rs
@@ -681,7 +681,10 @@ pub(super) fn apply_common_session_options(subcommand: Command) -> Command {
         )
 }
 
-pub(crate) fn apply_common_payment_options(subcommand: Command, default_amount: Option<&'static str>) -> Command {
+pub(crate) fn apply_common_payment_options(
+    subcommand: Command,
+    default_amount: Option<&'static str>,
+) -> Command {
     subcommand
         .arg(standard_payment_amount::arg(default_amount))
         .arg(payment_path::arg())

--- a/src/deploy/make.rs
+++ b/src/deploy/make.rs
@@ -26,7 +26,7 @@ impl ClientCommand for MakeDeploy {
             ))
             .display_order(display_order);
         let subcommand = creation_common::apply_common_session_options(subcommand);
-        let subcommand = creation_common::apply_common_payment_options(subcommand);
+        let subcommand = creation_common::apply_common_payment_options(subcommand, None);
         creation_common::apply_common_creation_options(subcommand, false)
     }
 

--- a/src/deploy/make_transfer.rs
+++ b/src/deploy/make_transfer.rs
@@ -28,7 +28,7 @@ impl ClientCommand for MakeTransfer {
                 creation_common::DisplayOrder::Force as usize,
                 true,
             ));
-        let subcommand = creation_common::apply_common_payment_options(subcommand, Some("2500"));
+        let subcommand = creation_common::apply_common_payment_options(subcommand, Some("2500000000"));
         creation_common::apply_common_creation_options(subcommand, false)
     }
 

--- a/src/deploy/make_transfer.rs
+++ b/src/deploy/make_transfer.rs
@@ -28,7 +28,10 @@ impl ClientCommand for MakeTransfer {
                 creation_common::DisplayOrder::Force as usize,
                 true,
             ));
-        let subcommand = creation_common::apply_common_payment_options(subcommand, Some("2500000000"));
+        let subcommand = creation_common::apply_common_payment_options(
+            subcommand,
+            Some(common::DEFAULT_TRANSFER_PAYMENT_AMOUNT),
+        );
         creation_common::apply_common_creation_options(subcommand, false)
     }
 

--- a/src/deploy/make_transfer.rs
+++ b/src/deploy/make_transfer.rs
@@ -28,7 +28,7 @@ impl ClientCommand for MakeTransfer {
                 creation_common::DisplayOrder::Force as usize,
                 true,
             ));
-        let subcommand = creation_common::apply_common_payment_options(subcommand);
+        let subcommand = creation_common::apply_common_payment_options(subcommand, Some("2500"));
         creation_common::apply_common_creation_options(subcommand, false)
     }
 

--- a/src/deploy/put.rs
+++ b/src/deploy/put.rs
@@ -21,7 +21,7 @@ impl ClientCommand for PutDeploy {
             .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
             .arg(creation_common::speculative_exec::arg());
         let subcommand = creation_common::apply_common_session_options(subcommand);
-        let subcommand = creation_common::apply_common_payment_options(subcommand);
+        let subcommand = creation_common::apply_common_payment_options(subcommand, None);
         creation_common::apply_common_creation_options(subcommand, true)
     }
 

--- a/src/deploy/transfer.rs
+++ b/src/deploy/transfer.rs
@@ -111,7 +111,10 @@ impl ClientCommand for Transfer {
             .arg(amount::arg())
             .arg(target_account::arg())
             .arg(transfer_id::arg());
-        let subcommand = creation_common::apply_common_payment_options(subcommand, Some("2500000000"));
+        let subcommand = creation_common::apply_common_payment_options(
+            subcommand,
+            Some(common::DEFAULT_TRANSFER_PAYMENT_AMOUNT),
+        );
         creation_common::apply_common_creation_options(subcommand, true)
     }
 

--- a/src/deploy/transfer.rs
+++ b/src/deploy/transfer.rs
@@ -111,7 +111,7 @@ impl ClientCommand for Transfer {
             .arg(amount::arg())
             .arg(target_account::arg())
             .arg(transfer_id::arg());
-        let subcommand = creation_common::apply_common_payment_options(subcommand);
+        let subcommand = creation_common::apply_common_payment_options(subcommand, Some("2500000000"));
         creation_common::apply_common_creation_options(subcommand, true)
     }
 


### PR DESCRIPTION
Constant value of payment amount (`2500000000` motes) is now default value for both `transfer` and `make-transfer` subcommands.

When the `default_value` argument is not passed to `standard_payment_amount()` function it will automatically make `--payment-amount` required (so it works as before in `make-deploy` and `put-deploy`)