### PR TITLE
Removing wildcard dependencies to allow cargo publish.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ doc = false
 async-trait = "0.1.59"
 base16 = "0.2.1"
 base64 = "0.13.1"
-casper-hashing = "*"
-casper-types = { version = "*", features = ["std"] }
+casper-hashing = "2.0.0"
+casper-types = { version = "3.0.0", features = ["std"] }
 clap = { version = "4", features = ["cargo", "deprecated", "wrap_help"] }
 clap_complete = "4"
 derp = "0.0.14"


### PR DESCRIPTION
We cannot have '*' as dependency versions in Cargo.toml and publish to crates.io.  Replaced casper-hashing and casper-types.