### PR TITLE
Proposition of changes into Casper Types to support a Rust SDK for 1.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,9 @@ itertools = "0.11.0"
 jsonrpc-lite = "0.6.0"
 num-traits = "0.2.15"
 once_cell = "1"
-rand = "=0.8.5"
+rand = "0.8.5"
 reqwest = { version = "0.11.13", features = ["json"] }
-schemars = "0.8.5"
+schemars = "=0.8.5"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "1.0.34"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ num-traits = "0.2.15"
 once_cell = "1"
 rand = "0.8.5"
 reqwest = { version = "0.11.13", features = ["json"] }
-schemars = "0.8"
+schemars = "0.8.13"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "1.0.34"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ repository = "https://github.com/casper-ecosystem/casper-client-rs"
 license = "Apache-2.0"
 
 [lib]
+crate-type = ["cdylib", "rlib"]
 name = "casper_client"
 path = "lib/lib.rs"
 
@@ -25,11 +26,13 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
+casper-hashing = { version = "2.0.0", git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.5" }
 async-trait = "0.1.59"
 base16 = "0.2.1"
-casper-hashing = "2.0.0"
-casper-types = { version = "3.0.0", features = ["std"] }
-clap = { version = "4", features = ["cargo", "deprecated", "wrap_help"] }
+casper-types = { version = "3.0.0", git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.5", features = [
+  "std",
+] }
+clap = { version = "4", features = ["cargo", "deprecated"] }
 clap_complete = "4"
 hex-buffer-serde = "0.4.0"
 humantime = "2"
@@ -43,13 +46,7 @@ schemars = "0.8"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "1.0.34"
-tokio = { version = "1.23.0", features = [
-  "macros",
-  "net",
-  "rt-multi-thread",
-  "sync",
-  "time",
-] }
+tokio = { version = "1.23.0", features = ["macros", "rt", "sync", "time"] }
 uint = "0.9.4"
 
 [dev-dependencies]
