### PR TITLE
Transfers - extra session args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.  The format
 ## Unreleased
 
 ### Added
+* Support passing `--session-arg` into `make-transfer` and `transfer` subcommands.
 * Add support for crafting unsigned deploys and transfers by providing an account, but not seccret key, to the `make-deploy` and `make-transfer` subcommands.
 
 

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -205,7 +205,7 @@ pub async fn transfer(
     transfer_id: &str,
     deploy_params: DeployStrParams<'_>,
     payment_params: PaymentStrParams<'_>,
-    session_args: Option<RuntimeArgs>,
+    session_args: Vec<&str>,
 ) -> Result<SuccessResponse<PutDeployResult>, CliError> {
     let rpc_id = parse::rpc_id(maybe_rpc_id);
     let verbosity = parse::verbosity(verbosity_level);
@@ -246,7 +246,7 @@ pub async fn speculative_transfer(
     transfer_id: &str,
     deploy_params: DeployStrParams<'_>,
     payment_params: PaymentStrParams<'_>,
-    session_args: Option<RuntimeArgs>,
+    session_args: Vec<&str>,
 ) -> Result<SuccessResponse<SpeculativeExecResult>, CliError> {
     let rpc_id = parse::rpc_id(maybe_rpc_id);
     let verbosity = parse::verbosity(verbosity_level);
@@ -283,7 +283,7 @@ pub fn make_transfer(
     deploy_params: DeployStrParams<'_>,
     payment_params: PaymentStrParams<'_>,
     force: bool,
-    session_args: Option<RuntimeArgs>,
+    session_args: Vec<&str>,
 ) -> Result<(), CliError> {
     let output = parse::output_kind(maybe_output_path, force);
     let deploy = deploy::new_transfer(

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -258,7 +258,7 @@ pub async fn speculative_transfer(
         deploy_params,
         payment_params,
         false,
-        session_args
+        session_args,
     )?;
     let speculative_exec = parse::block_identifier(maybe_block_id)?;
     crate::speculative_exec(rpc_id, node_address, speculative_exec, verbosity, deploy)

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -38,7 +38,7 @@ use serde::Serialize;
 use casper_hashing::Digest;
 #[cfg(doc)]
 use casper_types::{account::AccountHash, Key};
-use casper_types::{crypto, AsymmetricType, PublicKey, URef};
+use casper_types::{crypto, AsymmetricType, PublicKey, URef, RuntimeArgs};
 
 use crate::{
     rpcs::{
@@ -205,6 +205,7 @@ pub async fn transfer(
     transfer_id: &str,
     deploy_params: DeployStrParams<'_>,
     payment_params: PaymentStrParams<'_>,
+    session_args: Option<RuntimeArgs>,
 ) -> Result<SuccessResponse<PutDeployResult>, CliError> {
     let rpc_id = parse::rpc_id(maybe_rpc_id);
     let verbosity = parse::verbosity(verbosity_level);
@@ -216,6 +217,7 @@ pub async fn transfer(
         deploy_params,
         payment_params,
         false,
+        session_args,
     )?;
     crate::put_deploy(rpc_id, node_address, verbosity, deploy)
         .await
@@ -244,6 +246,7 @@ pub async fn speculative_transfer(
     transfer_id: &str,
     deploy_params: DeployStrParams<'_>,
     payment_params: PaymentStrParams<'_>,
+    session_args: Option<RuntimeArgs>,
 ) -> Result<SuccessResponse<SpeculativeExecResult>, CliError> {
     let rpc_id = parse::rpc_id(maybe_rpc_id);
     let verbosity = parse::verbosity(verbosity_level);
@@ -255,6 +258,7 @@ pub async fn speculative_transfer(
         deploy_params,
         payment_params,
         false,
+        session_args
     )?;
     let speculative_exec = parse::block_identifier(maybe_block_id)?;
     crate::speculative_exec(rpc_id, node_address, speculative_exec, verbosity, deploy)
@@ -279,6 +283,7 @@ pub fn make_transfer(
     deploy_params: DeployStrParams<'_>,
     payment_params: PaymentStrParams<'_>,
     force: bool,
+    session_args: Option<RuntimeArgs>,
 ) -> Result<(), CliError> {
     let output = parse::output_kind(maybe_output_path, force);
     let deploy = deploy::new_transfer(
@@ -289,6 +294,7 @@ pub fn make_transfer(
         deploy_params,
         payment_params,
         true,
+        session_args,
     )?;
     crate::output_deploy(output, &deploy).map_err(CliError::from)
 }

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -38,7 +38,7 @@ use serde::Serialize;
 use casper_hashing::Digest;
 #[cfg(doc)]
 use casper_types::{account::AccountHash, Key};
-use casper_types::{crypto, AsymmetricType, PublicKey, URef, RuntimeArgs};
+use casper_types::{crypto, AsymmetricType, PublicKey, URef};
 
 use crate::{
     rpcs::{

--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -109,11 +109,17 @@ pub fn new_transfer(
     let ttl = parse::ttl(deploy_params.ttl)?;
     let maybe_session_account = parse::session_account(deploy_params.session_account)?;
 
-    let mut deploy_builder =
-        DeployBuilder::new_transfer(chain_name, amount, source_purse, target, maybe_transfer_id, session)
-            .with_payment(payment)
-            .with_timestamp(timestamp)
-            .with_ttl(ttl);
+    let mut deploy_builder = DeployBuilder::new_transfer(
+        chain_name,
+        amount,
+        source_purse,
+        target,
+        maybe_transfer_id,
+        session,
+    )
+    .with_payment(payment)
+    .with_timestamp(timestamp)
+    .with_ttl(ttl);
     if let Some(secret_key) = &maybe_secret_key {
         deploy_builder = deploy_builder.with_secret_key(secret_key);
     }

--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -62,7 +62,7 @@ pub fn new_transfer(
     deploy_params: DeployStrParams,
     payment_params: PaymentStrParams,
     allow_unsigned_deploy: bool,
-    session_args: Option<RuntimeArgs>,
+    session_args: Vec<&str>,
 ) -> Result<Deploy, CliError> {
     let chain_name = deploy_params.chain_name.to_string();
     let maybe_secret_key = if allow_unsigned_deploy && deploy_params.secret_key.is_empty() {
@@ -79,6 +79,7 @@ pub fn new_transfer(
         Some(parse::secret_key_from_file(deploy_params.secret_key)?)
     };
     let payment = parse::payment_executable_deploy_item(payment_params)?;
+    let session = parse::arg_simple::get(&session_args)?;
 
     let amount = U512::from_dec_str(amount).map_err(|err| CliError::FailedToParseUint {
         context: "new_transfer amount",
@@ -109,7 +110,7 @@ pub fn new_transfer(
     let maybe_session_account = parse::session_account(deploy_params.session_account)?;
 
     let mut deploy_builder =
-        DeployBuilder::new_transfer(chain_name, amount, source_purse, target, maybe_transfer_id, session_args)
+        DeployBuilder::new_transfer(chain_name, amount, source_purse, target, maybe_transfer_id, Some(session))
             .with_payment(payment)
             .with_timestamp(timestamp)
             .with_ttl(ttl);

--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -1,4 +1,4 @@
-use casper_types::{account::AccountHash, AsymmetricType, PublicKey, UIntParseError, URef, U512};
+use casper_types::{account::AccountHash, AsymmetricType, PublicKey, UIntParseError, URef, U512, RuntimeArgs};
 
 use super::{parse, CliError, DeployStrParams, PaymentStrParams, SessionStrParams};
 use crate::{
@@ -62,6 +62,7 @@ pub fn new_transfer(
     deploy_params: DeployStrParams,
     payment_params: PaymentStrParams,
     allow_unsigned_deploy: bool,
+    session_args: Option<RuntimeArgs>,
 ) -> Result<Deploy, CliError> {
     let chain_name = deploy_params.chain_name.to_string();
     let maybe_secret_key = if allow_unsigned_deploy && deploy_params.secret_key.is_empty() {
@@ -108,7 +109,7 @@ pub fn new_transfer(
     let maybe_session_account = parse::session_account(deploy_params.session_account)?;
 
     let mut deploy_builder =
-        DeployBuilder::new_transfer(chain_name, amount, source_purse, target, maybe_transfer_id)
+        DeployBuilder::new_transfer(chain_name, amount, source_purse, target, maybe_transfer_id, session_args)
             .with_payment(payment)
             .with_timestamp(timestamp)
             .with_ttl(ttl);

--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -1,4 +1,4 @@
-use casper_types::{account::AccountHash, AsymmetricType, PublicKey, UIntParseError, URef, U512, RuntimeArgs};
+use casper_types::{account::AccountHash, AsymmetricType, PublicKey, UIntParseError, URef, U512};
 
 use super::{parse, CliError, DeployStrParams, PaymentStrParams, SessionStrParams};
 use crate::{
@@ -79,7 +79,7 @@ pub fn new_transfer(
         Some(parse::secret_key_from_file(deploy_params.secret_key)?)
     };
     let payment = parse::payment_executable_deploy_item(payment_params)?;
-    let session = parse::arg_simple::get(&session_args)?;
+    let session = Some(parse::arg_simple::get(&session_args)?);
 
     let amount = U512::from_dec_str(amount).map_err(|err| CliError::FailedToParseUint {
         context: "new_transfer amount",
@@ -110,7 +110,7 @@ pub fn new_transfer(
     let maybe_session_account = parse::session_account(deploy_params.session_account)?;
 
     let mut deploy_builder =
-        DeployBuilder::new_transfer(chain_name, amount, source_purse, target, maybe_transfer_id, Some(session))
+        DeployBuilder::new_transfer(chain_name, amount, source_purse, target, maybe_transfer_id, session)
             .with_payment(payment)
             .with_timestamp(timestamp)
             .with_ttl(ttl);

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -85,7 +85,7 @@ pub(super) fn session_account(value: &str) -> Result<Option<PublicKey>, CliError
 }
 
 /// Handles providing the arg for and retrieval of simple session and payment args.
-mod arg_simple {
+pub mod arg_simple {
     use super::*;
 
     pub(crate) mod session {
@@ -112,7 +112,7 @@ mod arg_simple {
         }
     }
 
-    fn get(values: &[&str]) -> Result<RuntimeArgs, CliError> {
+    pub fn get(values: &[&str]) -> Result<RuntimeArgs, CliError> {
         let mut runtime_args = RuntimeArgs::new();
         for arg in values {
             simple_args::insert_arg(arg, &mut runtime_args)?;

--- a/lib/cli/tests.rs
+++ b/lib/cli/tests.rs
@@ -423,7 +423,7 @@ fn should_fail_to_create_transfer_with_no_secret_key_while_not_allowing_unsigned
         deploy_params,
         payment_params,
         false,
-        Vec::new()
+        Vec::new(),
     );
 
     assert!(transfer_deploy.is_err());

--- a/lib/cli/tests.rs
+++ b/lib/cli/tests.rs
@@ -225,6 +225,7 @@ fn should_create_transfer() {
         deploy_params(),
         PaymentStrParams::with_amount("100"),
         false,
+        Vec::new(),
     );
 
     assert!(transfer_deploy.is_ok());
@@ -244,6 +245,7 @@ fn should_create_transfer() {
         deploy_params(),
         PaymentStrParams::with_amount("100"),
         false,
+        Vec::new(),
     );
 
     assert!(transfer_deploy.is_ok());
@@ -262,6 +264,7 @@ fn should_create_transfer() {
         deploy_params(),
         PaymentStrParams::with_amount("100"),
         false,
+        Vec::new(),
     );
 
     assert!(transfer_deploy.is_ok());
@@ -281,6 +284,7 @@ fn should_fail_to_create_transfer_with_bad_args() {
         deploy_params(),
         PaymentStrParams::with_amount("100"),
         false,
+        Vec::new(),
     );
 
     println!("{:?}", transfer_deploy);
@@ -345,6 +349,7 @@ fn should_create_unsigned_transfer() {
         deploy_params_without_secret_key(),
         PaymentStrParams::with_amount("100"),
         true,
+        Vec::new(),
     )
     .unwrap();
     assert!(transfer_deploy.approvals().is_empty());
@@ -366,6 +371,7 @@ fn should_fail_to_create_transfer_without_account() {
         deploy_params_without_account(),
         PaymentStrParams::with_amount("100"),
         true,
+        Vec::new(),
     );
     assert!(transfer_deploy.is_err());
     assert!(matches!(
@@ -392,6 +398,7 @@ fn should_fail_to_create_transfer_with_no_secret_key_while_not_allowing_unsigned
         deploy_params,
         payment_params,
         false,
+        Vec::new()
     );
 
     assert!(transfer_deploy.is_err());

--- a/lib/cli/tests.rs
+++ b/lib/cli/tests.rs
@@ -275,6 +275,31 @@ fn should_create_transfer() {
 }
 
 #[test]
+fn should_create_transfer_with_custom_args() {
+    use casper_types::{AsymmetricType, PublicKey};
+
+    // with public key.
+    let secret_key = SecretKey::generate_ed25519().unwrap();
+    let public_key = PublicKey::from(&secret_key).to_hex();
+    let transfer_deploy = deploy::new_transfer(
+        "10000",
+        None,
+        &public_key,
+        "1",
+        deploy_params(),
+        PaymentStrParams::with_amount("100"),
+        false,
+        vec!["targetAccountHex:public_key='012bac1d0ff9240ff0b7b06d555815640497861619ca12583ddef434885416e69b'"],
+    );
+
+    assert!(transfer_deploy.is_ok());
+    assert!(matches!(
+        transfer_deploy.unwrap().session(),
+        ExecutableDeployItem::Transfer { .. }
+    ));
+}
+
+#[test]
 fn should_fail_to_create_transfer_with_bad_args() {
     let transfer_deploy = deploy::new_transfer(
         "10000",

--- a/lib/types/deploy.rs
+++ b/lib/types/deploy.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use casper_hashing::Digest;
 use casper_types::{
     bytesrepr::{self, ToBytes},
-    crypto, PublicKey, SecretKey, Signature, URef, U512, RuntimeArgs
+    crypto, PublicKey, RuntimeArgs, SecretKey, Signature, URef, U512,
 };
 
 use crate::{
@@ -421,10 +421,15 @@ impl<'a> DeployBuilder<'a> {
         maybe_source: Option<URef>,
         target: TransferTarget,
         maybe_transfer_id: Option<u64>,
-        maybe_args: Option<RuntimeArgs>
+        maybe_args: Option<RuntimeArgs>,
     ) -> Self {
-        let session =
-            ExecutableDeployItem::new_transfer(amount, maybe_source, target, maybe_transfer_id, maybe_args);
+        let session = ExecutableDeployItem::new_transfer(
+            amount,
+            maybe_source,
+            target,
+            maybe_transfer_id,
+            maybe_args,
+        );
         DeployBuilder::new(chain_name, session)
     }
 

--- a/lib/types/deploy.rs
+++ b/lib/types/deploy.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use casper_hashing::Digest;
 use casper_types::{
     bytesrepr::{self, ToBytes},
-    crypto, PublicKey, SecretKey, Signature, URef, U512,
+    crypto, PublicKey, SecretKey, Signature, URef, U512, RuntimeArgs
 };
 
 use crate::{
@@ -421,9 +421,10 @@ impl<'a> DeployBuilder<'a> {
         maybe_source: Option<URef>,
         target: TransferTarget,
         maybe_transfer_id: Option<u64>,
+        maybe_args: Option<RuntimeArgs>
     ) -> Self {
         let session =
-            ExecutableDeployItem::new_transfer(amount, maybe_source, target, maybe_transfer_id);
+            ExecutableDeployItem::new_transfer(amount, maybe_source, target, maybe_transfer_id, maybe_args);
         DeployBuilder::new(chain_name, session)
     }
 

--- a/lib/types/executable_deploy_item.rs
+++ b/lib/types/executable_deploy_item.rs
@@ -169,11 +169,11 @@ impl ExecutableDeployItem {
         maybe_source: Option<URef>,
         target: TransferTarget,
         maybe_transfer_id: Option<u64>,
-        maybe_args: Option<RuntimeArgs>
+        maybe_args: Option<RuntimeArgs>,
     ) -> Self {
         let mut args = match maybe_args {
             Some(x) => x,
-            None => RuntimeArgs::new()
+            None => RuntimeArgs::new(),
         };
         args.insert(TRANSFER_ARG_AMOUNT, amount.into())
             .expect("should serialize amount arg");

--- a/lib/types/executable_deploy_item.rs
+++ b/lib/types/executable_deploy_item.rs
@@ -169,8 +169,12 @@ impl ExecutableDeployItem {
         maybe_source: Option<URef>,
         target: TransferTarget,
         maybe_transfer_id: Option<u64>,
+        maybe_args: Option<RuntimeArgs>
     ) -> Self {
-        let mut args = RuntimeArgs::new();
+        let mut args = match maybe_args {
+            Some(x) => x,
+            None => RuntimeArgs::new()
+        };
         args.insert(TRANSFER_ARG_AMOUNT, amount.into())
             .expect("should serialize amount arg");
 

--- a/src/deploy/make_transfer.rs
+++ b/src/deploy/make_transfer.rs
@@ -68,6 +68,8 @@ impl ClientCommand for MakeTransfer {
             },
             payment_str_params,
             force,
+            // TODO: Fix
+            None,
         )
         .map(|_| {
             Success::Output(if maybe_output_path.is_empty() {

--- a/src/deploy/make_transfer.rs
+++ b/src/deploy/make_transfer.rs
@@ -27,11 +27,16 @@ impl ClientCommand for MakeTransfer {
             .arg(common::force::arg(
                 creation_common::DisplayOrder::Force as usize,
                 true,
-            ));
+            ))
+            .arg(creation_common::arg_simple::session::arg())
+            .arg(creation_common::args_json::session::arg())
+            .arg(creation_common::args_complex::session::arg());
+
         let subcommand = creation_common::apply_common_payment_options(
             subcommand,
             Some(common::DEFAULT_TRANSFER_PAYMENT_AMOUNT),
         );
+
         creation_common::apply_common_creation_options(subcommand, false, false)
     }
 

--- a/src/deploy/make_transfer.rs
+++ b/src/deploy/make_transfer.rs
@@ -48,6 +48,7 @@ impl ClientCommand for MakeTransfer {
         let target_account = transfer::target_account::get(matches);
         let transfer_id = transfer::transfer_id::get(matches);
 
+        let str_params = creation_common::arg_simple::session::get(matches);
         let secret_key = common::secret_key::get(matches).unwrap_or_default();
         let timestamp = creation_common::timestamp::get(matches);
         let ttl = creation_common::ttl::get(matches);
@@ -74,7 +75,7 @@ impl ClientCommand for MakeTransfer {
             payment_str_params,
             force,
             // TODO: Fix
-            None,
+            str_params,
         )
         .map(|_| {
             Success::Output(if maybe_output_path.is_empty() {

--- a/src/deploy/make_transfer.rs
+++ b/src/deploy/make_transfer.rs
@@ -74,7 +74,6 @@ impl ClientCommand for MakeTransfer {
             },
             payment_str_params,
             force,
-            // TODO: Fix
             str_params,
         )
         .map(|_| {

--- a/src/deploy/transfer.rs
+++ b/src/deploy/transfer.rs
@@ -17,7 +17,6 @@ pub(super) mod amount {
     pub(in crate::deploy) fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
-            .short(ARG_SHORT)
             .required_unless_present(creation_common::show_simple_arg_examples::ARG_NAME)
             .required_unless_present(creation_common::show_json_args_examples::ARG_NAME)
             .value_name(ARG_VALUE_NAME)
@@ -125,6 +124,7 @@ impl ClientCommand for Transfer {
         let target_account = target_account::get(matches);
         let transfer_id = transfer_id::get(matches);
 
+        let str_params = creation_common::arg_simple::session::get(matches);
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);
@@ -155,8 +155,7 @@ impl ClientCommand for Transfer {
                     session_account: &session_account,
                 },
                 payment_str_params,
-                // TODO: Fix
-                None
+                str_params,
             )
             .await
             .map(Success::from)
@@ -176,8 +175,7 @@ impl ClientCommand for Transfer {
                     session_account: &session_account,
                 },
                 payment_str_params,
-                // TODO: Fix
-                None
+                str_params,
             )
             .await
             .map(Success::from)

--- a/src/deploy/transfer.rs
+++ b/src/deploy/transfer.rs
@@ -156,6 +156,8 @@ impl ClientCommand for Transfer {
                     session_account: &session_account,
                 },
                 payment_str_params,
+                // TODO: Fix
+                None
             )
             .await
             .map(Success::from)
@@ -175,6 +177,8 @@ impl ClientCommand for Transfer {
                     session_account: &session_account,
                 },
                 payment_str_params,
+                // TODO: Fix
+                None
             )
             .await
             .map(Success::from)

--- a/src/deploy/transfer.rs
+++ b/src/deploy/transfer.rs
@@ -11,7 +11,6 @@ pub(super) mod amount {
     use super::*;
 
     const ARG_NAME: &str = "amount";
-    const ARG_SHORT: char = 'a';
     const ARG_VALUE_NAME: &str = "512-BIT INTEGER";
     const ARG_HELP: &str = "The number of motes to transfer";
 


### PR DESCRIPTION
For now it only supports `--session-arg` like mentioned in a [ticket](https://github.com/casper-ecosystem/casper-client-rs/issues/67). 

I would consider supporting also JSON or complex args but was not sure about this - that's why for now I made `parse::arg_simple::get` public and use it in `new_transfer` method. If we would like to support all of the types then I can add different layer of abstraction dedicated to extending `Transfer` args.