### PR TITLE
Add sdk feature into feat 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ k256 = { version = "0.7.3", features = [
     "zeroize",
 ] }
 num-traits = "0.2.15"
-once_cell = "1"
+once_cell = { version = "1" }
 pem = "1"
 rand = "0.8.5"
 reqwest = { version = "0.11.13", features = ["json"] }
@@ -65,7 +65,7 @@ untrusted = "0.9.0"
 
 [features]
 default = ["tokio", "clap", "casper-types/std", "casper-types/json-schema"]
-sdk = ["casper-types/json-schema"]
+sdk = []
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["git"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,10 @@ doc = false
 async-trait = "0.1.59"
 base16 = "0.2.1"
 base64 = "0.13.1"
-casper-types = { version = "3.0.0", features = ["std", "json-schema"] }
+casper-types = { version = "3.0.0", default-features = false }
 clap = { version = "4", features = ["cargo", "deprecated"], optional = true }
-clap_complete = "4"
+clap_complete = { version = "4" }
 derp = "0.0.14"
-ed25519-dalek = { version = "1", default-features = false }
 getrandom = { version = "0.2.10", features = ["js"] }
 hex-buffer-serde = "0.4.0"
 humantime = "2"
@@ -48,7 +47,7 @@ once_cell = "1"
 pem = "1"
 rand = "0.8.5"
 reqwest = { version = "0.11.13", features = ["json"] }
-schemars = "0.8"
+schemars = { version = "0.8" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde-map-to-array = "1.1.0"
 serde_json = { version = "1", features = ["preserve_order"] }
@@ -65,9 +64,8 @@ uint = "0.9.4"
 untrusted = "0.9.0"
 
 [features]
-default = ["casper-types", "tokio", "clap"]
-casper-types = ["casper-types/std"]
-sdk = []
+default = ["tokio", "clap", "casper-types/std", "casper-types/json-schema"]
+sdk = ["casper-types/json-schema"]
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["git"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ num-traits = "0.2.15"
 once_cell = "1"
 rand = "0.8.5"
 reqwest = { version = "0.11.13", features = ["json"] }
-schemars = "0.8"
+schemars = "0.8.13"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde-map-to-array = "1.1.0"
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,7 @@ tempfile = "3"
 thiserror = "=1.0.34"
 tokio = { version = "1.23.0", features = [
     "macros",
-    "net",
-    "rt-multi-thread",
+    "rt",
     "sync",
     "time",
 ], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ doc = false
 [dependencies]
 async-trait = "0.1.59"
 base16 = "0.2.1"
-casper-types = { version = "3.0.0", git = "https://github.com/casper-network/casper-node.git", branch = "rustSDK", features = [
+casper-types = { version = "3.0.0", git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0", features = [
     "std",
     "json-schema",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ async-trait = "0.1.59"
 base16 = "0.2.1"
 base64 = "0.13.1"
 casper-types = { version = "3.0.0", git = "https://github.com/casper-network/casper-node.git", branch = "rustSDK", default-features = false, features = [
+    "sdk",
     "std",
     "json-schema",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ doc = false
 async-trait = "0.1.59"
 base16 = "0.2.1"
 base64 = "0.13.1"
-casper-types = { version = "3.0.0", git = "https://github.com/casper-network/casper-node.git", branch = "rustSDK", default-features = false, features = [
+casper-types = { version = "3.0.0", git = "https://github.com/casper-network/casper-node.git", branch = "rustSDK", features = [
     "std",
     "json-schema",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ casper-types = { version = "3.0.0", git = "https://github.com/casper-network/cas
 ] }
 clap = { version = "4", features = ["cargo", "deprecated"] }
 clap_complete = "4"
-getrandom = { version = "0.2.10", features = ["js"] }
+getrandom = "0.2.10"
 hex-buffer-serde = "0.4.0"
 humantime = "2"
 itertools = "0.11.0"
@@ -53,7 +53,7 @@ uint = "0.9.4"
 tempfile = "3.7.1"
 
 [features]
-sdk = ["casper-types/sdk"]
+sdk = ["casper-types/sdk", "getrandom/js"]
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["git"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ doc = false
 [dependencies]
 async-trait = "0.1.59"
 base16 = "0.2.1"
-base64 = "0.13.1"
 casper-types = { version = "3.0.0", git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0", features = [
     "std",
     "json-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ async-trait = "0.1.59"
 base16 = "0.2.1"
 base64 = "0.13.1"
 casper-types = { version = "3.0.0", git = "https://github.com/casper-network/casper-node.git", branch = "rustSDK", default-features = false, features = [
-    "sdk",
     "std",
     "json-schema",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "casper-client"
 version = "2.0.0" # when updating, also update 'html_root_url' in lib.rs
-authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>"]
+authors = [
+    "Marc Brinkmann <marc@casperlabs.io>",
+    "Fraser Hutchison <fraser@casperlabs.io>",
+]
 edition = "2021"
 description = "A client library and binary for interacting with the Casper network"
 documentation = "https://docs.rs/casper-client"
@@ -11,6 +14,7 @@ repository = "https://github.com/casper-ecosystem/casper-client-rs"
 license = "Apache-2.0"
 
 [lib]
+crate-type = ["cdylib", "rlib"]
 name = "casper_client"
 path = "lib/lib.rs"
 
@@ -24,16 +28,21 @@ async-trait = "0.1.59"
 base16 = "0.2.1"
 base64 = "0.13.1"
 casper-types = { version = "3.0.0", features = ["std", "json-schema"] }
-clap = { version = "4", features = ["cargo", "deprecated", "wrap_help"] }
+clap = { version = "4", features = ["cargo", "deprecated"], optional = true }
 clap_complete = "4"
 derp = "0.0.14"
 ed25519-dalek = { version = "1", default-features = false }
-getrandom = "0.2.8"
+getrandom = { version = "0.2.10", features = ["js"] }
 hex-buffer-serde = "0.4.0"
 humantime = "2"
 itertools = "0.10.5"
 jsonrpc-lite = "0.6.0"
-k256 = { version = "0.7.3", features = ["arithmetic", "ecdsa", "sha256", "zeroize"] }
+k256 = { version = "0.7.3", features = [
+    "arithmetic",
+    "ecdsa",
+    "sha256",
+    "zeroize",
+] }
 num-traits = "0.2.15"
 once_cell = "1"
 pem = "1"
@@ -46,9 +55,20 @@ serde_json = { version = "1", features = ["preserve_order"] }
 signature = "1"
 tempfile = "3"
 thiserror = "=1.0.34"
-tokio = { version = "1.23.0", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.23.0", features = [
+    "macros",
+    "net",
+    "rt-multi-thread",
+    "sync",
+    "time",
+], optional = true }
 uint = "0.9.4"
 untrusted = "0.9.0"
+
+[features]
+default = ["casper-types", "tokio", "clap"]
+casper-types = ["casper-types/std"]
+sdk = []
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["git"] }
@@ -59,9 +79,7 @@ casper-types = { git = "https://github.com/Fraser999/casper-node", branch = "212
 [package.metadata.deb]
 features = ["vendored-openssl"]
 revision = "0"
-assets = [
-    ["./target/release/casper-client", "/usr/bin/casper-client", "755"],
-]
+assets = [["./target/release/casper-client", "/usr/bin/casper-client", "755"]]
 extended-description = """
 Package for Casper Client to connect to Casper Node.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,14 @@ async-trait = "0.1.59"
 base16 = "0.2.1"
 base64 = "0.13.1"
 casper-types = { version = "3.0.0", git = "https://github.com/casper-network/casper-node.git", branch = "rustSDK", default-features = false, features = [
-    "datasize",
+    "std",
+    "json-schema",
 ] }
-clap = { version = "4", features = ["cargo", "deprecated"], optional = true }
-clap_complete = { version = "4" }
+clap = { version = "4", features = ["cargo", "deprecated"] }
+clap_complete = "4"
 derp = "0.0.14"
+# This does not wasm compile without std, features = ["js"] can be removed if consumer crate uses that feature, let's keep it for dev purpose
+# getrandom = { version = "0.2.10" }
 getrandom = { version = "0.2.10", features = ["js"] }
 hex-buffer-serde = "0.4.0"
 humantime = "2"
@@ -49,25 +52,19 @@ once_cell = { version = "1" }
 pem = "1"
 rand = "0.8.5"
 reqwest = { version = "0.11.13", features = ["json"] }
-schemars = { version = "0.8" }
+schemars = { version = "0.8.12" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde-map-to-array = "1.1.0"
 serde_json = { version = "1", features = ["preserve_order"] }
 signature = "1"
 tempfile = "3"
 thiserror = "=1.0.34"
-tokio = { version = "1.23.0", features = [
-    "macros",
-    "rt",
-    "sync",
-    "time",
-], optional = true }
+tokio = { version = "1.23.0", features = ["macros", "rt", "sync", "time"] }
 uint = "0.9.4"
 untrusted = "0.9.0"
 
 [features]
-default = ["tokio", "clap", "casper-types/std", "casper-types/json-schema"]
-sdk = []
+sdk = ["casper-types/sdk"]
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["git"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ doc = false
 [dependencies]
 async-trait = "0.1.59"
 base16 = "0.2.1"
+base64 = "0.13.1"
 casper-types = { version = "3.0.0", git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0", features = [
     "std",
     "json-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,9 @@ doc = false
 async-trait = "0.1.59"
 base16 = "0.2.1"
 base64 = "0.13.1"
-casper-types = { version = "3.0.0", default-features = false }
+casper-types = { version = "3.0.0", git = "https://github.com/casper-network/casper-node.git", branch = "rustSDK", default-features = false, features = [
+    "datasize",
+] }
 clap = { version = "4", features = ["cargo", "deprecated"], optional = true }
 clap_complete = { version = "4" }
 derp = "0.0.14"
@@ -69,9 +71,6 @@ sdk = []
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["git"] }
-
-[patch.crates-io]
-casper-types = { git = "https://github.com/Fraser999/casper-node", branch = "2124-use-execution-journal" }
 
 [package.metadata.deb]
 features = ["vendored-openssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ async-trait = "0.1.59"
 base16 = "0.2.1"
 casper-types = { version = "3.0.0", git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0", features = [
     "std",
-    "json-schema",
 ] }
 clap = { version = "4", features = ["cargo", "deprecated"] }
 clap_complete = "4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ casper-types = { version = "3.0.0", git = "https://github.com/casper-network/cas
 ] }
 clap = { version = "4", features = ["cargo", "deprecated"] }
 clap_complete = "4"
-getrandom = "0.2.10"
 hex-buffer-serde = "0.4.0"
 humantime = "2"
 itertools = "0.11.0"
@@ -53,7 +52,7 @@ uint = "0.9.4"
 tempfile = "3.7.1"
 
 [features]
-sdk = ["casper-types/sdk", "getrandom/js"]
+sdk = ["casper-types/sdk"]
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["git"] }

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -31,6 +31,8 @@ mod payment_str_params;
 mod session_str_params;
 mod simple_args;
 #[cfg(feature = "sdk")]
+pub use parse::account_identifier as parse_account_identifier;
+#[cfg(feature = "sdk")]
 pub use parse::purse_identifier as parse_purse_identifier;
 #[cfg(feature = "sdk")]
 pub use simple_args::insert_arg;

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -30,6 +30,7 @@ mod parse;
 mod payment_str_params;
 mod session_str_params;
 mod simple_args;
+#[cfg(feature = "sdk")]
 pub use simple_args::insert_arg;
 
 #[cfg(test)]
@@ -59,7 +60,7 @@ use crate::{Account, Block, Deploy, Error, StoredValue, Transfer};
 pub use deploy_str_params::DeployStrParams;
 pub use dictionary_item_str_params::DictionaryItemStrParams;
 pub use error::CliError;
-use json_args::JsonArg;
+pub use json_args::JsonArg;
 pub use json_args::{
     help as json_args_help, Error as JsonArgsError, ErrorDetails as JsonArgsErrorDetails,
 };

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -60,7 +60,7 @@ use crate::{
     SuccessResponse,
 };
 #[cfg(doc)]
-use crate::{Account, Block, Deploy, Error, StoredValue, Transfer};
+use crate::{Account, Block, Error, StoredValue, Transfer};
 #[cfg(doc)]
 use casper_types::PublicKey;
 pub use deploy_str_params::DeployStrParams;

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -121,16 +121,19 @@ pub async fn speculative_put_deploy(
 /// is false and a file exists at `maybe_output_path`, [`Error::FileAlreadyExists`] is returned
 /// and the file will not be written.
 pub fn make_deploy(
-    maybe_output_path: &str,
+    #[allow(unused_variables)] maybe_output_path: &str,
     deploy_params: DeployStrParams<'_>,
     session_params: SessionStrParams<'_>,
     payment_params: PaymentStrParams<'_>,
-    force: bool,
+    #[allow(unused_variables)] force: bool,
 ) -> Result<Deploy, CliError> {
-    let output = parse::output_kind(maybe_output_path, force);
     let deploy =
         deploy::with_payment_and_session(deploy_params, payment_params, session_params, true)?;
-    let _ = crate::output_deploy(output, &deploy).map_err(CliError::from);
+    #[cfg(not(any(feature = "sdk")))]
+    {
+        let output = parse::output_kind(maybe_output_path, force);
+        let _ = crate::output_deploy(output, &deploy).map_err(CliError::from);
+    }
     Ok(deploy)
 }
 
@@ -276,15 +279,14 @@ pub async fn speculative_transfer(
 /// is false and a file exists at `maybe_output_path`, [`Error::FileAlreadyExists`] is returned
 /// and the file will not be written.
 pub fn make_transfer(
-    maybe_output_path: &str,
+    #[allow(unused_variables)] maybe_output_path: &str,
     amount: &str,
     target_account: &str,
     transfer_id: &str,
     deploy_params: DeployStrParams<'_>,
     payment_params: PaymentStrParams<'_>,
-    force: bool,
+    #[allow(unused_variables)] force: bool,
 ) -> Result<Deploy, CliError> {
-    let output = parse::output_kind(maybe_output_path, force);
     let deploy = deploy::new_transfer(
         amount,
         None,
@@ -294,7 +296,11 @@ pub fn make_transfer(
         payment_params,
         true,
     )?;
-    let _ = crate::output_deploy(output, &deploy).map_err(CliError::from);
+    #[cfg(not(any(feature = "sdk")))]
+    {
+        let output = parse::output_kind(maybe_output_path, force);
+        let _ = crate::output_deploy(output, &deploy).map_err(CliError::from);
+    }
     Ok(deploy)
 }
 

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -66,9 +66,8 @@ use casper_types::PublicKey;
 pub use deploy_str_params::DeployStrParams;
 pub use dictionary_item_str_params::DictionaryItemStrParams;
 pub use error::CliError;
-pub use json_args::JsonArg;
 pub use json_args::{
-    help as json_args_help, Error as JsonArgsError, ErrorDetails as JsonArgsErrorDetails,
+    help as json_args_help, Error as JsonArgsError, ErrorDetails as JsonArgsErrorDetails, JsonArg
 };
 pub use payment_str_params::PaymentStrParams;
 pub use session_str_params::SessionStrParams;

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -31,6 +31,8 @@ mod payment_str_params;
 mod session_str_params;
 mod simple_args;
 #[cfg(feature = "sdk")]
+pub use parse::purse_identifier as parse_purse_identifier;
+#[cfg(feature = "sdk")]
 pub use simple_args::insert_arg;
 
 #[cfg(test)]

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -30,6 +30,8 @@ mod parse;
 mod payment_str_params;
 mod session_str_params;
 mod simple_args;
+pub use simple_args::insert_arg;
+
 #[cfg(test)]
 mod tests;
 

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -37,7 +37,7 @@ use serde::Serialize;
 
 #[cfg(doc)]
 use casper_types::{account::AccountHash, Key};
-use casper_types::{crypto, AsymmetricType, Digest, PublicKey, URef};
+use casper_types::{crypto, AsymmetricType, Deploy, Digest, PublicKey, URef};
 
 use crate::{
     rpcs::{
@@ -121,10 +121,11 @@ pub fn make_deploy(
     session_params: SessionStrParams<'_>,
     payment_params: PaymentStrParams<'_>,
     force: bool,
-) -> Result<(), CliError> {
+) -> Result<Deploy, CliError> {
     let output = parse::output_kind(maybe_output_path, force);
     let deploy = deploy::with_payment_and_session(deploy_params, payment_params, session_params)?;
-    crate::output_deploy(output, &deploy).map_err(CliError::from)
+    let _ = crate::output_deploy(output, &deploy).map_err(CliError::from);
+    Ok(deploy)
 }
 
 /// Reads a previously-saved [`Deploy`] from a file, cryptographically signs it, and outputs it to a
@@ -274,7 +275,7 @@ pub fn make_transfer(
     deploy_params: DeployStrParams<'_>,
     payment_params: PaymentStrParams<'_>,
     force: bool,
-) -> Result<(), CliError> {
+) -> Result<Deploy, CliError> {
     let output = parse::output_kind(maybe_output_path, force);
     let deploy = deploy::new_transfer(
         amount,
@@ -284,7 +285,8 @@ pub fn make_transfer(
         deploy_params,
         payment_params,
     )?;
-    crate::output_deploy(output, &deploy).map_err(CliError::from)
+    let _ = crate::output_deploy(output, &deploy).map_err(CliError::from);
+    Ok(deploy)
 }
 
 /// Retrieves a [`Deploy`] from the network.

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -134,6 +134,7 @@ pub fn make_deploy(
 /// `force` is true, and a file exists at `maybe_output_path`, it will be overwritten.  If `force`
 /// is false and a file exists at `maybe_output_path`, [`Error::FileAlreadyExists`] is returned
 /// and the file will not be written.
+#[cfg(not(any(feature = "sdk")))]
 pub fn sign_deploy_file(
     input_path: &str,
     secret_key_path: &str,

--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -17,7 +17,18 @@ pub fn with_payment_and_session(
     let session = parse::session_executable_deploy_item(session_params)?;
 
     #[cfg(feature = "sdk")]
-    let secret_key = SecretKey::generate_ed25519().unwrap();
+    let secret_key: SecretKey = {
+        let secret_key_bytes: Vec<u8> = deploy_params.secret_key.as_bytes().to_owned();
+        match SecretKey::from_pem(secret_key_bytes) {
+            Ok(key) => key,
+            Err(error) => {
+                return Err(CliError::Core(crate::Error::CryptoError {
+                    context: "secret key",
+                    error,
+                }));
+            }
+        }
+    };
 
     #[cfg(not(any(feature = "sdk")))]
     let secret_key = parse::secret_key_from_file(deploy_params.secret_key)?;

--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -18,8 +18,7 @@ pub fn with_payment_and_session(
 
     #[cfg(feature = "sdk")]
     let secret_key: SecretKey = {
-        let secret_key_bytes: Vec<u8> = deploy_params.secret_key.as_bytes().to_owned();
-        match SecretKey::from_pem(secret_key_bytes) {
+        match SecretKey::from_pem(deploy_params.secret_key) {
             Ok(key) => key,
             Err(error) => {
                 return Err(CliError::Core(crate::Error::CryptoError {
@@ -66,8 +65,7 @@ pub fn new_transfer(
 
     #[cfg(feature = "sdk")]
     let secret_key: SecretKey = {
-        let secret_key_bytes: Vec<u8> = deploy_params.secret_key.as_bytes().to_owned();
-        match SecretKey::from_pem(secret_key_bytes) {
+        match SecretKey::from_pem(deploy_params.secret_key) {
             Ok(key) => key,
             Err(error) => {
                 return Err(CliError::Core(crate::Error::CryptoError {

--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -24,11 +24,8 @@ pub fn with_payment_and_session(
         .with_payment(payment)
         .with_timestamp(timestamp)
         .with_ttl(ttl);
-
-    if let Some(secret_key) =
-        &get_maybe_secret_key(deploy_params.secret_key, allow_unsigned_deploy)?
-    {
-        println!("secret key: {:?}", secret_key);
+    let maybe_secret_key = get_maybe_secret_key(&deploy_params.secret_key, allow_unsigned_deploy)?;
+    if let Some(secret_key) = &maybe_secret_key {
         deploy_builder = deploy_builder.with_secret_key(secret_key);
     }
     if let Some(account) = maybe_session_account {
@@ -88,9 +85,8 @@ pub fn new_transfer(
             .with_timestamp(timestamp)
             .with_ttl(ttl);
 
-    if let Some(secret_key) =
-        &get_maybe_secret_key(deploy_params.secret_key, allow_unsigned_deploy)?
-    {
+    let maybe_secret_key = get_maybe_secret_key(&deploy_params.secret_key, allow_unsigned_deploy)?;
+    if let Some(secret_key) = &maybe_secret_key {
         deploy_builder = deploy_builder.with_secret_key(secret_key);
     }
     if let Some(account) = maybe_session_account {

--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -65,7 +65,18 @@ pub fn new_transfer(
     let chain_name = deploy_params.chain_name.to_string();
 
     #[cfg(feature = "sdk")]
-    let secret_key = SecretKey::generate_ed25519().unwrap();
+    let secret_key: SecretKey = {
+        let secret_key_bytes: Vec<u8> = deploy_params.secret_key.as_bytes().to_owned();
+        match SecretKey::from_pem(secret_key_bytes) {
+            Ok(key) => key,
+            Err(error) => {
+                return Err(CliError::Core(crate::Error::CryptoError {
+                    context: "secret key",
+                    error,
+                }));
+            }
+        }
+    };
 
     #[cfg(not(any(feature = "sdk")))]
     let secret_key = parse::secret_key_from_file(deploy_params.secret_key)?;

--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -24,7 +24,7 @@ pub fn with_payment_and_session(
         .with_payment(payment)
         .with_timestamp(timestamp)
         .with_ttl(ttl);
-    let maybe_secret_key = get_maybe_secret_key(&deploy_params.secret_key, allow_unsigned_deploy)?;
+    let maybe_secret_key = get_maybe_secret_key(deploy_params.secret_key, allow_unsigned_deploy)?;
     if let Some(secret_key) = &maybe_secret_key {
         deploy_builder = deploy_builder.with_secret_key(secret_key);
     }
@@ -85,7 +85,7 @@ pub fn new_transfer(
             .with_timestamp(timestamp)
             .with_ttl(ttl);
 
-    let maybe_secret_key = get_maybe_secret_key(&deploy_params.secret_key, allow_unsigned_deploy)?;
+    let maybe_secret_key = get_maybe_secret_key(deploy_params.secret_key, allow_unsigned_deploy)?;
     if let Some(secret_key) = &maybe_secret_key {
         deploy_builder = deploy_builder.with_secret_key(secret_key);
     }

--- a/lib/cli/error.rs
+++ b/lib/cli/error.rs
@@ -112,7 +112,7 @@ pub enum CliError {
     ConflictingArguments {
         /// Contextual description of where this error occurred including relevant paths,
         /// filenames, etc.
-        context: &'static str,
+        context: String,
         /// Arguments passed, with their values.
         args: Vec<String>,
     },

--- a/lib/cli/json_args.rs
+++ b/lib/cli/json_args.rs
@@ -17,7 +17,7 @@ use crate::cli::CliError;
 pub use error::{Error, ErrorDetails};
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub(super) struct JsonArg {
+pub struct JsonArg {
     name: String,
     #[serde(rename = "type")]
     cl_type: CLType,

--- a/lib/cli/json_args.rs
+++ b/lib/cli/json_args.rs
@@ -16,6 +16,7 @@ use casper_types::{
 use crate::cli::CliError;
 pub use error::{Error, ErrorDetails};
 
+/// Represents a JSON argument with a name, type, and value.
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct JsonArg {
     name: String,

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -1,13 +1,10 @@
 //! This module contains structs and helpers which are used by multiple subcommands related to
 //! creating deploys.
 
-use super::{simple_args, CliError, PaymentStrParams, SessionStrParams};
 #[cfg(not(any(feature = "sdk")))]
-use crate::OutputKind;
-use crate::{
-    AccountIdentifier, BlockIdentifier, GlobalStateIdentifier, JsonRpcId, PurseIdentifier,
-    Verbosity,
-};
+use std::path::Path;
+use std::{convert::TryInto, fs, io, str::FromStr};
+
 #[cfg(not(any(feature = "sdk")))]
 use casper_types::SecretKey;
 use casper_types::{
@@ -18,9 +15,14 @@ use casper_types::{
 };
 use rand::Rng;
 use serde::{self, Deserialize};
+
+use super::{simple_args, CliError, PaymentStrParams, SessionStrParams};
 #[cfg(not(any(feature = "sdk")))]
-use std::path::Path;
-use std::{convert::TryInto, fs, io, str::FromStr};
+use crate::OutputKind;
+use crate::{
+    AccountIdentifier, BlockIdentifier, GlobalStateIdentifier, JsonRpcId, PurseIdentifier,
+    Verbosity,
+};
 
 pub(super) fn rpc_id(maybe_rpc_id: &str) -> JsonRpcId {
     if maybe_rpc_id.is_empty() {

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -306,7 +306,7 @@ fn args_from_simple_or_json_or_complex(
     }
 }
 
-fn check_exactly_one_args_type_not_empty(
+fn check_no_conflicting_arg_types(
     simple: &Vec<&str>,
     json: &str,
     complex: &str,
@@ -451,11 +451,7 @@ pub(super) fn session_executable_deploy_item(
             requires[] requires_empty[session_entry_point, session_version]
     );
 
-    check_exactly_one_args_type_not_empty(
-        session_args_simple,
-        session_args_json,
-        session_args_complex,
-    )?;
+    check_no_conflicting_arg_types(session_args_simple, session_args_json, session_args_complex)?;
 
     let session_args = args_from_simple_or_json_or_complex(
         arg_simple::session::parse(session_args_simple)?,
@@ -551,11 +547,7 @@ pub(super) fn payment_executable_deploy_item(
         (payment_path) requires[] requires_empty[payment_entry_point, payment_version],
     );
 
-    check_exactly_one_args_type_not_empty(
-        payment_args_simple,
-        payment_args_json,
-        payment_args_complex,
-    )?;
+    check_no_conflicting_arg_types(payment_args_simple, payment_args_json, payment_args_complex)?;
 
     if let Ok(payment_args) = standard_payment(payment_amount) {
         return Ok(ExecutableDeployItem::ModuleBytes {

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -817,7 +817,7 @@ pub fn purse_identifier(purse_id: &str) -> Result<PurseIdentifier, CliError> {
 /// `account_identifier` can be a formatted public key, in the form of a hex-formatted string,
 /// a pem file, or a file containing a hex formatted string, or a formatted string representing
 /// an account hash.  It may not be empty.
-pub(super) fn account_identifier(account_identifier: &str) -> Result<AccountIdentifier, CliError> {
+pub fn account_identifier(account_identifier: &str) -> Result<AccountIdentifier, CliError> {
     const ACCOUNT_HASH_PREFIX: &str = "account-hash-";
 
     if account_identifier.is_empty() {

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -316,7 +316,7 @@ fn check_exactly_one_args_type_not_empty(
         .filter(|&&x| x)
         .count();
 
-    if count != 1 {
+    if count > 1 {
         return Err(CliError::ConflictingArguments {
             context: "parse_session_info args conflict (simple json complex)",
             args: vec![simple.join(", "), json.to_owned(), complex.to_owned()],

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -307,6 +307,7 @@ fn args_from_simple_or_json_or_complex(
 }
 
 fn check_no_conflicting_arg_types(
+    context: &str,
     simple: &Vec<&str>,
     json: &str,
     complex: &str,
@@ -318,7 +319,7 @@ fn check_no_conflicting_arg_types(
 
     if count > 1 {
         return Err(CliError::ConflictingArguments {
-            context: "parse_session_info args conflict (simple json complex)",
+            context: format!("parse_session_info {context} args conflict (simple json complex)",),
             args: vec![simple.join(", "), json.to_owned(), complex.to_owned()],
         });
     }
@@ -436,7 +437,7 @@ pub(super) fn session_executable_deploy_item(
     let is_session_transfer = if session_transfer { "true" } else { "" };
 
     check_exactly_one_not_empty!(
-        context: "parse_session_info",
+        context: "parse_session_info".into(),
         (session_hash)
             requires[session_entry_point] requires_empty[session_version],
         (session_name)
@@ -451,7 +452,12 @@ pub(super) fn session_executable_deploy_item(
             requires[] requires_empty[session_entry_point, session_version]
     );
 
-    check_no_conflicting_arg_types(session_args_simple, session_args_json, session_args_complex)?;
+    check_no_conflicting_arg_types(
+        "session",
+        session_args_simple,
+        session_args_json,
+        session_args_complex,
+    )?;
 
     let session_args = args_from_simple_or_json_or_complex(
         arg_simple::session::parse(session_args_simple)?,
@@ -533,7 +539,7 @@ pub(super) fn payment_executable_deploy_item(
         payment_entry_point,
     } = params;
     check_exactly_one_not_empty!(
-        context: "parse_payment_info",
+        context: "parse_payment_info".into(),
         (payment_amount)
             requires[] requires_empty[payment_entry_point, payment_version],
         (payment_hash)
@@ -547,7 +553,12 @@ pub(super) fn payment_executable_deploy_item(
         (payment_path) requires[] requires_empty[payment_entry_point, payment_version],
     );
 
-    check_no_conflicting_arg_types(payment_args_simple, payment_args_json, payment_args_complex)?;
+    check_no_conflicting_arg_types(
+        "payment",
+        payment_args_simple,
+        payment_args_json,
+        payment_args_complex,
+    )?;
 
     if let Ok(payment_args) = standard_payment(payment_amount) {
         return Ok(ExecutableDeployItem::ModuleBytes {
@@ -830,7 +841,7 @@ mod tests {
                 is_session_transfer: false
             }),
             Err(CliError::ConflictingArguments {
-                context: "parse_session_info",
+                context: "parse_session_info".into(),
                 ..
             })
         ));
@@ -850,7 +861,7 @@ mod tests {
                 payment_entry_point: "entrypoint",
             }),
             Err(CliError::ConflictingArguments {
-                context: "parse_payment_info",
+                context: "parse_payment_info".into(),
                 ..
             })
         ));
@@ -873,7 +884,7 @@ mod tests {
                 is_session_transfer: false
             }),
             Err(CliError::ConflictingArguments {
-                context: "parse_session_info",
+                context: "parse_session_info".into(),
                 ..
             })
         ));
@@ -896,7 +907,7 @@ mod tests {
                 payment_entry_point: "",
             }),
             Err(CliError::ConflictingArguments {
-                context: "parse_payment_info",
+                context: "parse_payment_info".into(),
                 ..
             })
         ));
@@ -1129,7 +1140,7 @@ mod tests {
         ///         assert!(matches!(
         ///             info,
         ///             Err(CliError::ConflictingArguments {
-        ///                 context: "parse_session_info",
+        ///                 context: "parse_session_info".into(),
         ///                 args: conflicting
         ///             }
         ///             ))
@@ -1181,7 +1192,7 @@ mod tests {
                             assert!(matches!(
                                 info,
                                 Err(CliError::ConflictingArguments {
-                                    context: $context,
+                                    context: $context.to_string(),
                                     ..
                                 }
                                 ))

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -1,24 +1,22 @@
 //! This module contains structs and helpers which are used by multiple subcommands related to
 //! creating deploys.
 
-use std::{convert::TryInto, fs, io, path::Path, str::FromStr};
-
-use rand::Rng;
-use serde::{self, Deserialize};
-
+use super::{simple_args, CliError, PaymentStrParams, SessionStrParams};
+#[cfg(not(any(feature = "sdk")))]
+use crate::OutputKind;
+use crate::{BlockIdentifier, GlobalStateIdentifier, JsonRpcId, PurseIdentifier, Verbosity};
+#[cfg(not(any(feature = "sdk")))]
+use casper_types::SecretKey;
 use casper_types::{
     account::AccountHash, bytesrepr, crypto, AsymmetricType, BlockHash, CLValue, DeployHash,
     Digest, ExecutableDeployItem, HashAddr, Key, NamedArg, PublicKey, RuntimeArgs, TimeDiff,
     Timestamp, UIntParseError, URef, U512,
 };
-
+use rand::Rng;
+use serde::{self, Deserialize};
 #[cfg(not(any(feature = "sdk")))]
-use casper_types::SecretKey;
-
-use super::{simple_args, CliError, PaymentStrParams, SessionStrParams};
-use crate::{
-    BlockIdentifier, GlobalStateIdentifier, JsonRpcId, OutputKind, PurseIdentifier, Verbosity,
-};
+use std::path::Path;
+use std::{convert::TryInto, fs, io, str::FromStr};
 
 pub(super) fn rpc_id(maybe_rpc_id: &str) -> JsonRpcId {
     if maybe_rpc_id.is_empty() {
@@ -38,6 +36,7 @@ pub(super) fn verbosity(verbosity_level: u64) -> Verbosity {
     }
 }
 
+#[cfg(not(any(feature = "sdk")))]
 pub(super) fn output_kind(maybe_output_path: &str, force: bool) -> OutputKind {
     if maybe_output_path.is_empty() {
         OutputKind::Stdout

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -431,10 +431,24 @@ pub(super) fn session_executable_deploy_item(
         (is_session_transfer)
             requires[] requires_empty[session_entry_point, session_version]
     );
-    if !session_args_simple.is_empty() && !session_args_complex.is_empty() {
+
+    if [
+        !session_args_simple.is_empty(),
+        !session_args_json.is_empty(),
+        !session_args_complex.is_empty(),
+    ]
+    .iter()
+    .filter(|&&x| x)
+    .count()
+        != 1
+    {
         return Err(CliError::ConflictingArguments {
             context: "parse_session_info",
-            args: vec!["session_args".to_owned(), "session_args_complex".to_owned()],
+            args: vec![
+                "session_args".to_owned(),
+                "session_args_json".to_owned(),
+                "session_args_complex".to_owned(),
+            ],
         });
     }
 

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -511,11 +511,14 @@ pub(super) fn session_executable_deploy_item(
             args: session_args,
         });
     }
-
-    let module_bytes = fs::read(session_path).map_err(|error| crate::Error::IoError {
-        context: format!("unable to read session file at '{}'", session_path),
-        error,
-    })?;
+    let module_bytes = if session_path != "sdk" {
+        fs::read(session_path).map_err(|error| crate::Error::IoError {
+            context: format!("unable to read session file at '{}'", session_path),
+            error,
+        })?
+    } else {
+        Vec::new()
+    };
     Ok(ExecutableDeployItem::ModuleBytes {
         module_bytes: module_bytes.into(),
         args: session_args,

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -8,9 +8,12 @@ use serde::{self, Deserialize};
 
 use casper_types::{
     account::AccountHash, bytesrepr, crypto, AsymmetricType, BlockHash, CLValue, DeployHash,
-    Digest, ExecutableDeployItem, HashAddr, Key, NamedArg, PublicKey, RuntimeArgs, SecretKey,
-    TimeDiff, Timestamp, UIntParseError, URef, U512,
+    Digest, ExecutableDeployItem, HashAddr, Key, NamedArg, PublicKey, RuntimeArgs, TimeDiff,
+    Timestamp, UIntParseError, URef, U512,
 };
+
+#[cfg(not(any(feature = "sdk")))]
+use casper_types::SecretKey;
 
 use super::{simple_args, CliError, PaymentStrParams, SessionStrParams};
 use crate::{
@@ -43,6 +46,7 @@ pub(super) fn output_kind(maybe_output_path: &str, force: bool) -> OutputKind {
     }
 }
 
+#[cfg(not(any(feature = "sdk")))]
 pub(super) fn secret_key_from_file<P: AsRef<Path>>(
     secret_key_path: P,
 ) -> Result<SecretKey, CliError> {

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -757,7 +757,7 @@ pub(super) fn global_state_identifier(
 }
 
 /// `purse_id` can be a formatted public key, account hash, or URef.  It may not be empty.
-pub(super) fn purse_identifier(purse_id: &str) -> Result<PurseIdentifier, CliError> {
+pub fn purse_identifier(purse_id: &str) -> Result<PurseIdentifier, CliError> {
     const ACCOUNT_HASH_PREFIX: &str = "account-hash-";
     const UREF_PREFIX: &str = "uref-";
 

--- a/lib/cli/payment_str_params.rs
+++ b/lib/cli/payment_str_params.rs
@@ -99,7 +99,7 @@ use crate::cli;
 ///
 /// **Note** while multiple payment args can be specified for a single payment code instance, only
 /// one of `payment_args_simple`, `payment_args_json` or `payment_args_complex` may be used.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct PaymentStrParams<'a> {
     pub(super) payment_amount: &'a str,
     pub(super) payment_hash: &'a str,

--- a/lib/cli/session_str_params.rs
+++ b/lib/cli/session_str_params.rs
@@ -1,3 +1,5 @@
+use casper_types::bytesrepr::Bytes;
+
 /// Container for session-related arguments used while constructing a `Deploy`.
 ///
 /// ## `session_args_simple`
@@ -36,6 +38,7 @@ pub struct SessionStrParams<'a> {
     pub(super) session_package_hash: &'a str,
     pub(super) session_package_name: &'a str,
     pub(super) session_path: &'a str,
+    pub(super) session_bytes: Bytes,
     pub(super) session_args_simple: Vec<&'a str>,
     pub(super) session_args_json: &'a str,
     pub(super) session_args_complex: &'a str,
@@ -59,6 +62,27 @@ impl<'a> SessionStrParams<'a> {
     ) -> Self {
         Self {
             session_path,
+            session_args_simple,
+            session_args_json,
+            session_args_complex,
+            ..Default::default()
+        }
+    }
+
+    /// Constructs a `SessionStrParams` using session bytes.
+    ///
+    /// * `session_bytes` are the bytes of the compiled Wasm session code.
+    /// * See the struct docs for a description of [`session_args_simple`](#session_args_simple),
+    ///   [`session_args_json`](#session_args_json) and
+    ///   [`session_args_complex`](#session_args_complex).
+    pub fn with_bytes(
+        session_bytes: Bytes,
+        session_args_simple: Vec<&'a str>,
+        session_args_json: &'a str,
+        session_args_complex: &'a str,
+    ) -> Self {
+        Self {
+            session_bytes,
             session_args_simple,
             session_args_json,
             session_args_complex,

--- a/lib/cli/session_str_params.rs
+++ b/lib/cli/session_str_params.rs
@@ -29,7 +29,7 @@
 ///
 /// **Note** while multiple session args can be specified for a single session code instance, only
 /// one of `session_args_simple`, `session_args_json` or `session_args_complex` may be used.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct SessionStrParams<'a> {
     pub(super) session_hash: &'a str,
     pub(super) session_name: &'a str,

--- a/lib/cli/simple_args.rs
+++ b/lib/cli/simple_args.rs
@@ -344,7 +344,7 @@ fn split_arg(arg: &str) -> Result<(&str, &str, &str), CliError> {
 }
 
 /// Insert a value built from a single arg into `runtime_args`.
-pub(super) fn insert_arg(arg: &str, runtime_args: &mut RuntimeArgs) -> Result<(), CliError> {
+pub fn insert_arg(arg: &str, runtime_args: &mut RuntimeArgs) -> Result<(), CliError> {
     let (name, initial_type, value) = split_arg(arg)?;
     let (simple_type, optional_status, trimmed_value) =
         get_simple_type_and_optional_status(initial_type, value)?;

--- a/lib/json_rpc/call.rs
+++ b/lib/json_rpc/call.rs
@@ -1,10 +1,9 @@
+use crate::{Error, JsonRpcId, SuccessResponse, Verbosity};
 use jsonrpc_lite::{JsonRpc, Params};
 use once_cell::sync::OnceCell;
 use reqwest::Client;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::json;
-
-use crate::{Error, JsonRpcId, SuccessResponse, Verbosity};
 
 const RPC_API_PATH: &str = "rpc";
 /// Statically declared client used when making HTTP requests
@@ -16,6 +15,7 @@ static CLIENT: OnceCell<Client> = OnceCell::new();
 pub(crate) struct Call {
     rpc_id: JsonRpcId,
     node_address: String,
+    #[allow(dead_code)]
     verbosity: Verbosity,
 }
 
@@ -53,6 +53,7 @@ impl Call {
             None => JsonRpc::request(&self.rpc_id, method),
         };
 
+        #[cfg(not(any(feature = "sdk")))]
         crate::json_pretty_print(&rpc_request, self.verbosity)?;
 
         let client = CLIENT.get_or_init(Client::new);
@@ -85,6 +86,7 @@ impl Call {
                     error,
                 })?;
 
+        #[cfg(not(any(feature = "sdk")))]
         crate::json_pretty_print(&rpc_response, self.verbosity)?;
 
         let response_kind = match &rpc_response {

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -35,7 +35,6 @@
     unused_qualifications
 )]
 
-#[cfg(not(any(feature = "sdk")))]
 pub mod cli;
 mod error;
 mod json_rpc;

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -35,6 +35,7 @@
     unused_qualifications
 )]
 
+#[cfg(not(any(feature = "sdk")))]
 pub mod cli;
 mod error;
 mod json_rpc;

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -39,7 +39,9 @@
 pub mod cli;
 mod error;
 mod json_rpc;
+#[cfg(not(any(feature = "sdk")))]
 pub mod keygen;
+#[cfg(not(any(feature = "sdk")))]
 mod output_kind;
 pub mod rpcs;
 pub mod types;

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -41,7 +41,6 @@ mod error;
 mod json_rpc;
 #[cfg(not(any(feature = "sdk")))]
 pub mod keygen;
-#[cfg(not(any(feature = "sdk")))]
 mod output_kind;
 pub mod rpcs;
 pub mod types;

--- a/lib/rpcs.rs
+++ b/lib/rpcs.rs
@@ -12,6 +12,6 @@ pub(crate) mod v1_6_0;
 pub(crate) mod v2_0_0;
 
 pub use v2_0_0::{
-    get_dictionary_item::DictionaryItemIdentifier, query_balance::PurseIdentifier,
-    query_global_state::GlobalStateIdentifier,
+    get_account::AccountIdentifier, get_dictionary_item::DictionaryItemIdentifier,
+    query_balance::PurseIdentifier, query_global_state::GlobalStateIdentifier,
 };

--- a/lib/rpcs/v1_4_5/get_account.rs
+++ b/lib/rpcs/v1_4_5/get_account.rs
@@ -23,7 +23,7 @@ impl GetAccountParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `state_get_account_info` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetAccountResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_auction_info.rs
+++ b/lib/rpcs/v1_4_5/get_auction_info.rs
@@ -19,7 +19,7 @@ impl GetAuctionInfoParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `state_get_auction_info` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetAuctionInfoResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_balance.rs
+++ b/lib/rpcs/v1_4_5/get_balance.rs
@@ -21,7 +21,7 @@ impl GetBalanceParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `state_get_balance` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetBalanceResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_block.rs
+++ b/lib/rpcs/v1_4_5/get_block.rs
@@ -19,7 +19,7 @@ impl GetBlockParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `chain_get_block` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetBlockResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_block_transfers.rs
+++ b/lib/rpcs/v1_4_5/get_block_transfers.rs
@@ -19,7 +19,7 @@ impl GetBlockTransfersParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `chain_get_block_transfers` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetBlockTransfersResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_dictionary_item.rs
+++ b/lib/rpcs/v1_4_5/get_dictionary_item.rs
@@ -11,7 +11,7 @@ use crate::Error;
 pub(crate) const GET_DICTIONARY_ITEM_METHOD: &str = "state_get_dictionary_item";
 
 /// The identifier for a dictionary item.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub enum DictionaryItemIdentifier {
     /// A dictionary item identified via an [`Account`]'s named keys.

--- a/lib/rpcs/v1_4_5/get_dictionary_item.rs
+++ b/lib/rpcs/v1_4_5/get_dictionary_item.rs
@@ -117,7 +117,7 @@ impl GetDictionaryItemParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `state_get_dictionary_item` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetDictionaryItemResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_era_info.rs
+++ b/lib/rpcs/v1_4_5/get_era_info.rs
@@ -36,7 +36,7 @@ pub struct EraSummary {
 
 /// The `result` field of a successful JSON-RPC response to a `chain_get_era_info_by_switch_block`
 /// request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetEraInfoResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_peers.rs
+++ b/lib/rpcs/v1_4_5/get_peers.rs
@@ -15,7 +15,7 @@ pub struct PeerEntry {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `info_get_peers` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetPeersResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_state_root_hash.rs
+++ b/lib/rpcs/v1_4_5/get_state_root_hash.rs
@@ -19,7 +19,7 @@ impl GetStateRootHashParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `chain_get_state_root_hash` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetStateRootHashResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_validator_changes.rs
+++ b/lib/rpcs/v1_4_5/get_validator_changes.rs
@@ -40,7 +40,7 @@ pub struct ValidatorChanges {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `info_get_validator_changes` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetValidatorChangesResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/list_rpcs.rs
+++ b/lib/rpcs/v1_4_5/list_rpcs.rs
@@ -137,7 +137,7 @@ pub struct OpenRpcSchema {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `rpc.discover` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ListRpcsResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/put_deploy.rs
+++ b/lib/rpcs/v1_4_5/put_deploy.rs
@@ -17,7 +17,7 @@ impl PutDeployParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to an `account_put_deploy` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct PutDeployResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/query_global_state.rs
+++ b/lib/rpcs/v1_4_5/query_global_state.rs
@@ -32,7 +32,7 @@ impl QueryGlobalStateParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `query_global_state` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct QueryGlobalStateResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_5_0/get_chainspec.rs
+++ b/lib/rpcs/v1_5_0/get_chainspec.rs
@@ -5,7 +5,7 @@ use casper_types::{ChainspecRawBytes, ProtocolVersion};
 pub(crate) const GET_CHAINSPEC_METHOD: &str = "info_get_chainspec";
 
 /// The `result` field of a successful JSON-RPC response to a `info_get_chainspec` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetChainspecResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_5_0/get_era_summary.rs
+++ b/lib/rpcs/v1_5_0/get_era_summary.rs
@@ -19,7 +19,7 @@ impl GetEraSummaryParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `chain_get_era_summary` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetEraSummaryResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_5_0/get_node_status.rs
+++ b/lib/rpcs/v1_5_0/get_node_status.rs
@@ -57,7 +57,7 @@ pub struct BlockSynchronizerStatus {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `info_get_status` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetNodeStatusResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_5_0/query_balance.rs
+++ b/lib/rpcs/v1_5_0/query_balance.rs
@@ -40,7 +40,7 @@ impl QueryBalanceParams {
 }
 
 /// Result for "query_balance" RPC response.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct QueryBalanceResult {
     /// The RPC API version.
     pub api_version: ProtocolVersion,

--- a/lib/rpcs/v1_5_0/speculative_exec.rs
+++ b/lib/rpcs/v1_5_0/speculative_exec.rs
@@ -25,7 +25,7 @@ impl SpeculativeExecParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `speculative_exec` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct SpeculativeExecResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_6_0/get_account.rs
+++ b/lib/rpcs/v1_6_0/get_account.rs
@@ -40,7 +40,7 @@ impl GetAccountParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `state_get_account_info` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetAccountResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v2_0_0/get_deploy.rs
+++ b/lib/rpcs/v2_0_0/get_deploy.rs
@@ -15,7 +15,7 @@ pub struct DeployExecutionInfo {
 }
 
 /// The `result` field of a successful JSON-RPC response to an `info_get_deploy` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetDeployResult {
     /// The JSON-RPC server version.

--- a/lib/types/legacy_execution_result.rs
+++ b/lib/types/legacy_execution_result.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use casper_types::BlockHash;
 
 /// The execution result of a single deploy.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct LegacyExecutionResult {
     /// The block hash.

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,7 @@ fn cli() -> Command {
         ))
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     let arg_matches = cli().get_matches();
     let (subcommand_name, matches) = arg_matches.subcommand().unwrap_or_else(|| {


### PR DESCRIPTION
Right now this feature only build with --lib

Mainly adds some `#[cfg(feature = "sdk")]` where it is possible or not to use io/fs, or prevent sending to std with `json_pretty_print` and returning deploys 
Changes the way secret key is loaded in `with_payment_and_session()`
Publicizes some methods outside the crate 
Adds `session_bytes` to `session_executable_deploy_item()` and adds `check_no_conflicting_arg_types() `(might require additional unit tests)
Adds `with_bytes()` to `SessionStrParams `
Adds some `Clone` attributes to some structs
Removes rt-multi-thread, `The default runtime flavor is 'multi_thread', but the 'rt-multi-thread' feature is disabled.` switching (flavor = "current_thread") to tokio main

<s>I could not make it compile without this change in cargo.toml related to casper types
`getrandom = { version = "0.2.10", features = ["js"] }` getrandom probably needs to be replaced by something else.</s>
Removing `[patch.crates-io]` as I believe this bug was fixed and this is not needed anymore.

https://github.com/casper-ecosystem/rustSDK/issues/4
https://github.com/casper-ecosystem/rustSDK/issues/5