### PR TITLE
Account identifier

### DIFF
--- a/.github/workflows/ci-casper-client-rs.yml
+++ b/.github/workflows/ci-casper-client-rs.yml
@@ -38,7 +38,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: audit
-          args: --ignore RUSTSEC-2022-0093
 
       - name: Clippy
         uses: actions-rs/cargo@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.  The format
 ### Added
 * Add support for crafting unsigned deploys and transfers by providing an account, but not seccret key, to the `make-deploy` and `make-transfer` subcommands.
 * Added an optional flag to retrieve finalized approvals for `info_get_deploy`
+* Add support for providing an account identifier (public key, or account hash) for the `state_get_account_info` RPC method.
 
 
 ## [2.0.0] - 2023-06-28

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ async-trait = "0.1.59"
 base16 = "0.2.1"
 base64 = "0.13.1"
 casper-hashing = "2.0.0"
-casper-types = { version = "3.0.0", features = ["std"] }
+casper-types = { version = "3.0.0", features = ["std", "json-schema"] }
 clap = { version = "4", features = ["cargo", "deprecated", "wrap_help"] }
 clap_complete = "4"
 derp = "0.0.14"
@@ -55,7 +55,7 @@ vergen = { version = "7", default-features = false, features = ["git"] }
 
 [patch.crates-io]
 casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "release-1.5.0-rc.1" }
-casper-types = { git = "https://github.com/casper-network/casper-node", branch = "release-1.5.0-rc.1" }
+casper-types = { git = "https://github.com/casper-network/casper-node", branch = "release-1.5.0-rc.1"}
 
 [package.metadata.deb]
 features = ["vendored-openssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "casper-client"
 version = "2.0.0" # when updating, also update 'html_root_url' in lib.rs
-authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>",]
+authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>", "Zachary Showalter <zach@casperlabs.io>"]
 edition = "2021"
 description = "A client library and binary for interacting with the Casper network"
 documentation = "https://docs.rs/casper-client"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,40 +22,34 @@ doc = false
 [dependencies]
 async-trait = "0.1.59"
 base16 = "0.2.1"
-base64 = "0.13.1"
 casper-hashing = "2.0.0"
-casper-types = { version = "3.0.0", features = ["std", "json-schema"] }
+casper-types = { version = "3.0.0", features = ["std"] }
 clap = { version = "4", features = ["cargo", "deprecated", "wrap_help"] }
 clap_complete = "4"
-derp = "0.0.14"
-ed25519-dalek = { version = "1", default-features = false }
-getrandom = "0.2.10"
 hex-buffer-serde = "0.4.0"
 humantime = "2"
-itertools = "0.10.5"
+itertools = "0.11.0"
 jsonrpc-lite = "0.6.0"
-k256 = { version = "0.7.3", features = ["arithmetic", "ecdsa", "sha256", "zeroize", ] }
 num-traits = "0.2.15"
 once_cell = "1"
-pem = "1"
 rand = "0.8.5"
 reqwest = { version = "0.11.13", features = ["json"] }
 schemars = "0.8"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
-signature = "1"
-tempfile = "3"
-thiserror = "=1.0.34"
+thiserror = "1.0.34"
 tokio = { version = "1.23.0", features = ["macros", "net", "rt-multi-thread", "sync", "time", ]}
 uint = "0.9.4"
-untrusted = "0.9.0"
+
+[dev-dependencies]
+tempfile = "3.7.1"
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["git"] }
 
 [patch.crates-io]
-casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "release-1.5.0-rc.1" }
-casper-types = { git = "https://github.com/casper-network/casper-node", branch = "release-1.5.0-rc.1"}
+casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
+casper-types = { git = "https://github.com/casper-network/casper-node", branch = "dev"}
 
 [package.metadata.deb]
 features = ["vendored-openssl"]

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -36,9 +36,9 @@ mod tests;
 use serde::Serialize;
 
 use casper_hashing::Digest;
+use casper_types::URef;
 #[cfg(doc)]
 use casper_types::{account::AccountHash, Key};
