### PR TITLE
Update GetBlockResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ All notable changes to this project will be documented in this file.  The format
 * Add an optional flag to retrieve finalized approvals for `info_get_deploy`
 * Add support for providing an account identifier (public key, or account hash) for the `state_get_account_info` RPC method.
 
+### Fixed
+* Fix `GetBlockResult` to match the node's RPC response via `JsonBlockWithSignatures`, and provide block proofs.
 
 
 ## [2.0.0] - 2023-06-28

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,9 @@ num-traits = "0.2.15"
 once_cell = "1"
 rand = "0.8.5"
 reqwest = { version = "0.11.13", features = ["json"] }
-schemars = "0.8.12"
+schemars = "0.8.13"
 serde = { version = "1", default-features = false, features = ["derive"] }
-serde-map-to-array = {version = "1.1.1", features = ["json-schema"]}
+serde-map-to-array = "1.1.1"
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "1.0.34"
 tokio = { version = "1.23.0", features = ["macros", "net", "rt-multi-thread", "sync", "time", ]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,9 @@ num-traits = "0.2.15"
 once_cell = "1"
 rand = "0.8.5"
 reqwest = { version = "0.11.13", features = ["json"] }
-schemars = "0.8"
+schemars = "0.8.12"
 serde = { version = "1", default-features = false, features = ["derive"] }
-serde-map-to-array = "1.1.0"
+serde-map-to-array = {version = "1.1.1", features = ["json-schema"]}
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "1.0.34"
 tokio = { version = "1.23.0", features = ["macros", "net", "rt-multi-thread", "sync", "time", ]}

--- a/lib/rpcs/v2_0_0.rs
+++ b/lib/rpcs/v2_0_0.rs
@@ -1,6 +1,7 @@
 //! The JSON-RPC request and response types at v2.0.0 of casper-node.
 
 pub(crate) mod get_deploy;
+pub mod get_block;
 
 // The following RPCs are all unchanged from v1.6.0, so we just re-export them.
 
@@ -19,11 +20,6 @@ pub(crate) mod get_auction_info {
 pub(crate) mod get_balance {
     pub use crate::rpcs::v1_6_0::get_balance::GetBalanceResult;
     pub(crate) use crate::rpcs::v1_6_0::get_balance::{GetBalanceParams, GET_BALANCE_METHOD};
-}
-
-pub(crate) mod get_block {
-    pub use crate::rpcs::v1_6_0::get_block::GetBlockResult;
-    pub(crate) use crate::rpcs::v1_6_0::get_block::{GetBlockParams, GET_BLOCK_METHOD};
 }
 
 pub(crate) mod get_block_transfers {

--- a/lib/rpcs/v2_0_0.rs
+++ b/lib/rpcs/v2_0_0.rs
@@ -1,6 +1,7 @@
 //! The JSON-RPC request and response types at v2.0.0 of casper-node.
 
 pub(crate) mod get_deploy;
+
 pub mod get_block;
 
 // The following RPCs are all unchanged from v1.6.0, so we just re-export them.

--- a/lib/rpcs/v2_0_0.rs
+++ b/lib/rpcs/v2_0_0.rs
@@ -1,8 +1,7 @@
 //! The JSON-RPC request and response types at v2.0.0 of casper-node.
 
 pub(crate) mod get_deploy;
-
-pub mod get_block;
+pub(crate) mod get_block;
 
 // The following RPCs are all unchanged from v1.6.0, so we just re-export them.
 

--- a/lib/rpcs/v2_0_0/get_block.rs
+++ b/lib/rpcs/v2_0_0/get_block.rs
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Serialize};
+
+use casper_types::ProtocolVersion;
+
+pub(crate) use crate::rpcs::v1_6_0::get_block::{GetBlockParams, GET_BLOCK_METHOD};
+
+use crate::types::JsonBlockWithSignatures;
+
+/// The `result` field of a successful JSON-RPC response to a `chain_get_block` request.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct GetBlockResult {
+    /// The JSON-RPC server version.
+    pub api_version: ProtocolVersion,
+    /// The block, if found.
+    pub block: Option<JsonBlockWithSignatures>,
+}

--- a/lib/rpcs/v2_0_0/get_block.rs
+++ b/lib/rpcs/v2_0_0/get_block.rs
@@ -13,5 +13,5 @@ pub struct GetBlockResult {
     /// The JSON-RPC server version.
     pub api_version: ProtocolVersion,
     /// The block, if found.
-    pub block: Option<JsonBlockWithSignatures>,
+    pub block_with_signatures: Option<JsonBlockWithSignatures>,
 }

--- a/lib/types.rs
+++ b/lib/types.rs
@@ -3,7 +3,9 @@
 mod auction_state;
 mod deploy_execution_info;
 mod legacy_execution_result;
+mod json_block_with_signatures;
 
+pub use json_block_with_signatures::JsonBlockWithSignatures;
 pub use auction_state::AuctionState;
 pub use deploy_execution_info::DeployExecutionInfo;
 pub use legacy_execution_result::LegacyExecutionResult;

--- a/lib/types/json_block_with_signatures.rs
+++ b/lib/types/json_block_with_signatures.rs
@@ -7,7 +7,6 @@ use casper_types::{Block, PublicKey, Signature};
 
 /// A JSON-friendly representation of a block and the signatures for that block.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "datasize", derive(DataSize))]
 #[serde(deny_unknown_fields)]
 pub struct JsonBlockWithSignatures {
     /// The block.

--- a/lib/types/json_block_with_signatures.rs
+++ b/lib/types/json_block_with_signatures.rs
@@ -22,12 +22,3 @@ impl KeyValueLabels for BlockProofLabels {
     const KEY: &'static str = "public_key";
     const VALUE: &'static str = "signature";
 }
-
-impl KeyValueJsonSchema for BlockProofLabels {
-    const JSON_SCHEMA_KV_NAME: Option<&'static str> = Some("BlockProof");
-    const JSON_SCHEMA_KV_DESCRIPTION: Option<&'static str> = Some(
-        "A validator's public key paired with a corresponding signature of a given block hash.",
-    );
-    const JSON_SCHEMA_KEY_DESCRIPTION: Option<&'static str> = Some("The validator's public key.");
-    const JSON_SCHEMA_VALUE_DESCRIPTION: Option<&'static str> = Some("The validator's signature.");
-}

--- a/lib/types/json_block_with_signatures.rs
+++ b/lib/types/json_block_with_signatures.rs
@@ -1,0 +1,34 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_map_to_array::{BTreeMapToArray, KeyValueJsonSchema, KeyValueLabels, };
+
+use casper_types::{Block, PublicKey, Signature};
+
+/// A JSON-friendly representation of a block and the signatures for that block.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+#[serde(deny_unknown_fields)]
+pub struct JsonBlockWithSignatures {
+    /// The block.
+    pub block: Block,
+    /// The proofs of the block, i.e. a collection of validators' signatures of the block hash.
+    #[serde(with = "BTreeMapToArray::<PublicKey, Signature, BlockProofLabels>")]
+    pub proofs: BTreeMap<PublicKey, Signature>,
+}
+
+struct BlockProofLabels;
+
+impl KeyValueLabels for BlockProofLabels {
+    const KEY: &'static str = "public_key";
+    const VALUE: &'static str = "signature";
+}
+
+impl KeyValueJsonSchema for BlockProofLabels {
+    const JSON_SCHEMA_KV_NAME: Option<&'static str> = Some("BlockProof");
+    const JSON_SCHEMA_KV_DESCRIPTION: Option<&'static str> = Some(
+        "A validator's public key paired with a corresponding signature of a given block hash.",
+    );
+    const JSON_SCHEMA_KEY_DESCRIPTION: Option<&'static str> = Some("The validator's public key.");
+    const JSON_SCHEMA_VALUE_DESCRIPTION: Option<&'static str> = Some("The validator's signature.");
+}

