### PR TITLE
49 Branding Updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ assets = [["./target/release/casper-client", "/usr/bin/casper-client", "755"], ]
 extended-description = """
 Package for Casper Client to connect to Casper Node.
 
-For information on using package, see https://github.com/CasperLabs/casper-node
+For information on using package, see https://github.com/casper-network/casper-node
 """
 
 [package.metadata.deb.variants.bionic]

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -24,8 +24,8 @@
 
 #![doc(
     html_root_url = "https://docs.rs/casper-client/2.0.0",
-    html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
-    html_logo_url = "https://raw.githubusercontent.com/CasperLabs/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png",
+    html_favicon_url = "https://raw.githubusercontent.com/casper-network/casper-node/blob/dev/images/Casper_Logo_Favicon_48.png",
+    html_logo_url = "https://raw.githubusercontent.com/casper-network/casper-node/blob/dev/images/Casper_Logo_Favicon.png",
     test(attr(forbid(warnings)))
 )]
 #![warn(


### PR DESCRIPTION
This PR brings `casper-client-rs` branding in line with the new branding in the `casper-node` repo.

No new files or code changes, as everything here points to the assets stored with the node.

Closes #49 