### PR TITLE
Add flag to get finalized approvals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Added
 * Add support for crafting unsigned deploys and transfers by providing an account, but not seccret key, to the `make-deploy` and `make-transfer` subcommands.
-
+* Added an optional flag to retrieve finalized approvals for `info_get_deploy`
 
 
 ## [2.0.0] - 2023-06-28

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -307,9 +307,15 @@ pub async fn get_deploy(
     let rpc_id = parse::rpc_id(maybe_rpc_id);
     let verbosity = parse::verbosity(verbosity_level);
     let deploy_hash = parse::deploy_hash(deploy_hash)?;
-    crate::get_deploy(rpc_id, node_address, verbosity, deploy_hash, finalized_approvals)
-        .await
-        .map_err(CliError::from)
+    crate::get_deploy(
+        rpc_id,
+        node_address,
+        verbosity,
+        deploy_hash,
+        finalized_approvals,
+    )
+    .await
+    .map_err(CliError::from)
 }
 
 /// Retrieves a [`Block`] from the network.

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -302,11 +302,12 @@ pub async fn get_deploy(
     node_address: &str,
     verbosity_level: u64,
     deploy_hash: &str,
+    finalized_approvals: bool,
 ) -> Result<SuccessResponse<GetDeployResult>, CliError> {
     let rpc_id = parse::rpc_id(maybe_rpc_id);
     let verbosity = parse::verbosity(verbosity_level);
     let deploy_hash = parse::deploy_hash(deploy_hash)?;
-    crate::get_deploy(rpc_id, node_address, verbosity, deploy_hash, false)
+    crate::get_deploy(rpc_id, node_address, verbosity, deploy_hash, finalized_approvals)
         .await
         .map_err(CliError::from)
 }

--- a/src/deploy/get.rs
+++ b/src/deploy/get.rs
@@ -15,6 +15,7 @@ enum DisplayOrder {
     NodeAddress,
     RpcId,
     DeployHash,
+    FinalizedApprovals
 }
 
 /// Handles providing the arg for and retrieval of the deploy hash.
@@ -41,6 +42,31 @@ mod deploy_hash {
     }
 }
 
+/// Handles providing the arg for the retrieval of the finalized approvals.
+mod finalized_approvals {
+    use super::*;
+
+    const ARG_NAME: &str = "get-finalized-approvals";
+    const ARG_VALUE_NAME: &str = "BOOLEAN";
+    const ARG_HELP: &str = "An optional flag specifying whether the finalized approvals are retrieved";
+
+    pub(super) fn arg() -> Arg {
+        Arg::new(ARG_NAME)
+            .required(false)
+            .value_name(ARG_VALUE_NAME)
+            .help(ARG_HELP)
+            .display_order(DisplayOrder::FinalizedApprovals as usize)
+    }
+
+    pub(super) fn get(matches: &ArgMatches) -> bool {
+        matches
+            .get_one::<bool>(ARG_NAME)
+            .copied()
+            .unwrap_or_default()
+    }
+
+}
+
 #[async_trait]
 impl ClientCommand for GetDeploy {
     const NAME: &'static str = "get-deploy";
@@ -56,6 +82,7 @@ impl ClientCommand for GetDeploy {
             ))
             .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
             .arg(deploy_hash::arg())
+            .arg(finalized_approvals::arg())
     }
 
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
@@ -63,8 +90,9 @@ impl ClientCommand for GetDeploy {
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);
         let deploy_hash = deploy_hash::get(matches);
+        let finalized_approvals = finalized_approvals::get(matches);
 
-        casper_client::cli::get_deploy(maybe_rpc_id, node_address, verbosity_level, deploy_hash)
+        casper_client::cli::get_deploy(maybe_rpc_id, node_address, verbosity_level, deploy_hash, finalized_approvals)
             .await
             .map(Success::from)
     }