--- a/lib/types/json_block_with_signatures.rs
+++ b/lib/types/json_block_with_signatures.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
-use serde_map_to_array::{BTreeMapToArray, KeyValueJsonSchema, KeyValueLabels, };
+use serde_map_to_array::{BTreeMapToArray, KeyValueLabels};
 
 use casper_types::{Block, PublicKey, Signature};
 

--- a/src/deploy/list.rs
+++ b/src/deploy/list.rs
@@ -36,10 +36,10 @@ impl From<GetBlockResult> for ListDeploysResult {
             deploy_hashes: get_block_result
                 .block
                 .as_ref()
-                .map(|block| block.body().deploy_hashes().to_vec()),
+                .map(|block| block.block.body().deploy_hashes().to_vec()),
             transfer_hashes: get_block_result
                 .block
-                .map(|ref block| block.body().transfer_hashes().to_vec()),
+                .map(|ref block| block.block.body().transfer_hashes().to_vec()),
         }
     }
 }

--- a/src/deploy/list.rs
+++ b/src/deploy/list.rs
@@ -34,11 +34,11 @@ impl From<GetBlockResult> for ListDeploysResult {
         ListDeploysResult {
             api_version: get_block_result.api_version,
             deploy_hashes: get_block_result
-                .block
+                .block_with_signatures
                 .as_ref()
                 .map(|block| block.block.body().deploy_hashes().to_vec()),
             transfer_hashes: get_block_result
-                .block
+                .block_with_signatures
                 .map(|ref block| block.block.body().transfer_hashes().to_vec()),
         }
     }


