### PR TITLE
Update to match node change

### DIFF
--- a/lib/cli/error.rs
+++ b/lib/cli/error.rs
@@ -40,7 +40,7 @@ pub enum CliError {
         /// Contextual description of where this error occurred.
         context: &'static str,
         /// The actual error raised.
-        error: casper_types::account::FromStrError,
+        error: casper_types::addressable_entity::FromStrError,
     },
 
     /// Failed to parse a [`URef`] from a formatted string.


### PR DESCRIPTION
This PR fixes an issue caused after merging the latest node changes into the `2124-use-execution-journal` branch currently used in the patch section of the manifest.