-use casper_types::{URef};
 
 use crate::{
     rpcs::{

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -38,7 +38,7 @@ use serde::Serialize;
 use casper_hashing::Digest;
 #[cfg(doc)]
 use casper_types::{account::AccountHash, Key};
-use casper_types::{crypto, AsymmetricType, PublicKey, URef};
+use casper_types::{URef};
 
 use crate::{
     rpcs::{

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -55,6 +55,8 @@ use crate::{
 };
 #[cfg(doc)]
 use crate::{Account, Block, Deploy, Error, StoredValue, Transfer};
+#[cfg(doc)]
+use casper_types::PublicKey;
 pub use deploy_str_params::DeployStrParams;
 pub use dictionary_item_str_params::DictionaryItemStrParams;
 pub use error::CliError;

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -534,16 +534,12 @@ pub async fn get_account(
     node_address: &str,
     verbosity_level: u64,
     maybe_block_id: &str,
-    public_key: &str,
+    account_identifier: &str,
 ) -> Result<SuccessResponse<GetAccountResult>, CliError> {
     let rpc_id = parse::rpc_id(maybe_rpc_id);
     let verbosity = parse::verbosity(verbosity_level);
     let maybe_block_id = parse::block_identifier(maybe_block_id)?;
-    let account_identifier =
-        PublicKey::from_hex(public_key).map_err(|error| crate::Error::CryptoError {
-            context: "public key in get_account",
-            error: crypto::ErrorExt::from(error),
-        })?;
+    let account_identifier = parse::account_identifier(account_identifier)?;
 
     crate::get_account(
         rpc_id,

--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -39,7 +39,6 @@ pub fn with_payment_and_session(
         .with_ttl(ttl);
 
     if let Some(secret_key) = &maybe_secret_key {
-        println!("secret key: {:?}", secret_key);
         deploy_builder = deploy_builder.with_secret_key(secret_key);
     }
     if let Some(account) = maybe_session_account {

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -15,7 +15,8 @@ use casper_types::{
 use super::{simple_args, CliError, PaymentStrParams, SessionStrParams};
 use crate::{
     types::{BlockHash, DeployHash, ExecutableDeployItem, TimeDiff, Timestamp},
-    BlockIdentifier, GlobalStateIdentifier, JsonRpcId, OutputKind, PurseIdentifier, Verbosity, AccountIdentifier
+    AccountIdentifier, BlockIdentifier, GlobalStateIdentifier, JsonRpcId, OutputKind,
+    PurseIdentifier, Verbosity,
 };
 
 pub(super) fn rpc_id(maybe_rpc_id: &str) -> JsonRpcId {
@@ -776,26 +777,29 @@ pub(super) fn account_identifier(account_identifier: &str) -> Result<AccountIden
     const ACCOUNT_HASH_PREFIX: &str = "account-hash-";
 
     if account_identifier.is_empty() {
-           return Err(CliError::InvalidArgument {
+        return Err(CliError::InvalidArgument {
             context: "account_identifier",
-            error: "cannot be empty string".to_string()});
+            error: "cannot be empty string".to_string(),
+        });
     }
 
     if account_identifier.starts_with(ACCOUNT_HASH_PREFIX) {
-        let account_hash = AccountHash::from_formatted_str(account_identifier).map_err(|error| {
-            CliError::FailedToParseAccountHash {
-                context: "account_identifier",
-                error,
-            }
-        })?;
+        let account_hash =
+            AccountHash::from_formatted_str(account_identifier).map_err(|error| {
+                CliError::FailedToParseAccountHash {
+                    context: "account_identifier",
+                    error,
+                }
+            })?;
         return Ok(AccountIdentifier::AccountHash(account_hash));
     }
 
-    let public_key =
-        PublicKey::from_hex(account_identifier).map_err(|error| CliError::FailedToParsePublicKey {
+    let public_key = PublicKey::from_hex(account_identifier).map_err(|error| {
+        CliError::FailedToParsePublicKey {
             context: "account_identifier".to_string(),
             error,
-        })?;
+        }
+    })?;
     Ok(AccountIdentifier::PublicKey(public_key))
 }
 

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -1526,13 +1526,13 @@ mod tests {
             }
         }
     }
-    mod account_identifier{
-        use casper_types::account::AccountHash;
-        use crate::rpcs::v1_6_0::get_account::AccountIdentifier;
+
+    mod account_identifier {
         use super::*;
         #[test]
         pub fn should_parse_valid_account_hash() {
-            let account_hash = "account-hash-c029c14904b870e64c1d443d428c606740e82f341bea0f8542ca6494cef1383e";
+            let account_hash =
+                "account-hash-c029c14904b870e64c1d443d428c606740e82f341bea0f8542ca6494cef1383e";
             let parsed = account_identifier(account_hash).unwrap();
             let _expected = AccountHash::from_formatted_str(account_hash).unwrap();
             assert!(matches!(parsed, AccountIdentifier::AccountHash(_expected)));
@@ -1546,14 +1546,15 @@ mod tests {
         }
 
         #[test]
-        pub fn should_fail_to_parse_invalid_account_hash(){
+        pub fn should_fail_to_parse_invalid_account_hash() {
             //This is the account hash from above with several characters removed
-            let account_hash = "account-hash-c029c14904b870e1d443d428c606740e82f341bea0f8542ca6494cef1383e";
+            let account_hash =
+                "account-hash-c029c14904b870e1d443d428c606740e82f341bea0f8542ca6494cef1383e";
             let parsed = account_identifier(account_hash);
             assert!(parsed.is_err());
         }
         #[test]
-        pub fn should_fail_to_parse_invalid_public_key(){
+        pub fn should_fail_to_parse_invalid_public_key() {
             //This is the public key from above with several characters removed
             let public_key = "01567f0f205e83291312cd82988d66143d376cee7de904dd26054bbb69b3c80";
             let parsed = account_identifier(public_key);

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -770,6 +770,8 @@ pub(super) fn purse_identifier(purse_id: &str) -> Result<PurseIdentifier, CliErr
         })?;
     Ok(PurseIdentifier::MainPurseUnderPublicKey(public_key))
 }
+
+/// Add
 pub(super) fn account_identifier(account_identifier: &str) -> Result<AccountIdentifier, CliError> {
     const ACCOUNT_HASH_PREFIX: &str = "account-hash-";
 
@@ -794,7 +796,7 @@ pub(super) fn account_identifier(account_identifier: &str) -> Result<AccountIden
             context: "account_identifier".to_string(),
             error,
         })?;
-    return Ok(AccountIdentifier::PublicKey(public_key))
+    Ok(AccountIdentifier::PublicKey(public_key))
 }
 
 #[cfg(test)]

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -15,7 +15,7 @@ use casper_types::{
 use super::{simple_args, CliError, PaymentStrParams, SessionStrParams};
 use crate::{
     types::{BlockHash, DeployHash, ExecutableDeployItem, TimeDiff, Timestamp},
-    BlockIdentifier, GlobalStateIdentifier, JsonRpcId, OutputKind, PurseIdentifier, Verbosity,
+    BlockIdentifier, GlobalStateIdentifier, JsonRpcId, OutputKind, PurseIdentifier, Verbosity, AccountIdentifier
 };
 
 pub(super) fn rpc_id(maybe_rpc_id: &str) -> JsonRpcId {

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -1535,8 +1535,11 @@ mod tests {
             let account_hash =
                 "account-hash-c029c14904b870e64c1d443d428c606740e82f341bea0f8542ca6494cef1383e";
             let parsed = account_identifier(account_hash).unwrap();
+            //This lint should be re-enabled once this bug is fixed. Currently, clippy erroneously flags this variable as unused on both lines.
+            #[allow(unused_variables)]
             let expected = AccountHash::from_formatted_str(account_hash).unwrap();
-            assert!(matches!(parsed, AccountIdentifier::AccountHash(expected)));
+            //The _ should be removed from this statement once the above clippy bug is fixed.
+            assert!(matches!(parsed, AccountIdentifier::AccountHash(_expected)));
         }
 
         #[test]

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -1529,14 +1529,16 @@ mod tests {
 
     mod account_identifier {
         use super::*;
+
         #[test]
         pub fn should_parse_valid_account_hash() {
             let account_hash =
                 "account-hash-c029c14904b870e64c1d443d428c606740e82f341bea0f8542ca6494cef1383e";
             let parsed = account_identifier(account_hash).unwrap();
-            let _expected = AccountHash::from_formatted_str(account_hash).unwrap();
-            assert!(matches!(parsed, AccountIdentifier::AccountHash(_expected)));
+            let expected = AccountHash::from_formatted_str(account_hash).unwrap();
+            assert!(matches!(parsed, AccountIdentifier::AccountHash(expected)));
         }
+
         #[test]
         pub fn should_parse_valid_public_key() {
             let public_key = "01567f0f205e83291312cd82988d66143d376cee7de904dd2605d3f4bbb69b3c80";
@@ -1553,6 +1555,7 @@ mod tests {
             let parsed = account_identifier(account_hash);
             assert!(parsed.is_err());
         }
+
         #[test]
         pub fn should_fail_to_parse_invalid_public_key() {
             //This is the public key from above with several characters removed

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -770,6 +770,32 @@ pub(super) fn purse_identifier(purse_id: &str) -> Result<PurseIdentifier, CliErr
         })?;
     Ok(PurseIdentifier::MainPurseUnderPublicKey(public_key))
 }
+pub(super) fn account_identifier(account_identifier: &str) -> Result<AccountIdentifier, CliError> {
+    const ACCOUNT_HASH_PREFIX: &str = "account-hash-";
+
+    if account_identifier.is_empty() {
+           return Err(CliError::InvalidArgument {
+            context: "account_identifier",
+            error: "cannot be empty string".to_string()});
+    }
+
+    if account_identifier.starts_with(ACCOUNT_HASH_PREFIX) {
+        let account_hash = AccountHash::from_formatted_str(account_identifier).map_err(|error| {
+            CliError::FailedToParseAccountHash {
+                context: "account_identifier",
+                error,
+            }
+        })?;
+        return Ok(AccountIdentifier::AccountHash(account_hash));
+    }
+
+    let public_key =
+        PublicKey::from_hex(account_identifier).map_err(|error| CliError::FailedToParsePublicKey {
+            context: "account_identifier".to_string(),
+            error,
+        })?;
+    return Ok(AccountIdentifier::PublicKey(public_key))
+}
 
 #[cfg(test)]
 mod tests {

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -1535,19 +1535,16 @@ mod tests {
             let account_hash =
                 "account-hash-c029c14904b870e64c1d443d428c606740e82f341bea0f8542ca6494cef1383e";
             let parsed = account_identifier(account_hash).unwrap();
-            //This lint should be re-enabled once this bug is fixed. Currently, clippy erroneously flags this variable as unused on both lines.
-            #[allow(unused_variables)]
             let expected = AccountHash::from_formatted_str(account_hash).unwrap();
-            //The _ should be removed from this statement once the above clippy bug is fixed.
-            assert!(matches!(parsed, AccountIdentifier::AccountHash(_expected)));
+            assert_eq!(parsed, AccountIdentifier::AccountHash(expected));
         }
 
         #[test]
         pub fn should_parse_valid_public_key() {
             let public_key = "01567f0f205e83291312cd82988d66143d376cee7de904dd2605d3f4bbb69b3c80";
             let parsed = account_identifier(public_key).unwrap();
-            let _expected = PublicKey::from_hex(public_key).unwrap();
-            assert!(matches!(parsed, AccountIdentifier::PublicKey(_expected)));
+            let expected = PublicKey::from_hex(public_key).unwrap();
+            assert_eq!(parsed, AccountIdentifier::PublicKey(expected));
         }
 
         #[test]

--- a/lib/cli/tests.rs
+++ b/lib/cli/tests.rs
@@ -1,4 +1,4 @@
-use casper_types::SecretKey;
+use casper_types::{AsymmetricType, PublicKey, SecretKey};
 
 use crate::{
     types::{ExecutableDeployItem, MAX_SERIALIZED_SIZE_OF_DEPLOY},

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -73,7 +73,7 @@ use rpcs::{
         QueryBalanceResult, QueryGlobalStateResult, SpeculativeExecResult,
     },
     v1_5_0::{
-        get_account::{GetAccountParams, GET_ACCOUNT_METHOD},
+        get_account::{AccountIdentifier, GetAccountParams, GET_ACCOUNT_METHOD},
         get_auction_info::{GetAuctionInfoParams, GET_AUCTION_INFO_METHOD},
         get_balance::{GetBalanceParams, GET_BALANCE_METHOD},
         get_block::{GetBlockParams, GET_BLOCK_METHOD},
@@ -370,7 +370,7 @@ pub async fn get_account(
     node_address: &str,
     verbosity: Verbosity,
     maybe_block_identifier: Option<BlockIdentifier>,
-    account_identifier: PublicKey,
+    account_identifier: AccountIdentifier,
 ) -> Result<SuccessResponse<GetAccountResult>, Error> {
     let params = GetAccountParams::new(account_identifier, maybe_block_identifier);
     JsonRpcCall::new(rpc_id, node_address, verbosity)

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -72,7 +72,6 @@ use rpcs::{
         GetStateRootHashResult, GetValidatorChangesResult, ListRpcsResult, PutDeployResult,
         QueryBalanceResult, QueryGlobalStateResult, SpeculativeExecResult,
     },
-    v1_6_0::get_account::AccountIdentifier,
     v1_6_0::{
         get_account::{GetAccountParams, GET_ACCOUNT_METHOD},
         get_auction_info::{GetAuctionInfoParams, GET_AUCTION_INFO_METHOD},
@@ -94,6 +93,9 @@ use rpcs::{
         query_global_state::{QueryGlobalStateParams, QUERY_GLOBAL_STATE_METHOD},
         speculative_exec::{SpeculativeExecParams, SPECULATIVE_EXEC_METHOD},
     },
+    v1_6_0::{
+        get_account::AccountIdentifier,
+    },
     DictionaryItemIdentifier,
 };
 pub use transfer_target::TransferTarget;
@@ -102,6 +104,7 @@ use types::{Account, Block, StoredValue};
 use types::{Deploy, DeployHash, MAX_SERIALIZED_SIZE_OF_DEPLOY};
 pub use validation::ValidateResponseError;
 pub use verbosity::Verbosity;
+
 
 /// Puts a [`Deploy`] to the network for execution.
 ///

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -57,7 +57,7 @@ use serde::Serialize;
 use casper_hashing::Digest;
 #[cfg(doc)]
 use casper_types::Transfer;
-use casper_types::{Key, PublicKey, SecretKey, URef};
+use casper_types::{Key, SecretKey, URef};
 
 pub use error::Error;
 use json_rpc::JsonRpcCall;
@@ -72,8 +72,8 @@ use rpcs::{
         GetStateRootHashResult, GetValidatorChangesResult, ListRpcsResult, PutDeployResult,
         QueryBalanceResult, QueryGlobalStateResult, SpeculativeExecResult,
     },
-    v1_5_0::{
-        get_account::{AccountIdentifier, GetAccountParams, GET_ACCOUNT_METHOD},
+    v1_6_0::{
+        get_account::{GetAccountParams, GET_ACCOUNT_METHOD},
         get_auction_info::{GetAuctionInfoParams, GET_AUCTION_INFO_METHOD},
         get_balance::{GetBalanceParams, GET_BALANCE_METHOD},
         get_block::{GetBlockParams, GET_BLOCK_METHOD},
@@ -93,6 +93,9 @@ use rpcs::{
         query_global_state::{QueryGlobalStateParams, QUERY_GLOBAL_STATE_METHOD},
         speculative_exec::{SpeculativeExecParams, SPECULATIVE_EXEC_METHOD},
     },
+    v1_6_0::{
+        get_account::AccountIdentifier,
+    },
     DictionaryItemIdentifier,
 };
 pub use transfer_target::TransferTarget;
@@ -101,6 +104,7 @@ use types::{Account, Block, StoredValue};
 use types::{Deploy, DeployHash, MAX_SERIALIZED_SIZE_OF_DEPLOY};
 pub use validation::ValidateResponseError;
 pub use verbosity::Verbosity;
+
 
 /// Puts a [`Deploy`] to the network for execution.
 ///

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -72,9 +72,8 @@ use rpcs::{
         GetStateRootHashResult, GetValidatorChangesResult, ListRpcsResult, PutDeployResult,
         QueryBalanceResult, QueryGlobalStateResult, SpeculativeExecResult,
     },
-    v1_6_0::get_account::AccountIdentifier,
     v1_6_0::{
-        get_account::{GetAccountParams, GET_ACCOUNT_METHOD},
+        get_account::{AccountIdentifier, GetAccountParams, GET_ACCOUNT_METHOD},
         get_auction_info::{GetAuctionInfoParams, GET_AUCTION_INFO_METHOD},
         get_balance::{GetBalanceParams, GET_BALANCE_METHOD},
         get_block::{GetBlockParams, GET_BLOCK_METHOD},

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -72,6 +72,7 @@ use rpcs::{
         GetStateRootHashResult, GetValidatorChangesResult, ListRpcsResult, PutDeployResult,
         QueryBalanceResult, QueryGlobalStateResult, SpeculativeExecResult,
     },
+    v1_6_0::get_account::AccountIdentifier,
     v1_6_0::{
         get_account::{GetAccountParams, GET_ACCOUNT_METHOD},
         get_auction_info::{GetAuctionInfoParams, GET_AUCTION_INFO_METHOD},
@@ -93,9 +94,6 @@ use rpcs::{
         query_global_state::{QueryGlobalStateParams, QUERY_GLOBAL_STATE_METHOD},
         speculative_exec::{SpeculativeExecParams, SPECULATIVE_EXEC_METHOD},
     },
-    v1_6_0::{
-        get_account::AccountIdentifier,
-    },
     DictionaryItemIdentifier,
 };
 pub use transfer_target::TransferTarget;
@@ -104,7 +102,6 @@ use types::{Account, Block, StoredValue};
 use types::{Deploy, DeployHash, MAX_SERIALIZED_SIZE_OF_DEPLOY};
 pub use validation::ValidateResponseError;
 pub use verbosity::Verbosity;
-
 
 /// Puts a [`Deploy`] to the network for execution.
 ///

--- a/lib/rpcs.rs
+++ b/lib/rpcs.rs
@@ -6,6 +6,9 @@ pub mod results;
 pub(crate) mod v1_4_5;
 /// RPCs provided by the v1.5.0 node.
 pub(crate) mod v1_5_0;
+/// RPCs provided by the v1.6.0 node.
+pub(crate) mod v1_6_0;
+
 pub use v1_5_0::{
     get_dictionary_item::DictionaryItemIdentifier, query_balance::PurseIdentifier,
     query_global_state::GlobalStateIdentifier,

--- a/lib/rpcs/results.rs
+++ b/lib/rpcs/results.rs
@@ -1,30 +1,30 @@
 //! The various types constituting the `result` field of a successful JSON-RPC response.
 
-pub use super::v1_5_0::get_account::GetAccountResult;
-pub use super::v1_5_0::get_auction_info::GetAuctionInfoResult;
-pub use super::v1_5_0::get_balance::GetBalanceResult;
-pub use super::v1_5_0::get_block::GetBlockResult;
-pub use super::v1_5_0::get_block_transfers::GetBlockTransfersResult;
-pub use super::v1_5_0::get_chainspec::{ChainspecRawBytes, GetChainspecResult};
-pub use super::v1_5_0::get_deploy::GetDeployResult;
-pub use super::v1_5_0::get_dictionary_item::GetDictionaryItemResult;
-pub use super::v1_5_0::get_era_info::{EraSummary, GetEraInfoResult};
-pub use super::v1_5_0::get_era_summary::GetEraSummaryResult;
-pub use super::v1_5_0::get_node_status::{
+pub use super::v1_6_0::get_account::GetAccountResult;
+pub use super::v1_6_0::get_auction_info::GetAuctionInfoResult;
+pub use super::v1_6_0::get_balance::GetBalanceResult;
+pub use super::v1_6_0::get_block::GetBlockResult;
+pub use super::v1_6_0::get_block_transfers::GetBlockTransfersResult;
+pub use super::v1_6_0::get_chainspec::{ChainspecRawBytes, GetChainspecResult};
+pub use super::v1_6_0::get_deploy::GetDeployResult;
+pub use super::v1_6_0::get_dictionary_item::GetDictionaryItemResult;
+pub use super::v1_6_0::get_era_info::{EraSummary, GetEraInfoResult};
+pub use super::v1_6_0::get_era_summary::GetEraSummaryResult;
+pub use super::v1_6_0::get_node_status::{
     ActivationPoint, AvailableBlockRange, GetNodeStatusResult, MinimalBlockInfo, NextUpgrade,
     ReactorState,
 };
-pub use super::v1_5_0::get_peers::{GetPeersResult, PeerEntry};
-pub use super::v1_5_0::get_state_root_hash::GetStateRootHashResult;
-pub use super::v1_5_0::get_validator_changes::{
+pub use super::v1_6_0::get_peers::{GetPeersResult, PeerEntry};
+pub use super::v1_6_0::get_state_root_hash::GetStateRootHashResult;
+pub use super::v1_6_0::get_validator_changes::{
     GetValidatorChangesResult, ValidatorChange, ValidatorChangeInEra, ValidatorChanges,
 };
-pub use super::v1_5_0::list_rpcs::{
+pub use super::v1_6_0::list_rpcs::{
     Components, Example, ExampleParam, ExampleResult, ListRpcsResult, Method, OpenRpcContactField,
     OpenRpcInfoField, OpenRpcLicenseField, OpenRpcSchema, OpenRpcServerEntry, ResponseResult,
     SchemaParam,
 };
-pub use super::v1_5_0::put_deploy::PutDeployResult;
-pub use super::v1_5_0::query_balance::QueryBalanceResult;
-pub use super::v1_5_0::query_global_state::QueryGlobalStateResult;
-pub use super::v1_5_0::speculative_exec::SpeculativeExecResult;
+pub use super::v1_6_0::put_deploy::PutDeployResult;
+pub use super::v1_6_0::query_balance::QueryBalanceResult;
+pub use super::v1_6_0::query_global_state::QueryGlobalStateResult;
+pub use super::v1_6_0::speculative_exec::SpeculativeExecResult;

--- a/lib/rpcs/v1_4_5/get_account.rs
+++ b/lib/rpcs/v1_4_5/get_account.rs
@@ -21,8 +21,8 @@ pub enum AccountIdentifier {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct GetAccountParams {
-    ///The identifier of an Account.
-    account_identifier: AccountIdentifier,
+    ///The identifier of an Account. (named public key to match the JSON-RPC API)
+    public_key: AccountIdentifier,
     /// The block identifier.
     block_identifier: Option<BlockIdentifier>,
 }
@@ -30,7 +30,7 @@ pub(crate) struct GetAccountParams {
 impl GetAccountParams {
     pub(crate) fn new(account_identifier: AccountIdentifier, block_identifier: Option<BlockIdentifier>) -> Self {
         GetAccountParams {
-            account_identifier,
+            public_key: account_identifier,
             block_identifier,
         }
     }

--- a/lib/rpcs/v1_4_5/get_account.rs
+++ b/lib/rpcs/v1_4_5/get_account.rs
@@ -1,8 +1,8 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use casper_types::{ProtocolVersion, PublicKey};
 use casper_types::account::AccountHash;
+use casper_types::{ProtocolVersion, PublicKey};
 
 use crate::{rpcs::common::BlockIdentifier, types::Account};
 
@@ -28,7 +28,10 @@ pub(crate) struct GetAccountParams {
 }
 
 impl GetAccountParams {
-    pub(crate) fn new(account_identifier: AccountIdentifier, block_identifier: Option<BlockIdentifier>) -> Self {
+    pub(crate) fn new(
+        account_identifier: AccountIdentifier,
+        block_identifier: Option<BlockIdentifier>,
+    ) -> Self {
         GetAccountParams {
             public_key: account_identifier,
             block_identifier,

--- a/lib/rpcs/v1_4_5/get_account.rs
+++ b/lib/rpcs/v1_4_5/get_account.rs
@@ -1,22 +1,36 @@
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use casper_types::{ProtocolVersion, PublicKey};
+use casper_types::account::AccountHash;
 
 use crate::{rpcs::common::BlockIdentifier, types::Account};
 
 pub(crate) const GET_ACCOUNT_METHOD: &str = "state_get_account_info";
 
+/// Identifier of an account.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum AccountIdentifier {
+    /// The public key of an account
+    PublicKey(PublicKey),
+    /// The account hash of an account
+    AccountHash(AccountHash),
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct GetAccountParams {
-    public_key: PublicKey,
+    ///The identifier of an Account.
+    account_identifier: AccountIdentifier,
+    /// The block identifier.
     block_identifier: Option<BlockIdentifier>,
 }
 
 impl GetAccountParams {
-    pub(crate) fn new(public_key: PublicKey, block_identifier: Option<BlockIdentifier>) -> Self {
+    pub(crate) fn new(account_identifier: AccountIdentifier, block_identifier: Option<BlockIdentifier>) -> Self {
         GetAccountParams {
-            public_key,
+            account_identifier,
             block_identifier,
         }
     }

--- a/lib/rpcs/v1_4_5/get_account.rs
+++ b/lib/rpcs/v1_4_5/get_account.rs
@@ -10,7 +10,7 @@ pub(crate) const GET_ACCOUNT_METHOD: &str = "state_get_account_info";
 
 /// Identifier of an account.
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, untagged)]
 pub enum AccountIdentifier {
     /// The public key of an account
     PublicKey(PublicKey),

--- a/lib/rpcs/v1_5_0.rs
+++ b/lib/rpcs/v1_5_0.rs
@@ -11,7 +11,6 @@ pub(crate) mod speculative_exec;
 
 pub(crate) mod get_account {
     pub use crate::rpcs::v1_4_5::get_account::GetAccountResult;
-    pub(crate) use crate::rpcs::v1_4_5::get_account::{GetAccountParams, GET_ACCOUNT_METHOD};
 }
 
 pub(crate) mod get_auction_info {

--- a/lib/rpcs/v1_5_0.rs
+++ b/lib/rpcs/v1_5_0.rs
@@ -10,8 +10,7 @@ pub(crate) mod speculative_exec;
 // The following RPCs are all unchanged from v1.4.5, so we just re-export them.
 
 pub(crate) mod get_account {
-    pub use crate::rpcs::v1_4_5::get_account::GetAccountResult;
-    pub use crate::rpcs::v1_4_5::get_account::AccountIdentifier;
+    pub use crate::rpcs::v1_4_5::get_account::{GetAccountResult, AccountIdentifier};
     pub(crate) use crate::rpcs::v1_4_5::get_account::{GetAccountParams, GET_ACCOUNT_METHOD};
 }
 

--- a/lib/rpcs/v1_5_0.rs
+++ b/lib/rpcs/v1_5_0.rs
@@ -11,6 +11,7 @@ pub(crate) mod speculative_exec;
 
 pub(crate) mod get_account {
     pub use crate::rpcs::v1_4_5::get_account::GetAccountResult;
+    pub use crate::rpcs::v1_4_5::get_account::AccountIdentifier;
     pub(crate) use crate::rpcs::v1_4_5::get_account::{GetAccountParams, GET_ACCOUNT_METHOD};
 }
 

--- a/lib/rpcs/v1_5_0.rs
+++ b/lib/rpcs/v1_5_0.rs
@@ -10,7 +10,7 @@ pub(crate) mod speculative_exec;
 // The following RPCs are all unchanged from v1.4.5, so we just re-export them.
 
 pub(crate) mod get_account {
-    pub use crate::rpcs::v1_4_5::get_account::{GetAccountResult, AccountIdentifier};
+    pub use crate::rpcs::v1_4_5::get_account::GetAccountResult;
     pub(crate) use crate::rpcs::v1_4_5::get_account::{GetAccountParams, GET_ACCOUNT_METHOD};
 }
 

--- a/lib/rpcs/v1_6_0.rs
+++ b/lib/rpcs/v1_6_0.rs
@@ -1,0 +1,112 @@
+//! The JSON-RPC request and response types at v1.5.0 of casper-node.
+
+pub(crate) mod get_account{
+    pub(crate) use crate::rpcs::v1_5_0::get_account::{GetAccountParams, GET_ACCOUNT_METHOD};
+    pub use crate::rpcs::v1_4_5::get_account::{AccountIdentifier, GetAccountResult};
+}
+
+// The following RPCs are all unchanged from v1.5.0, so we just re-export them.
+
+pub(crate) mod get_chainspec{
+    pub(crate) use crate::rpcs::v1_5_0::get_chainspec::GET_CHAINSPEC_METHOD;
+}
+
+pub(crate) mod get_deploy{
+    pub(crate) use crate::rpcs::v1_5_0::get_deploy::{GetDeployParams, GET_DEPLOY_METHOD};
+}
+
+pub(crate) mod get_era_summary{
+    pub(crate) use crate::rpcs::v1_5_0::get_era_summary::{GetEraSummaryParams, GET_ERA_SUMMARY_METHOD};
+}
+
+pub(crate) mod get_node_status{
+    pub(crate) use crate::rpcs::v1_5_0::get_node_status::GET_NODE_STATUS_METHOD;
+}
+
+pub(crate) mod query_balance{
+    pub(crate) use crate::rpcs::v1_5_0::query_balance::{PurseIdentifier, QueryBalanceParams, QUERY_BALANCE_METHOD};
+}
+
+pub(crate) mod speculative_exec{
+    pub(crate) use crate::rpcs::v1_5_0::speculative_exec::{SpeculativeExecParams, SPECULATIVE_EXEC_METHOD};
+}
+
+pub(crate) mod get_auction_info {
+    pub use crate::rpcs::v1_5_0::get_auction_info::GetAuctionInfoResult;
+    pub(crate) use crate::rpcs::v1_5_0::get_auction_info::{
+        GetAuctionInfoParams, GET_AUCTION_INFO_METHOD,
+    };
+}
+
+pub(crate) mod get_balance {
+    pub use crate::rpcs::v1_5_0::get_balance::GetBalanceResult;
+    pub(crate) use crate::rpcs::v1_5_0::get_balance::{GetBalanceParams, GET_BALANCE_METHOD};
+}
+
+pub(crate) mod get_block {
+    pub use crate::rpcs::v1_5_0::get_block::GetBlockResult;
+    pub(crate) use crate::rpcs::v1_5_0::get_block::{GetBlockParams, GET_BLOCK_METHOD};
+}
+
+pub(crate) mod get_block_transfers {
+    pub use crate::rpcs::v1_5_0::get_block_transfers::GetBlockTransfersResult;
+    pub(crate) use crate::rpcs::v1_5_0::get_block_transfers::{
+        GetBlockTransfersParams, GET_BLOCK_TRANSFERS_METHOD,
+    };
+}
+
+pub(crate) mod get_dictionary_item {
+    pub use crate::rpcs::v1_5_0::get_dictionary_item::{
+        DictionaryItemIdentifier, GetDictionaryItemResult,
+    };
+    pub(crate) use crate::rpcs::v1_5_0::get_dictionary_item::{
+        GetDictionaryItemParams, GET_DICTIONARY_ITEM_METHOD,
+    };
+}
+
+pub(crate) mod get_era_info {
+    pub use crate::rpcs::v1_5_0::get_era_info::{EraSummary, GetEraInfoResult};
+    pub(crate) use crate::rpcs::v1_5_0::get_era_info::{GetEraInfoParams, GET_ERA_INFO_METHOD};
+}
+
+pub(crate) mod get_peers {
+    pub(crate) use crate::rpcs::v1_5_0::get_peers::GET_PEERS_METHOD;
+    pub use crate::rpcs::v1_5_0::get_peers::{GetPeersResult, PeerEntry};
+}
+
+pub(crate) mod get_state_root_hash {
+    pub use crate::rpcs::v1_5_0::get_state_root_hash::GetStateRootHashResult;
+    pub(crate) use crate::rpcs::v1_5_0::get_state_root_hash::{
+        GetStateRootHashParams, GET_STATE_ROOT_HASH_METHOD,
+    };
+}
+
+pub(crate) mod get_validator_changes {
+    pub(crate) use crate::rpcs::v1_5_0::get_validator_changes::GET_VALIDATOR_CHANGES_METHOD;
+    pub use crate::rpcs::v1_5_0::get_validator_changes::{
+        GetValidatorChangesResult, ValidatorChange, ValidatorChangeInEra, ValidatorChanges,
+    };
+}
+
+pub(crate) mod list_rpcs {
+    pub(crate) use crate::rpcs::v1_5_0::list_rpcs::LIST_RPCS_METHOD;
+    pub use crate::rpcs::v1_5_0::list_rpcs::{
+        Components, Example, ExampleParam, ExampleResult, ListRpcsResult, Method,
+        OpenRpcContactField, OpenRpcInfoField, OpenRpcLicenseField, OpenRpcSchema,
+        OpenRpcServerEntry, ResponseResult, SchemaParam,
+    };
+}
+
+pub(crate) mod put_deploy {
+    pub use crate::rpcs::v1_5_0::put_deploy::PutDeployResult;
+    pub(crate) use crate::rpcs::v1_5_0::put_deploy::{PutDeployParams, PUT_DEPLOY_METHOD};
+}
+
+pub(crate) mod query_global_state {
+    pub use crate::rpcs::v1_5_0::query_global_state::{
+        GlobalStateIdentifier, QueryGlobalStateResult,
+    };
+    pub(crate) use crate::rpcs::v1_5_0::query_global_state::{
+        QueryGlobalStateParams, QUERY_GLOBAL_STATE_METHOD,
+    };
+}

--- a/lib/rpcs/v1_6_0.rs
+++ b/lib/rpcs/v1_6_0.rs
@@ -1,34 +1,40 @@
 //! The JSON-RPC request and response types at v1.5.0 of casper-node.
 
-pub(crate) mod get_account{
-    pub(crate) use crate::rpcs::v1_5_0::get_account::{GetAccountParams, GET_ACCOUNT_METHOD};
+pub(crate) mod get_account {
     pub use crate::rpcs::v1_4_5::get_account::{AccountIdentifier, GetAccountResult};
+    pub(crate) use crate::rpcs::v1_5_0::get_account::{GetAccountParams, GET_ACCOUNT_METHOD};
 }
 
 // The following RPCs are all unchanged from v1.5.0, so we just re-export them.
 
-pub(crate) mod get_chainspec{
+pub(crate) mod get_chainspec {
     pub(crate) use crate::rpcs::v1_5_0::get_chainspec::GET_CHAINSPEC_METHOD;
 }
 
-pub(crate) mod get_deploy{
+pub(crate) mod get_deploy {
     pub(crate) use crate::rpcs::v1_5_0::get_deploy::{GetDeployParams, GET_DEPLOY_METHOD};
 }
 
-pub(crate) mod get_era_summary{
-    pub(crate) use crate::rpcs::v1_5_0::get_era_summary::{GetEraSummaryParams, GET_ERA_SUMMARY_METHOD};
+pub(crate) mod get_era_summary {
+    pub(crate) use crate::rpcs::v1_5_0::get_era_summary::{
+        GetEraSummaryParams, GET_ERA_SUMMARY_METHOD,
+    };
 }
 
-pub(crate) mod get_node_status{
+pub(crate) mod get_node_status {
     pub(crate) use crate::rpcs::v1_5_0::get_node_status::GET_NODE_STATUS_METHOD;
 }
 
-pub(crate) mod query_balance{
-    pub(crate) use crate::rpcs::v1_5_0::query_balance::{PurseIdentifier, QueryBalanceParams, QUERY_BALANCE_METHOD};
+pub(crate) mod query_balance {
+    pub(crate) use crate::rpcs::v1_5_0::query_balance::{
+        PurseIdentifier, QueryBalanceParams, QUERY_BALANCE_METHOD,
+    };
 }
 
-pub(crate) mod speculative_exec{
-    pub(crate) use crate::rpcs::v1_5_0::speculative_exec::{SpeculativeExecParams, SPECULATIVE_EXEC_METHOD};
+pub(crate) mod speculative_exec {
+    pub(crate) use crate::rpcs::v1_5_0::speculative_exec::{
+        SpeculativeExecParams, SPECULATIVE_EXEC_METHOD,
+    };
 }
 
 pub(crate) mod get_auction_info {

--- a/lib/rpcs/v1_6_0.rs
+++ b/lib/rpcs/v1_6_0.rs
@@ -1,40 +1,34 @@
 //! The JSON-RPC request and response types at v1.5.0 of casper-node.
 
-pub(crate) mod get_account {
-    pub use crate::rpcs::v1_4_5::get_account::{AccountIdentifier, GetAccountResult};
+pub(crate) mod get_account{
     pub(crate) use crate::rpcs::v1_5_0::get_account::{GetAccountParams, GET_ACCOUNT_METHOD};
+    pub use crate::rpcs::v1_4_5::get_account::{AccountIdentifier, GetAccountResult};
 }
 
 // The following RPCs are all unchanged from v1.5.0, so we just re-export them.
 
-pub(crate) mod get_chainspec {
+pub(crate) mod get_chainspec{
     pub(crate) use crate::rpcs::v1_5_0::get_chainspec::GET_CHAINSPEC_METHOD;
 }
 
-pub(crate) mod get_deploy {
+pub(crate) mod get_deploy{
     pub(crate) use crate::rpcs::v1_5_0::get_deploy::{GetDeployParams, GET_DEPLOY_METHOD};
 }
 
-pub(crate) mod get_era_summary {
-    pub(crate) use crate::rpcs::v1_5_0::get_era_summary::{
-        GetEraSummaryParams, GET_ERA_SUMMARY_METHOD,
-    };
+pub(crate) mod get_era_summary{
+    pub(crate) use crate::rpcs::v1_5_0::get_era_summary::{GetEraSummaryParams, GET_ERA_SUMMARY_METHOD};
 }
 
-pub(crate) mod get_node_status {
+pub(crate) mod get_node_status{
     pub(crate) use crate::rpcs::v1_5_0::get_node_status::GET_NODE_STATUS_METHOD;
 }
 
-pub(crate) mod query_balance {
-    pub(crate) use crate::rpcs::v1_5_0::query_balance::{
-        PurseIdentifier, QueryBalanceParams, QUERY_BALANCE_METHOD,
-    };
+pub(crate) mod query_balance{
+    pub(crate) use crate::rpcs::v1_5_0::query_balance::{PurseIdentifier, QueryBalanceParams, QUERY_BALANCE_METHOD};
 }
 
-pub(crate) mod speculative_exec {
-    pub(crate) use crate::rpcs::v1_5_0::speculative_exec::{
-        SpeculativeExecParams, SPECULATIVE_EXEC_METHOD,
-    };
+pub(crate) mod speculative_exec{
+    pub(crate) use crate::rpcs::v1_5_0::speculative_exec::{SpeculativeExecParams, SPECULATIVE_EXEC_METHOD};
 }
 
 pub(crate) mod get_auction_info {

--- a/lib/rpcs/v1_6_0.rs
+++ b/lib/rpcs/v1_6_0.rs
@@ -5,15 +5,13 @@ pub(crate) mod get_account;
 // The following RPCs are all unchanged from v1.5.0, so we just re-export them.
 
 pub(crate) mod get_chainspec {
-    pub(crate) use crate::rpcs::v1_5_0::get_chainspec::{GET_CHAINSPEC_METHOD};
+    pub(crate) use crate::rpcs::v1_5_0::get_chainspec::GET_CHAINSPEC_METHOD;
     pub use crate::rpcs::v1_5_0::get_chainspec::{ChainspecRawBytes, GetChainspecResult};
 }
 
 pub(crate) mod get_deploy {
-    pub(crate) use crate::rpcs::v1_5_0::get_deploy::{
-        GetDeployParams, GET_DEPLOY_METHOD,
-    };
-    pub use crate::rpcs::v1_5_0::get_deploy::{GetDeployResult};
+    pub use crate::rpcs::v1_5_0::get_deploy::GetDeployResult;
+    pub(crate) use crate::rpcs::v1_5_0::get_deploy::{GetDeployParams, GET_DEPLOY_METHOD};
 }
 
 pub(crate) mod get_era_summary {

--- a/lib/rpcs/v1_6_0.rs
+++ b/lib/rpcs/v1_6_0.rs
@@ -1,21 +1,23 @@
 //! The JSON-RPC request and response types at v1.5.0 of casper-node.
 
-pub(crate) mod get_account {
-    pub use crate::rpcs::v1_4_5::get_account::{AccountIdentifier, GetAccountResult};
-    pub(crate) use crate::rpcs::v1_5_0::get_account::{GetAccountParams, GET_ACCOUNT_METHOD};
-}
+pub(crate) mod get_account;
 
 // The following RPCs are all unchanged from v1.5.0, so we just re-export them.
 
 pub(crate) mod get_chainspec {
-    pub(crate) use crate::rpcs::v1_5_0::get_chainspec::GET_CHAINSPEC_METHOD;
+    pub(crate) use crate::rpcs::v1_5_0::get_chainspec::{GET_CHAINSPEC_METHOD};
+    pub use crate::rpcs::v1_5_0::get_chainspec::{ChainspecRawBytes, GetChainspecResult};
 }
 
 pub(crate) mod get_deploy {
-    pub(crate) use crate::rpcs::v1_5_0::get_deploy::{GetDeployParams, GET_DEPLOY_METHOD};
+    pub(crate) use crate::rpcs::v1_5_0::get_deploy::{
+        GetDeployParams, GET_DEPLOY_METHOD,
+    };
+    pub use crate::rpcs::v1_5_0::get_deploy::{GetDeployResult};
 }
 
 pub(crate) mod get_era_summary {
+    pub use crate::rpcs::v1_5_0::get_era_summary::GetEraSummaryResult;
     pub(crate) use crate::rpcs::v1_5_0::get_era_summary::{
         GetEraSummaryParams, GET_ERA_SUMMARY_METHOD,
     };
@@ -23,15 +25,21 @@ pub(crate) mod get_era_summary {
 
 pub(crate) mod get_node_status {
     pub(crate) use crate::rpcs::v1_5_0::get_node_status::GET_NODE_STATUS_METHOD;
+    pub use crate::rpcs::v1_5_0::get_node_status::{
+        ActivationPoint, AvailableBlockRange, GetNodeStatusResult, MinimalBlockInfo, NextUpgrade,
+        ReactorState,
+    };
 }
 
 pub(crate) mod query_balance {
+    pub use crate::rpcs::v1_5_0::query_balance::QueryBalanceResult;
     pub(crate) use crate::rpcs::v1_5_0::query_balance::{
         PurseIdentifier, QueryBalanceParams, QUERY_BALANCE_METHOD,
     };
 }
 
 pub(crate) mod speculative_exec {
+    pub use crate::rpcs::v1_5_0::speculative_exec::SpeculativeExecResult;
     pub(crate) use crate::rpcs::v1_5_0::speculative_exec::{
         SpeculativeExecParams, SPECULATIVE_EXEC_METHOD,
     };

--- a/lib/rpcs/v1_6_0/get_account.rs
+++ b/lib/rpcs/v1_6_0/get_account.rs
@@ -7,7 +7,7 @@ pub(crate) use crate::rpcs::v1_4_5::get_account::GET_ACCOUNT_METHOD;
 use crate::{rpcs::common::BlockIdentifier, types::Account};
 
 /// Identifier of an account.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 #[serde(deny_unknown_fields, untagged)]
 pub enum AccountIdentifier {
     /// The public key of an account
@@ -19,7 +19,7 @@ pub enum AccountIdentifier {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct GetAccountParams {
-    ///The identifier of an Account. (named public key to match the JSON-RPC API)
+    /// The identifier of an Account. (named public key to match the JSON-RPC API)
     account_identifier: AccountIdentifier,
     /// The block identifier.
     block_identifier: Option<BlockIdentifier>,

--- a/lib/rpcs/v1_6_0/get_account.rs
+++ b/lib/rpcs/v1_6_0/get_account.rs
@@ -1,12 +1,10 @@
-
 use serde::{Deserialize, Serialize};
 
 use casper_types::account::AccountHash;
 use casper_types::{ProtocolVersion, PublicKey};
 
-use crate::{rpcs::common::BlockIdentifier, types::Account};
 pub(crate) use crate::rpcs::v1_4_5::get_account::GET_ACCOUNT_METHOD;
-
+use crate::{rpcs::common::BlockIdentifier, types::Account};
 
 /// Identifier of an account.
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -22,7 +20,7 @@ pub enum AccountIdentifier {
 #[serde(deny_unknown_fields)]
 pub(crate) struct GetAccountParams {
     ///The identifier of an Account. (named public key to match the JSON-RPC API)
-    public_key: AccountIdentifier,
+    account_identifier: AccountIdentifier,
     /// The block identifier.
     block_identifier: Option<BlockIdentifier>,
 }

--- a/lib/rpcs/v1_6_0/get_account.rs
+++ b/lib/rpcs/v1_6_0/get_account.rs
@@ -31,7 +31,7 @@ impl GetAccountParams {
         block_identifier: Option<BlockIdentifier>,
     ) -> Self {
         GetAccountParams {
-            public_key: account_identifier,
+            account_identifier,
             block_identifier,
         }
     }

--- a/lib/rpcs/v1_6_0/get_account.rs
+++ b/lib/rpcs/v1_6_0/get_account.rs
@@ -1,26 +1,39 @@
+
 use serde::{Deserialize, Serialize};
 
+use casper_types::account::AccountHash;
 use casper_types::{ProtocolVersion, PublicKey};
 
 use crate::{rpcs::common::BlockIdentifier, types::Account};
+pub(crate) use crate::rpcs::v1_4_5::get_account::GET_ACCOUNT_METHOD;
 
-pub(crate) const GET_ACCOUNT_METHOD: &str = "state_get_account_info";
+
+/// Identifier of an account.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, untagged)]
+pub enum AccountIdentifier {
+    /// The public key of an account
+    PublicKey(PublicKey),
+    /// The account hash of an account
+    AccountHash(AccountHash),
+}
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct GetAccountParams {
     ///The identifier of an Account. (named public key to match the JSON-RPC API)
-    public_key: PublicKey,
+    public_key: AccountIdentifier,
     /// The block identifier.
     block_identifier: Option<BlockIdentifier>,
 }
 
 impl GetAccountParams {
-    //This clippy link should be re-enabled once the client is updated to handle multiple different node versions.
-    #[allow(dead_code)]
-    pub(crate) fn new(public_key: PublicKey, block_identifier: Option<BlockIdentifier>) -> Self {
+    pub(crate) fn new(
+        account_identifier: AccountIdentifier,
+        block_identifier: Option<BlockIdentifier>,
+    ) -> Self {
         GetAccountParams {
-            public_key,
+            public_key: account_identifier,
             block_identifier,
         }
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -316,6 +316,40 @@ pub(super) mod purse_identifier {
     }
 }
 
+pub(super) mod account_identifier{
+    use super::*;
+
+    pub(super) const ARG_NAME: &str = "account-identifier";
+    const ARG_SHORT: char = 'a';
+    const ARG_VALUE_NAME: &str = "FORMATTED STRING or PATH";
+    const ARG_HELP: &str =
+        "The identifier for an account. This can be a public key or account hash. To provide a \
+        public key, it must be a properly formatted public key. The public key may \
+        be read in from a file, in which case enter the path to the file as the --account-identifier \
+        argument. The file should be one of the two public key files generated via the `keygen` \
+        subcommand; \"public_key_hex\" or \"public_key.pem\". To provide an account hash, it must \
+        be formatted as \"account-hash-<HEX STRING>\"";
+
+    pub fn arg(order: usize, is_required: bool) -> Arg {
+        Arg::new(ARG_NAME)
+            .long(ARG_NAME)
+            .short(ARG_SHORT)
+            .required(is_required)
+            .value_name(ARG_VALUE_NAME)
+            .help(ARG_HELP)
+            .display_order(order)
+    }
+
+    pub fn get(matches: &ArgMatches) -> Result<String, CliError> {
+        let value = matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_default();
+        public_key::try_read_from_file(value)
+    }
+
+}
+
 /// Handles providing the arg for and retrieval of the purse URef.
 pub(super) mod purse_uref {
     use super::*;

--- a/src/common.rs
+++ b/src/common.rs
@@ -316,7 +316,7 @@ pub(super) mod purse_identifier {
     }
 }
 
-pub(super) mod account_identifier{
+pub(super) mod account_identifier {
     use super::*;
 
     pub(super) const ARG_NAME: &str = "account-identifier";
@@ -347,7 +347,6 @@ pub(super) mod account_identifier{
             .unwrap_or_default();
         public_key::try_read_from_file(value)
     }
-
 }
 
 /// Handles providing the arg for and retrieval of the purse URef.

--- a/src/get_account.rs
+++ b/src/get_account.rs
@@ -9,7 +9,7 @@ use crate::{command::ClientCommand, common, Success};
 
 /// Legacy name of command.
 const COMMAND_ALIAS: &str = "get-account-info";
-const PUBLIC_KEY_IS_REQUIRED: bool = true;
+const ACCOUNT_IDENTIFIER_IS_REQUIRED: bool = true;
 
 pub struct GetAccount;
 
@@ -19,7 +19,7 @@ enum DisplayOrder {
     NodeAddress,
     RpcId,
     BlockIdentifier,
-    PublicKey,
+    AccountIdentifier,
 }
 
 #[async_trait]
@@ -41,9 +41,9 @@ impl ClientCommand for GetAccount {
                 DisplayOrder::BlockIdentifier as usize,
                 true,
             ))
-            .arg(common::public_key::arg(
-                DisplayOrder::PublicKey as usize,
-                PUBLIC_KEY_IS_REQUIRED,
+            .arg(common::account_identifier::arg(
+                DisplayOrder::AccountIdentifier as usize,
+                ACCOUNT_IDENTIFIER_IS_REQUIRED,
             ))
     }
 
@@ -52,14 +52,14 @@ impl ClientCommand for GetAccount {
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);
         let block_identifier = common::block_identifier::get(matches);
-        let public_key = common::public_key::get(matches, PUBLIC_KEY_IS_REQUIRED)?;
+        let account_idenfitier = common::account_identifier::get(matches)?;
 
         casper_client::cli::get_account(
             maybe_rpc_id,
             node_address,
             verbosity_level,
             block_identifier,
-            &public_key,
+            &account_idenfitier,
         )
         .await
         .map(Success::from)

--- a/src/get_account.rs
+++ b/src/get_account.rs
@@ -10,6 +10,8 @@ use crate::{command::ClientCommand, common, Success};
 /// Legacy name of command.
 const COMMAND_ALIAS: &str = "get-account-info";
 const ACCOUNT_IDENTIFIER_IS_REQUIRED: bool = true;
+const ACCOUNT_IDENTIFIER_ALIAS: &str = "public-key";
+const ACCOUNT_IDENTIFIER_SHORT_ALIAS: char = 'p';
 
 pub struct GetAccount;
 
@@ -44,7 +46,7 @@ impl ClientCommand for GetAccount {
             .arg(common::account_identifier::arg(
                 DisplayOrder::AccountIdentifier as usize,
                 ACCOUNT_IDENTIFIER_IS_REQUIRED,
-            ))
+            ).alias(ACCOUNT_IDENTIFIER_ALIAS).short_alias(ACCOUNT_IDENTIFIER_SHORT_ALIAS))
     }
 
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {

--- a/src/get_account.rs
+++ b/src/get_account.rs
@@ -43,10 +43,14 @@ impl ClientCommand for GetAccount {
                 DisplayOrder::BlockIdentifier as usize,
                 true,
             ))
-            .arg(common::account_identifier::arg(
-                DisplayOrder::AccountIdentifier as usize,
-                ACCOUNT_IDENTIFIER_IS_REQUIRED,
-            ).alias(ACCOUNT_IDENTIFIER_ALIAS).short_alias(ACCOUNT_IDENTIFIER_SHORT_ALIAS))
+            .arg(
+                common::account_identifier::arg(
+                    DisplayOrder::AccountIdentifier as usize,
+                    ACCOUNT_IDENTIFIER_IS_REQUIRED,
+                )
+                .alias(ACCOUNT_IDENTIFIER_ALIAS)
+                .short_alias(ACCOUNT_IDENTIFIER_SHORT_ALIAS),
+            )
     }
 
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {


### PR DESCRIPTION
# Summary of work done:
- Update the get-account command to accept an account identifier.
- Add the `AccountIdentifier` enum to support this update.
- Ensure `AccountIdentifier` has attributes to allow serde to properly format it and avoid breaking changes to the RPC API

### Sample requests:

Request for an account using a public key from an NCTL network
```
{
  "jsonrpc": "2.0",
  "method": "state_get_account_info",
  "params": {
    "public_key": "01fbabf372fe762ad840834f7dab5d88e522ffa39c9f53d1e991056cef110faeb2",
    "block_identifier": null
  },
  "id": -2271248039839344330
}
```

Associated output:

```
{
  "jsonrpc": "2.0",
  "result": {
    "api_version": "1.0.0",
    "account": {
      "account_hash": "account-hash-c029c14904b870e64c1d443d428c606740e82f341bea0f8542ca6494cef1383e",
      "named_keys": [],
      "main_purse": "uref-cf8a03704e4865323fd1b02166e52302ce8fc4c931d76d04e6faea33ee52d93e-007",
      "associated_keys": [
        {
          "account_hash": "account-hash-c029c14904b870e64c1d443d428c606740e82f341bea0f8542ca6494cef1383e",
          "weight": 1
        }
      ],
      "action_thresholds": {
        "deployment": 1,
        "key_management": 1
      }
    },
    "merkle_proof": "[2228 hex chars]"
  },
  "id": -2271248039839344330
}
```

Request for the same account using an account hash instead:

```
{
  "jsonrpc": "2.0",
  "method": "state_get_account_info",
  "params": {
    "public_key": "account-hash-c029c14904b870e64c1d443d428c606740e82f341bea0f8542ca6494cef1383e",
    "block_identifier": null
  },
  "id": -3436401869523751496
}
```

Associated output:

```
{
  "jsonrpc": "2.0",
  "result": {
    "api_version": "1.0.0",
    "account": {
      "account_hash": "account-hash-c029c14904b870e64c1d443d428c606740e82f341bea0f8542ca6494cef1383e",
      "named_keys": [],
      "main_purse": "uref-cf8a03704e4865323fd1b02166e52302ce8fc4c931d76d04e6faea33ee52d93e-007",
      "associated_keys": [
        {
          "account_hash": "account-hash-c029c14904b870e64c1d443d428c606740e82f341bea0f8542ca6494cef1383e",
          "weight": 1
        }
      ],
      "action_thresholds": {
        "deployment": 1,
        "key_management": 1
      }
    },
    "merkle_proof": "[2228 hex chars]"
  },
  "id": -3436401869523751496
}
```

# Associated ticket(s):
- #55  
- [Support providing account hashes as an alternative to public keys throughout the casper-client where this makes sense](https://app.zenhub.com/workspaces/rust-sdk-64b185bf2cb87924e7759d9d/issues/gh/casper-ecosystem/casper-client-rs/55) 