### PR DESCRIPTION
# Summary of work done:
- Add `JsonBlockWithSignatures` to types
- Change `GetBlockResult` to contain a `JsonBlockWithSignatures`, rather than a Block
- Update `From<GetBlockResult>` for `ListDeploysResult`
### Sample request:

Request for a specific block from an NCTL network 
```
{
  "jsonrpc": "2.0",
  "method": "chain_get_block",
  "params": {
    "block_identifier": {
      "Height": 10
    }
  },
  "id": 220061567579167330
}
```

Associated output:

```
{
  "jsonrpc": "2.0",
  "result": {
    "api_version": "1.0.0",
    "block_with_signatures": {
      "block": {
        "Version2": {
          "hash": "fa66c6523d409884e12a1542f4991f893e3758adaf531e2af861681983d92c34",
          "header": {
            "parent_hash": "a8e5efcd3702f3fe635bd96ed3af594cdd99bd9c9679a309b09e2851e71a31f4",
            "state_root_hash": "5723118c3d731fd6443ef47f8a99a59c0d56fb87e4787856791eae30b6085f61",
            "body_hash": "994ea594b616d29b0d1625075d160248cb63cac5730d36c75ab4bf64aa372871",
            "random_bit": true,
            "accumulated_seed": "426d5e8ee1e8c3ad65708e68ac3ce9e61c1d3b794d570462247b421ed0eda199",
            "era_end": null,
            "timestamp": "2023-09-18T19:27:35.936Z",
            "era_id": 1,
            "height": 10,
            "protocol_version": "1.0.0"
          },
          "body": {
            "proposer": "0156637c9e70e46fbe97ae0117288b1bcbfc8ee2f1370ab132a930bce70a470481",
            "deploy_hashes": [],
            "transfer_hashes": []
          }
        }
      },
      "proofs": [
        {
          "public_key": "0156637c9e70e46fbe97ae0117288b1bcbfc8ee2f1370ab132a930bce70a470481",
          "signature": "015d7c0c8989bb881366ada77c27e8250a0387cde65d20eb7b12a80dbe626980f895c1433d6f84ca52772c6f56de045600e93603d2122a282a09af845cfb31a603"
        },
        {
          "public_key": "0162e43f9f39821b568318fe008f9e9d161e9e07bedf56943a834572c9b835fa49",
          "signature": "01ac4fa3dc82e07f000176030b561a844221e99dd8d1dbd4325653f907de2ec646a6c7c4e24ea89d6bc44b85e85d030e53b49c65935aa9d0d42848854ba171f30e"
        },
        {
          "public_key": "01b518a6b0f9a73322c325dc6a603a05951a83de4cb3631690d6f09039f583a157",
          "signature": "014419773b0a0b22320b256f5a840483833f026bdfb5f272ee226d77d5772a4cf94b58b70a8cf80469e4bbdf455f015416627dcbd4f951ea5d392291a25c0dbf00"
        },
        {
          "public_key": "01dd327a943acc4bbcf4a0d32b35426eb7430080f7970fbaf12e5cefb9eb1699ef",
          "signature": "01423fc95817a67554ab5ab337a38e27bafe3c2a438bc4b0417dd9fb01caec9267cd02511f0ad0147861d949a380c549cadf925800a422592f38ed57824b67a20a"
        },
        {
          "public_key": "01e4077cf35ae79149a8f8ce25a87d5b68232e1c9c197e0da480b7208c3b5806fa",
          "signature": "01f9edc2b6428e55c08c1089719cf87022d5efb25fa1c471235f48aaa8b3f4efce49d16f9c56a85b307127810a9452afb1e60e8db7232c59b15aa6d67e72c0b508"
        }
      ]
    }
  },
  "id": 220061567579167330
}

```