--- a/src/deploy/get.rs
+++ b/src/deploy/get.rs
@@ -48,16 +48,16 @@ mod finalized_approvals {
 
     const ARG_NAME: &str = "get-finalized-approvals";
     const ARG_SHORT: char = 'a';
-    const ARG_VALUE_NAME: &str = "BOOLEAN";
     const ARG_HELP: &str =
-        "An optional flag specifying whether the finalized approvals are retrieved";
+        "If passed, the returned deploy approvals are the ones finalized in the block.\
+         Otherwise the approvals attached to the deploy when first received by the node \
+         will be returned";
 
     pub(super) fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
             .required(false)
-            .value_name(ARG_VALUE_NAME)
             .action(ArgAction::SetTrue)
             .help(ARG_HELP)
             .display_order(DisplayOrder::FinalizedApprovals as usize)

--- a/src/deploy/get.rs
+++ b/src/deploy/get.rs
@@ -1,7 +1,7 @@
 use std::str;
 
 use async_trait::async_trait;
-use clap::{Arg, ArgMatches, Command, ArgAction};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 
 use casper_client::cli::CliError;
 
@@ -15,7 +15,7 @@ enum DisplayOrder {
     NodeAddress,
     RpcId,
     DeployHash,
-    FinalizedApprovals
+    FinalizedApprovals,
 }
 
 /// Handles providing the arg for and retrieval of the deploy hash.
@@ -49,7 +49,8 @@ mod finalized_approvals {
     const ARG_NAME: &str = "get-finalized-approvals";
     const ARG_SHORT: char = 'a';
     const ARG_VALUE_NAME: &str = "BOOLEAN";
-    const ARG_HELP: &str = "An optional flag specifying whether the finalized approvals are retrieved";
+    const ARG_HELP: &str =
+        "An optional flag specifying whether the finalized approvals are retrieved";
 
     pub(super) fn arg() -> Arg {
         Arg::new(ARG_NAME)
@@ -68,7 +69,6 @@ mod finalized_approvals {
             .copied()
             .unwrap_or_default()
     }
-
 }
 
 #[async_trait]
@@ -96,8 +96,14 @@ impl ClientCommand for GetDeploy {
         let deploy_hash = deploy_hash::get(matches);
         let finalized_approvals = finalized_approvals::get(matches);
 
-        casper_client::cli::get_deploy(maybe_rpc_id, node_address, verbosity_level, deploy_hash, finalized_approvals)
-            .await
-            .map(Success::from)
+        casper_client::cli::get_deploy(
+            maybe_rpc_id,
+            node_address,
+            verbosity_level,
+            deploy_hash,
+            finalized_approvals,
+        )
+        .await
+        .map(Success::from)
     }
 }

--- a/src/deploy/get.rs
+++ b/src/deploy/get.rs
@@ -1,7 +1,7 @@
 use std::str;
 
 use async_trait::async_trait;
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgMatches, Command, ArgAction};
 
 use casper_client::cli::CliError;
 
@@ -47,13 +47,17 @@ mod finalized_approvals {
     use super::*;
 
     const ARG_NAME: &str = "get-finalized-approvals";
+    const ARG_SHORT: char = 'a';
     const ARG_VALUE_NAME: &str = "BOOLEAN";
     const ARG_HELP: &str = "An optional flag specifying whether the finalized approvals are retrieved";
 
     pub(super) fn arg() -> Arg {
         Arg::new(ARG_NAME)
+            .long(ARG_NAME)
+            .short(ARG_SHORT)
             .required(false)
             .value_name(ARG_VALUE_NAME)
+            .action(ArgAction::SetTrue)
             .help(ARG_HELP)
             .display_order(DisplayOrder::FinalizedApprovals as usize)
     }


### PR DESCRIPTION
Original PR comment written by @darthsiroftardis 

CHANGELOG:

- Added an optional flag to retrieve finalized approvals for `info-get-deploy`

Sample output

```
casper-client get-deploy -n 'http://localhost:11104' 019686892b61c710d1da583efd87dca84a0c870150f70d4e273db0c1f2843974 --get-finalized-approvals -v
```

```
casper-client get-deploy -n http://localhost:11104 019686892b61c710d1da583efd87dca84a0c870150f70d4e273db0c1f2843974 -a -v
```

```
{
  "jsonrpc": "2.0",
  "method": "info_get_deploy",
  "params": {
    "deploy_hash": "019686892b61c710d1da583efd87dca84a0c870150f70d4e273db0c1f2843974",
    "finalized_approvals": true
  },
  "id": -8222935797003964137
}
```

Closes #58 

Additionally:

- Addressed previous PR feedback [here](https://github.com/casper-ecosystem/casper-client-rs/pull/76)
- Added changes to CHANGELOG.md