@@ -60,10 +57,6 @@ sdk = ["casper-types/sdk"]
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["git"] }
-
-[patch.crates-io]
-casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.5" }
-casper-types = { git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.5" }
 
 [package.metadata.deb]
 features = ["vendored-openssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ doc = false
 async-trait = "0.1.59"
 base16 = "0.2.1"
 casper-hashing = "2.0.0"
-casper-types = { version = "3.0.0", features = ["std", "sdk"] }
+casper-types = { version = "3.0.0", features = ["std"] }
 clap = { version = "4", features = ["cargo", "deprecated", "wrap_help"] }
 clap_complete = "4"
 hex-buffer-serde = "0.4.0"
@@ -54,6 +54,9 @@ uint = "0.9.4"
 
 [dev-dependencies]
 tempfile = "3.7.1"
+
+[features]
+sdk = ["casper-types/sdk"]
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["git"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ num-traits = "0.2.15"
 once_cell = "1"
 rand = "0.8.5"
 reqwest = { version = "0.11.13", features = ["json"] }
-schemars = "0.8.13"
+schemars = "0.8"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "1.0.34"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ num-traits = "0.2.15"
 once_cell = "1"
 rand = "0.8.5"
 reqwest = { version = "0.11.13", features = ["json"] }
-schemars = "0.8"
+schemars = "0.8.5"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "1.0.34"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "casper-client"
-version = "2.0.0" # when updating, also update 'html_root_url' in lib.rs
-authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>", "Zachary Showalter <zach@casperlabs.io>"]
+# when updating, also update 'html_root_url' in lib.rs
+version = "2.0.0"
+authors = [
+  "Marc Brinkmann <marc@casperlabs.io>",
+  "Fraser Hutchison <fraser@casperlabs.io>",
+  "Zachary Showalter <zach@casperlabs.io>",
+]
 edition = "2021"
 description = "A client library and binary for interacting with the Casper network"
 documentation = "https://docs.rs/casper-client"
@@ -23,7 +28,7 @@ doc = false
 async-trait = "0.1.59"
 base16 = "0.2.1"
 casper-hashing = "2.0.0"
-casper-types = { version = "3.0.0", features = ["std"] }
+casper-types = { version = "3.0.0", features = ["std", "sdk"] }
 clap = { version = "4", features = ["cargo", "deprecated", "wrap_help"] }
 clap_complete = "4"
 hex-buffer-serde = "0.4.0"
@@ -38,7 +43,13 @@ schemars = "0.8"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "1.0.34"
-tokio = { version = "1.23.0", features = ["macros", "net", "rt-multi-thread", "sync", "time", ]}
+tokio = { version = "1.23.0", features = [
+  "macros",
+  "net",
+  "rt-multi-thread",
+  "sync",
+  "time",
+] }
 uint = "0.9.4"
 
 [dev-dependencies]
@@ -48,13 +59,13 @@ tempfile = "3.7.1"
 vergen = { version = "7", default-features = false, features = ["git"] }
 
 [patch.crates-io]
-casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
-casper-types = { git = "https://github.com/casper-network/casper-node", branch = "dev"}
+casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.5" }
+casper-types = { git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.5" }
 
 [package.metadata.deb]
 features = ["vendored-openssl"]
 revision = "0"
-assets = [["./target/release/casper-client", "/usr/bin/casper-client", "755"], ]
+assets = [["./target/release/casper-client", "/usr/bin/casper-client", "755"]]
 extended-description = """
 Package for Casper Client to connect to Casper Node.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,10 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-casper-hashing = { version = "2.0.0", git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.6" }
+casper-hashing = { version = "2.0.0" }
 async-trait = "0.1.59"
 base16 = "0.2.1"
-casper-types = { version = "3.0.0", git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.6", features = [
-  "std",
-] }
+casper-types = { version = "3.0.0", features = ["std"] }
 clap = { version = "4", features = ["cargo", "deprecated"] }
 clap_complete = "4"
 hex-buffer-serde = "0.4.0"
@@ -57,6 +55,10 @@ sdk = ["casper-types/sdk"]
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["git"] }
+
+[patch.crates-io]
+casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
+casper-types = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
 
 [package.metadata.deb]
 features = ["vendored-openssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ itertools = "0.11.0"
 jsonrpc-lite = "0.6.0"
 num-traits = "0.2.15"
 once_cell = "1"
-rand = "0.8.5"
+rand = "=0.8.5"
 reqwest = { version = "0.11.13", features = ["json"] }
 schemars = "0.8.5"
 serde = { version = "1", default-features = false, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-casper-hashing = { version = "2.0.0", git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.5" }
+casper-hashing = { version = "2.0.0", git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.6" }
 async-trait = "0.1.59"
 base16 = "0.2.1"
-casper-types = { version = "3.0.0", git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.5", features = [
+casper-types = { version = "3.0.0", git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.6", features = [
   "std",
 ] }
 clap = { version = "4", features = ["cargo", "deprecated"] }

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -31,7 +31,12 @@ mod payment_str_params;
 mod session_str_params;
 mod simple_args;
 #[cfg(feature = "sdk")]
+pub use parse::account_identifier as parse_account_identifier;
+#[cfg(feature = "sdk")]
+pub use parse::purse_identifier as parse_purse_identifier;
+#[cfg(feature = "sdk")]
 pub use simple_args::insert_arg;
+
 #[cfg(test)]
 mod tests;
 

--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -1,6 +1,6 @@
-#[cfg(feature = "sdk")]
-use casper_types::SecretKey;
-use casper_types::{account::AccountHash, AsymmetricType, PublicKey, UIntParseError, URef, U512};
+use casper_types::{
+    account::AccountHash, AsymmetricType, PublicKey, SecretKey, UIntParseError, URef, U512,
+};
 
 use super::{parse, CliError, DeployStrParams, PaymentStrParams, SessionStrParams};
 use crate::{

--- a/lib/cli/error.rs
+++ b/lib/cli/error.rs
@@ -113,7 +113,7 @@ pub enum CliError {
     ConflictingArguments {
         /// Contextual description of where this error occurred including relevant paths,
         /// filenames, etc.
-        context: &'static str,
+        context: String,
         /// Arguments passed, with their values.
         args: Vec<String>,
     },

--- a/lib/cli/json_args.rs
+++ b/lib/cli/json_args.rs
@@ -16,8 +16,9 @@ use casper_types::{
 use crate::cli::CliError;
 pub use error::{Error, ErrorDetails};
 
+/// Represents a JSON argument with a name, type, and value.
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub(super) struct JsonArg {
+pub struct JsonArg {
     name: String,
     #[serde(rename = "type")]
     cl_type: CLType,

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -1,22 +1,28 @@
 //! This module contains structs and helpers which are used by multiple subcommands related to
 //! creating deploys.
 
-use std::{convert::TryInto, fs, io, path::Path, str::FromStr};
+#[cfg(not(any(feature = "sdk")))]
+use std::path::Path;
+use std::{convert::TryInto, fs, io, str::FromStr};
 
 use rand::Rng;
 use serde::{self, Deserialize};
 
 use casper_hashing::Digest;
+#[cfg(not(any(feature = "sdk")))]
+use casper_types::SecretKey;
 use casper_types::{
     account::AccountHash, bytesrepr, crypto, AsymmetricType, CLValue, HashAddr, Key, NamedArg,
-    PublicKey, RuntimeArgs, SecretKey, UIntParseError, URef, U512,
+    PublicKey, RuntimeArgs, UIntParseError, URef, U512,
 };
 
 use super::{simple_args, CliError, PaymentStrParams, SessionStrParams};
+#[cfg(not(any(feature = "sdk")))]
+use crate::OutputKind;
 use crate::{
     types::{BlockHash, DeployHash, ExecutableDeployItem, TimeDiff, Timestamp},
-    AccountIdentifier, BlockIdentifier, GlobalStateIdentifier, JsonRpcId, OutputKind,
-    PurseIdentifier, Verbosity,
+    AccountIdentifier, BlockIdentifier, GlobalStateIdentifier, JsonRpcId, PurseIdentifier,
+    Verbosity,
 };
 
 pub(super) fn rpc_id(maybe_rpc_id: &str) -> JsonRpcId {
@@ -37,6 +43,7 @@ pub(super) fn verbosity(verbosity_level: u64) -> Verbosity {
     }
 }
 
+#[cfg(not(any(feature = "sdk")))]
 pub(super) fn output_kind(maybe_output_path: &str, force: bool) -> OutputKind {
     if maybe_output_path.is_empty() {
         OutputKind::Stdout
@@ -45,6 +52,7 @@ pub(super) fn output_kind(maybe_output_path: &str, force: bool) -> OutputKind {
     }
 }
 
+#[cfg(not(any(feature = "sdk")))]
 pub(super) fn secret_key_from_file<P: AsRef<Path>>(
     secret_key_path: P,
 ) -> Result<SecretKey, CliError> {

--- a/lib/cli/payment_str_params.rs
+++ b/lib/cli/payment_str_params.rs
@@ -99,7 +99,7 @@ use crate::cli;
 ///
 /// **Note** while multiple payment args can be specified for a single payment code instance, only
 /// one of `payment_args_simple`, `payment_args_json` or `payment_args_complex` may be used.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct PaymentStrParams<'a> {
     pub(super) payment_amount: &'a str,
     pub(super) payment_hash: &'a str,

--- a/lib/cli/session_str_params.rs
+++ b/lib/cli/session_str_params.rs
@@ -1,3 +1,5 @@
+use casper_types::bytesrepr::Bytes;
+
 /// Container for session-related arguments used while constructing a `Deploy`.
 ///
 /// ## `session_args_simple`
@@ -29,13 +31,14 @@
 ///
 /// **Note** while multiple session args can be specified for a single session code instance, only
 /// one of `session_args_simple`, `session_args_json` or `session_args_complex` may be used.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct SessionStrParams<'a> {
     pub(super) session_hash: &'a str,
     pub(super) session_name: &'a str,
     pub(super) session_package_hash: &'a str,
     pub(super) session_package_name: &'a str,
     pub(super) session_path: &'a str,
+    pub(super) session_bytes: Bytes,
     pub(super) session_args_simple: Vec<&'a str>,
     pub(super) session_args_json: &'a str,
     pub(super) session_args_complex: &'a str,
@@ -59,6 +62,27 @@ impl<'a> SessionStrParams<'a> {
     ) -> Self {
         Self {
             session_path,
+            session_args_simple,
+            session_args_json,
+            session_args_complex,
+            ..Default::default()
+        }
+    }
+
+    /// Constructs a `SessionStrParams` using session bytes.
+    ///
+    /// * `session_bytes` are the bytes of the compiled Wasm session code.
+    /// * See the struct docs for a description of [`session_args_simple`](#session_args_simple),
+    ///   [`session_args_json`](#session_args_json) and
+    ///   [`session_args_complex`](#session_args_complex).
+    pub fn with_bytes(
+        session_bytes: Bytes,
+        session_args_simple: Vec<&'a str>,
+        session_args_json: &'a str,
+        session_args_complex: &'a str,
+    ) -> Self {
+        Self {
+            session_bytes,
             session_args_simple,
             session_args_json,
             session_args_complex,

--- a/lib/cli/simple_args.rs
+++ b/lib/cli/simple_args.rs
@@ -676,7 +676,7 @@ mod tests {
         const ARG_GIBBERISH: &str = "asdf|1234(..)";
         const ARG_UNQUOTED: &str = "name:u32=0"; // value needs single quotes to be valid
         const EMPTY: &str = "";
-        const LARGE_2K_INPUT: &str = r#"
+        const LARGE_2K_INPUT: &str = r"
 eJy2irIizK6zT0XOklyBAY1KVUsAbyF6eJUYBmRPHqX2rONbaEieJt4Ci1eZYjBdHdEq46oMBH0LeiQO8RIJb95
 SJGEp83RxakDj7trunJVvMbj2KZFnpJOyEauFa35dlaVG9Ki7hjFy4BLlDyA0Wgwk20RXFkbgKQIQVvR16RPffR
 WO86WqZ3gMuOh447svZRYfhbRF3NVBaWRz7SJ9Zm3w8djisvS0Y3GSnpzKnSEQirApqomfQTHTrU9ww2SMgdGuu
@@ -701,7 +701,7 @@ Q8d1wPtqKgayVtgdIaMbvsnXMkRqITkf3o8Qh495pm1wkKArTGFGODXc1cCKheFUEtJWdK92DHH7OuRE
 PKzSUg2k18wyf9XCy1pQKv31wii3rWrWMCbxOWmhuzw1N9tqO8U97NsThRSoPAjpd05G2roia4m4CaPWTAUmVky
 RfiWoA7bglAh4Aoz2LN2ezFleTNJjjLw3n9bYPg5BdRL8n8wimhXDo9SW46A5YS62C08ZOVtvfn82YRaYkuKKz7
 3NJ25PnQG6diMm4Lm3wi22yR7lY7oYYJjLNcaLYOI6HOvaJ
-"#;
+";
 
         check_insert_invalid_arg(ARG_BAD_TYPE);
         check_insert_invalid_arg(ARG_GIBBERISH);

--- a/lib/cli/simple_args.rs
+++ b/lib/cli/simple_args.rs
@@ -344,7 +344,7 @@ fn split_arg(arg: &str) -> Result<(&str, &str, &str), CliError> {
 }
 
 /// Insert a value built from a single arg into `runtime_args`.
-pub(super) fn insert_arg(arg: &str, runtime_args: &mut RuntimeArgs) -> Result<(), CliError> {
+pub fn insert_arg(arg: &str, runtime_args: &mut RuntimeArgs) -> Result<(), CliError> {
     let (name, initial_type, value) = split_arg(arg)?;
     let (simple_type, optional_status, trimmed_value) =
         get_simple_type_and_optional_status(initial_type, value)?;

--- a/lib/cli/tests.rs
+++ b/lib/cli/tests.rs
@@ -182,7 +182,7 @@ fn should_fail_to_create_large_deploy() {
 #[test]
 fn should_read_deploy() {
     let bytes = SAMPLE_DEPLOY.as_bytes();
-    assert!(matches!(crate::read_deploy(bytes), Ok(_)));
+    assert!(crate::read_deploy(bytes).is_ok());
 }
 
 #[test]

--- a/lib/json_rpc/call.rs
+++ b/lib/json_rpc/call.rs
@@ -16,6 +16,7 @@ static CLIENT: OnceCell<Client> = OnceCell::new();
 pub(crate) struct Call {
     rpc_id: JsonRpcId,
     node_address: String,
+    #[allow(dead_code)]
     verbosity: Verbosity,
 }
 
@@ -53,6 +54,7 @@ impl Call {
             None => JsonRpc::request(&self.rpc_id, method),
         };
 
+        #[cfg(not(any(feature = "sdk")))]
         crate::json_pretty_print(&rpc_request, self.verbosity)?;
 
         let client = CLIENT.get_or_init(Client::new);
@@ -85,6 +87,7 @@ impl Call {
                     error,
                 })?;
 
+        #[cfg(not(any(feature = "sdk")))]
         crate::json_pretty_print(&rpc_response, self.verbosity)?;
 
         let response_kind = match &rpc_response {

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -38,6 +38,7 @@
 pub mod cli;
 mod error;
 mod json_rpc;
+#[cfg(not(any(feature = "sdk")))]
 pub mod keygen;
 mod output_kind;
 pub mod rpcs;

--- a/lib/rpcs.rs
+++ b/lib/rpcs.rs
@@ -13,3 +13,5 @@ pub use v1_5_0::{
     get_dictionary_item::DictionaryItemIdentifier, query_balance::PurseIdentifier,
     query_global_state::GlobalStateIdentifier,
 };
+
+pub use v1_6_0::get_account::AccountIdentifier;

--- a/lib/rpcs/v1_4_5/get_account.rs
+++ b/lib/rpcs/v1_4_5/get_account.rs
@@ -27,7 +27,7 @@ impl GetAccountParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `state_get_account_info` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetAccountResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_auction_info.rs
+++ b/lib/rpcs/v1_4_5/get_auction_info.rs
@@ -19,7 +19,7 @@ impl GetAuctionInfoParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `state_get_auction_info` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetAuctionInfoResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_balance.rs
+++ b/lib/rpcs/v1_4_5/get_balance.rs
@@ -22,7 +22,7 @@ impl GetBalanceParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `state_get_balance` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetBalanceResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_block.rs
+++ b/lib/rpcs/v1_4_5/get_block.rs
@@ -19,7 +19,7 @@ impl GetBlockParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `chain_get_block` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetBlockResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_block_transfers.rs
+++ b/lib/rpcs/v1_4_5/get_block_transfers.rs
@@ -19,7 +19,7 @@ impl GetBlockTransfersParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `chain_get_block_transfers` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetBlockTransfersResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_deploy.rs
+++ b/lib/rpcs/v1_4_5/get_deploy.rs
@@ -23,7 +23,7 @@ impl GetDeployParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to an `info_get_deploy` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetDeployResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_dictionary_item.rs
+++ b/lib/rpcs/v1_4_5/get_dictionary_item.rs
@@ -10,7 +10,7 @@ use crate::{types::StoredValue, Error};
 pub(crate) const GET_DICTIONARY_ITEM_METHOD: &str = "state_get_dictionary_item";
 
 /// The identifier for a dictionary item.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub enum DictionaryItemIdentifier {
     /// A dictionary item identified via an [`Account`]'s named keys.
@@ -116,7 +116,7 @@ impl GetDictionaryItemParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `state_get_dictionary_item` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetDictionaryItemResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_era_info.rs
+++ b/lib/rpcs/v1_4_5/get_era_info.rs
@@ -40,7 +40,7 @@ pub struct EraSummary {
 
 /// The `result` field of a successful JSON-RPC response to a `chain_get_era_info_by_switch_block`
 /// request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetEraInfoResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_node_status.rs
+++ b/lib/rpcs/v1_4_5/get_node_status.rs
@@ -46,7 +46,7 @@ pub struct NextUpgrade {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `info_get_status` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetNodeStatusResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_peers.rs
+++ b/lib/rpcs/v1_4_5/get_peers.rs
@@ -15,7 +15,7 @@ pub struct PeerEntry {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `info_get_peers` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetPeersResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_state_root_hash.rs
+++ b/lib/rpcs/v1_4_5/get_state_root_hash.rs
@@ -20,7 +20,7 @@ impl GetStateRootHashParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `chain_get_state_root_hash` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetStateRootHashResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_validator_changes.rs
+++ b/lib/rpcs/v1_4_5/get_validator_changes.rs
@@ -40,7 +40,7 @@ pub struct ValidatorChanges {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `info_get_validator_changes` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetValidatorChangesResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/list_rpcs.rs
+++ b/lib/rpcs/v1_4_5/list_rpcs.rs
@@ -137,7 +137,7 @@ pub struct OpenRpcSchema {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `rpc.discover` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ListRpcsResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/put_deploy.rs
+++ b/lib/rpcs/v1_4_5/put_deploy.rs
@@ -19,7 +19,7 @@ impl PutDeployParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to an `account_put_deploy` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct PutDeployResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/query_global_state.rs
+++ b/lib/rpcs/v1_4_5/query_global_state.rs
@@ -37,7 +37,7 @@ impl QueryGlobalStateParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `query_global_state` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct QueryGlobalStateResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_5_0/get_chainspec.rs
+++ b/lib/rpcs/v1_5_0/get_chainspec.rs
@@ -39,7 +39,7 @@ impl Display for ChainspecRawBytes {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `info_get_chainspec` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetChainspecResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_5_0/get_deploy.rs
+++ b/lib/rpcs/v1_5_0/get_deploy.rs
@@ -6,7 +6,7 @@ pub(crate) use crate::rpcs::v1_4_5::get_deploy::{GetDeployParams, GET_DEPLOY_MET
 use crate::types::{BlockHashAndHeight, Deploy, ExecutionResult};
 
 /// The `result` field of a successful JSON-RPC response to an `info_get_deploy` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetDeployResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_5_0/get_era_summary.rs
+++ b/lib/rpcs/v1_5_0/get_era_summary.rs
@@ -19,7 +19,7 @@ impl GetEraSummaryParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `chain_get_era_summary` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetEraSummaryResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_5_0/get_node_status.rs
+++ b/lib/rpcs/v1_5_0/get_node_status.rs
@@ -59,7 +59,7 @@ pub struct BlockSynchronizerStatus {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `info_get_status` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetNodeStatusResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_5_0/query_balance.rs
+++ b/lib/rpcs/v1_5_0/query_balance.rs
@@ -40,7 +40,7 @@ impl QueryBalanceParams {
 }
 
 /// Result for "query_balance" RPC response.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct QueryBalanceResult {
     /// The RPC API version.
     pub api_version: ProtocolVersion,

--- a/lib/rpcs/v1_5_0/speculative_exec.rs
+++ b/lib/rpcs/v1_5_0/speculative_exec.rs
@@ -25,7 +25,7 @@ impl SpeculativeExecParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `speculative_exec` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct SpeculativeExecResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_6_0/get_account.rs
+++ b/lib/rpcs/v1_6_0/get_account.rs
@@ -38,7 +38,7 @@ impl GetAccountParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `state_get_account_info` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetAccountResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_6_0/query_global_state.rs
+++ b/lib/rpcs/v1_6_0/query_global_state.rs
@@ -38,7 +38,7 @@ impl QueryGlobalStateParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `query_global_state` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct QueryGlobalStateResult {
     /// The JSON-RPC server version.

--- a/lib/types/block.rs
+++ b/lib/types/block.rs
@@ -61,6 +61,12 @@ impl Display for BlockHash {
     }
 }
 
+impl AsRef<[u8]> for BlockHash {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
 impl ToBytes for BlockHash {
     fn write_bytes(&self, buffer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
         self.0.write_bytes(buffer)

--- a/lib/types/deploy.rs
+++ b/lib/types/deploy.rs
@@ -196,11 +196,20 @@ impl ToBytes for Approval {
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct Deploy {
-    hash: DeployHash,
-    header: DeployHeader,
-    payment: ExecutableDeployItem,
-    session: ExecutableDeployItem,
-    approvals: Vec<Approval>,
+    /// The unique identifier for the deploy.
+    pub hash: DeployHash,
+
+    /// The header information for the deploy.
+    pub header: DeployHeader,
+
+    /// The payment logic for the deploy.
+    pub payment: ExecutableDeployItem,
+
+    /// The session logic for the deploy.
+    pub session: ExecutableDeployItem,
+
+    /// List of approvals for the deploy.
+    pub approvals: Vec<Approval>,
 }
 
 /// Used when constructing a `Deploy`.
@@ -396,10 +405,15 @@ impl<'a> DeployBuilder<'a> {
     ///     [`with_standard_payment`](Self::with_standard_payment) or
     ///     [`with_payment`](Self::with_payment)
     pub fn new<C: Into<String>>(chain_name: C, session: ExecutableDeployItem) -> Self {
+        #[cfg(not(any(feature = "sdk")))]
+        let timestamp = Timestamp::now();
+        #[cfg(feature = "sdk")]
+        let timestamp = Timestamp::default();
+
         DeployBuilder {
             account: None,
             secret_key: None,
-            timestamp: Timestamp::now(),
+            timestamp,
             ttl: Deploy::DEFAULT_TTL,
             gas_price: Deploy::DEFAULT_GAS_PRICE,
             dependencies: vec![],

--- a/lib/types/deploy.rs
+++ b/lib/types/deploy.rs
@@ -45,6 +45,12 @@ impl Display for DeployHash {
     }
 }
 
+impl AsRef<[u8]> for DeployHash {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
 impl ToBytes for DeployHash {
     fn write_bytes(&self, buffer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
         self.0.write_bytes(buffer)

--- a/lib/types/executable_deploy_item.rs
+++ b/lib/types/executable_deploy_item.rs
@@ -198,8 +198,7 @@ impl ExecutableDeployItem {
     }
 
     /// Returns the runtime arguments.
-    #[cfg(test)]
-    pub(crate) fn args(&self) -> &RuntimeArgs {
+    pub fn args(&self) -> &RuntimeArgs {
         match self {
             ExecutableDeployItem::ModuleBytes { args, .. }
             | ExecutableDeployItem::StoredContractByHash { args, .. }

--- a/lib/types/execution_result.rs
+++ b/lib/types/execution_result.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use super::BlockHash;
 
 /// The execution result of a single deploy.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ExecutionResult {
     /// The block hash.

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,7 @@ fn cli() -> Command {
         ))
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     let arg_matches = cli().get_matches();
     let (subcommand_name, matches) = arg_matches.subcommand().unwrap_or_else(|| {


### PR DESCRIPTION
This PR intends to pull changes made for the Rust SDK. It is adding a sdk feature and affects several methods or expose them accordingly to be able to compile the SDK.

This PR has a strong dependency on PR against node 1.6 https://github.com/casper-network/casper-node/pull/4348

Right now this feature only build with --lib

Mainly adds some `#[cfg(feature = "sdk")]` where it is possible or not to use io/fs, or prevent sending to std with `json_pretty_print` and returning deploys 
Changes the way secret key is loaded in `with_payment_and_session()`
Publicizes some methods outside the crate 
Adds `session_bytes` to `session_executable_deploy_item()` and adds `check_no_conflicting_arg_types() `(might require additional unit tests)
Adds `with_bytes()` to `SessionStrParams `
Adds some `Clone` attributes to some structs
Removes rt-multi-thread, `The default runtime flavor is 'multi_thread', but the 'rt-multi-thread' feature is disabled.` switching (flavor = "current_thread") to tokio main. Please check this change is legit.

 Had an issue with schemars, I had to fix the version to "=0.8.5" apparently with Casper node 1.6.
 
 For simplicity for now keeping new get_maybe_secret_key() as one function and not two as per previous PR for 2.0
 
 https://github.com/casper-ecosystem/rustSDK/issues/4
 https://github.com/casper-ecosystem/rustSDK/issues/5
 https://github.com/casper-ecosystem/rustSDK/issues/13
