### PR TITLE
Ignore RUSTSEC-2022-0093 temporarily

### DIFF
--- a/.github/workflows/ci-casper-client-rs.yml
+++ b/.github/workflows/ci-casper-client-rs.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: audit
+          args: --ignore RUSTSEC-2022-0093
 
       - name: Clippy
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
This new rustsec warning will need to be ignored until it is resolved in `casper-types`.