Request for the most recent block from an NCTL network by providing no block identifier

```
{
  "jsonrpc": "2.0",
  "method": "chain_get_block",
  "id": -6305169290758910529
}
```

Associated output:

```
{
  "jsonrpc": "2.0",
  "result": {
    "api_version": "1.0.0",
    "block_with_signatures": {
      "block": {
        "Version2": {
          "hash": "0f4db97896f7a86576e43a05c2a37e26463dfb015a27dd71a016b1c590500af3",
          "header": {
            "parent_hash": "1c0759be2e7d06856f05b559e7dd1682af5d6d7e938f1ae64cd4b388ab0080d2",
            "state_root_hash": "e0e28bdf09f1420f92e6bd9199c60f080d89efaf5827c40a8f99f38b17265a08",
            "body_hash": "994ea594b616d29b0d1625075d160248cb63cac5730d36c75ab4bf64aa372871",
            "random_bit": true,
            "accumulated_seed": "d9ad22a477fad1db2936a3e126c5d2c018def17042b124b6e1b97685e51321e1",
            "era_end": null,
            "timestamp": "2023-09-18T21:23:06.368Z",
            "era_id": 155,
            "height": 1588,
            "protocol_version": "1.0.0"
          },
          "body": {
            "proposer": "0156637c9e70e46fbe97ae0117288b1bcbfc8ee2f1370ab132a930bce70a470481",
            "deploy_hashes": [],
            "transfer_hashes": []
          }
        }
      },
      "proofs": [
        {
          "public_key": "0156637c9e70e46fbe97ae0117288b1bcbfc8ee2f1370ab132a930bce70a470481",
          "signature": "016e37b4187b61c9f3048ab5bc3013ff6380cb6818db1cd8317071f2ea6476b117ff07bce8ed24e26c5b35dd99d8142fe06f09b76fbe13bb7d4530cdf2a7545e01"
        },
        {
          "public_key": "0162e43f9f39821b568318fe008f9e9d161e9e07bedf56943a834572c9b835fa49",
          "signature": "01e6ac72fc217b9b3a13359785a3b008a4cef170645e236d9f2423d9b9e8f609fc19424585576576213f7752cb8c7ff0b4e8c5e2f56992845def988b624fabca08"
        },
        {
          "public_key": "01b518a6b0f9a73322c325dc6a603a05951a83de4cb3631690d6f09039f583a157",
          "signature": "010a720b09620245d6f31af10bce4ddf8c8e36a725d141539ccb491c8a8aef4850c02826b6be3bdbaa9b48d3f4f4da292cf1495c44c53e2529eae0fd0639dd0b05"
        },
        {
          "public_key": "01dd327a943acc4bbcf4a0d32b35426eb7430080f7970fbaf12e5cefb9eb1699ef",
          "signature": "01d9b82f644f002be038346ccbfc39fab46be606917d53a837b7834173794315d5780dddd0e8c92a85bb033c0ce8cc864e266336d160ce8f92ee18a607b2677e02"
        },
        {
          "public_key": "01e4077cf35ae79149a8f8ce25a87d5b68232e1c9c197e0da480b7208c3b5806fa",
          "signature": "01d8fb970a8e782cef2dd7def7e3f317e96cd416f641613c9b5aab82359ec90e45054baacd9fdc6c108480561d12c3105cae2b7dd430dbc6e29c1df8a0ca785502"
        }
      ]
    }
  },
  "id": -6305169290758910529
}

```

# Associated ticket(s):
#108 
[Ticket #108](https://app.zenhub.com/workspaces/rust-sdk-64b185bf2cb87924e7759d9d/issues/gh/casper-ecosystem/casper-client-rs/108)