### PR TITLE
Proposition of changes into Casper Types to support a Rust SDK for 1.6

### DIFF
--- a/.github/workflows/ci-casper-client-rs.yml
+++ b/.github/workflows/ci-casper-client-rs.yml
@@ -27,6 +27,7 @@ jobs:
           toolchain: stable
           profile: minimal
           components: rustfmt, clippy
+          target: wasm32-unknown-unknown
 
       - name: Fmt
         uses: actions-rs/cargo@v1
@@ -45,6 +46,12 @@ jobs:
           command: clippy
           args: --all-targets
 
+      - name: Clippy with no features
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-targets --no-default-features
+
       - name: Doc
         uses: actions-rs/cargo@v1
         with:
@@ -55,3 +62,15 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+
+      - name: Test with no features
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features
+
+      - name: Build lib for Wasm with no features
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --lib --target wasm32-unknown-unknown --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,7 @@
 [package]
 name = "casper-client"
-# when updating, also update 'html_root_url' in lib.rs
-version = "2.0.0"
-authors = [
-  "Marc Brinkmann <marc@casperlabs.io>",
-  "Fraser Hutchison <fraser@casperlabs.io>",
-  "Zachary Showalter <zach@casperlabs.io>",
-]
+version = "2.0.0" # when updating, also update 'html_root_url' in lib.rs
+authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>", "Zachary Showalter <zach@casperlabs.io>"]
 edition = "2021"
 description = "A client library and binary for interacting with the Casper network"
 documentation = "https://docs.rs/casper-client"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,9 @@ itertools = "0.11.0"
 jsonrpc-lite = "0.6.0"
 num-traits = "0.2.15"
 once_cell = "1"
-rand = "=0.8.5"
+rand = "0.8.5"
 reqwest = { version = "0.11.13", features = ["json"] }
-schemars = "0.8.5"
+schemars = "=0.8.5"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "1.0.34"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ num-traits = "0.2.15"
 once_cell = "1"
 rand = "0.8.5"
 reqwest = { version = "0.11.13", features = ["json"] }
-schemars = "0.8"
+schemars = "0.8.13"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "1.0.34"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ repository = "https://github.com/casper-ecosystem/casper-client-rs"
 license = "Apache-2.0"
 
 [lib]
+crate-type = ["cdylib", "rlib"]
 name = "casper_client"
 path = "lib/lib.rs"
 
@@ -25,11 +26,13 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
+casper-hashing = { version = "2.0.0", git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.5" }
 async-trait = "0.1.59"
 base16 = "0.2.1"
-casper-hashing = "2.0.0"
-casper-types = { version = "3.0.0", features = ["std"] }
-clap = { version = "4", features = ["cargo", "deprecated", "wrap_help"] }
+casper-types = { version = "3.0.0", git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.5", features = [
+  "std",
+] }
+clap = { version = "4", features = ["cargo", "deprecated"] }
 clap_complete = "4"
 hex-buffer-serde = "0.4.0"
 humantime = "2"
@@ -43,13 +46,7 @@ schemars = "0.8"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "1.0.34"
-tokio = { version = "1.23.0", features = [
-  "macros",
-  "net",
-  "rt-multi-thread",
-  "sync",
-  "time",
-] }
+tokio = { version = "1.23.0", features = ["macros", "rt", "sync", "time"] }
 uint = "0.9.4"
 
 [dev-dependencies]
@@ -60,10 +57,6 @@ sdk = ["casper-types/sdk"]
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["git"] }
-
-[patch.crates-io]
-casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.5" }
-casper-types = { git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.5" }
 
 [package.metadata.deb]
 features = ["vendored-openssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ num-traits = "0.2.15"
 once_cell = "1"
 rand = "0.8.5"
 reqwest = { version = "0.11.13", features = ["json"] }
-schemars = "0.8.5"
+schemars = "=0.8.5"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "1.0.34"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,12 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-casper-hashing = { version = "2.0.0" }
+casper-hashing = { version = "2.0.0", git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.6" }
 async-trait = "0.1.59"
 base16 = "0.2.1"
-casper-types = { version = "3.0.0", features = ["std"] }
+casper-types = { version = "3.0.0", git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.6", features = [
+  "std",
+] }
 clap = { version = "4", features = ["cargo", "deprecated"] }
 clap_complete = "4"
 hex-buffer-serde = "0.4.0"
@@ -55,10 +57,6 @@ sdk = ["casper-types/sdk"]
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["git"] }
-
-[patch.crates-io]
-casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
-casper-types = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
 
 [package.metadata.deb]
 features = ["vendored-openssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,42 +19,43 @@ path = "lib/lib.rs"
 name = "casper-client"
 path = "src/main.rs"
 doc = false
-
-[dependencies]
-async-trait = "0.1.59"
-base16 = "0.2.1"
-casper-hashing = "2.0.0"
-casper-types = { version = "3.0.0", features = ["std"] }
-clap = { version = "4", features = ["cargo", "deprecated"] }
-clap_complete = "4"
-hex-buffer-serde = "0.4.0"
-humantime = "2"
-itertools = "0.11.0"
-jsonrpc-lite = "0.6.0"
-num-traits = "0.2.15"
-once_cell = "1"
-rand = "0.8.5"
-reqwest = { version = "0.11.13", features = ["json"] }
-schemars = "=0.8.5"
-serde = { version = "1", default-features = false, features = ["derive"] }
-serde_json = { version = "1", features = ["preserve_order"] }
-thiserror = "1.0.34"
-tokio = { version = "1.23.0", features = ["macros", "rt", "sync", "time"] }
-uint = "0.9.4"
-
-[dev-dependencies]
-tempfile = "3.7.1"
+required-features = ["async-trait", "clap", "clap_complete", "tokio", "std-fs-io"]
 
 [features]
-default = ["std-fs-io"]
+default = ["async-trait", "clap", "clap_complete", "tokio", "std-fs-io"]
 std-fs-io = ["casper-types/std-fs-io"]
+
+[dependencies]
+async-trait = { version = "0.1.74", optional = true }
+base16 = "0.2.1"
+casper-hashing = "3.0.0"
+casper-types = { version = "4.0.1", features = ["std"] }
+clap = { version = "4.4.10", optional = true, features = ["cargo", "deprecated", "wrap_help"] }
+clap_complete = { version = "4.4.4", optional = true }
+hex-buffer-serde = "0.4.0"
+humantime = "2.1.0"
+itertools = "0.12.0"
+jsonrpc-lite = "0.6.0"
+num-traits = "0.2.15"
+once_cell = "1.18.0"
+rand = "0.8.5"
+reqwest = { version = "0.11.22", features = ["json"] }
+schemars = "=0.8.5"
+serde = { version = "1.0.193", default-features = false, features = ["derive"] }
+serde_json = { version = "1.0.108", features = ["preserve_order"] }
+thiserror = "1.0.50"
+tokio = { version = "1.34.0", optional = true, features = ["macros", "rt", "sync", "time"] }
+uint = "0.9.5"
+
+[dev-dependencies]
+tempfile = "3.8.1"
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["git"] }
 
 [patch.crates-io]
-casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
-casper-types = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
+casper-hashing = { git = "https://github.com/Fraser999/casper-node", branch = "rustSDK-1.6" }
+casper-types = { git = "https://github.com/Fraser999/casper-node", branch = "rustSDK-1.6" }
 
 [package.metadata.deb]
 features = ["vendored-openssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ doc = false
 async-trait = "0.1.59"
 base16 = "0.2.1"
 casper-hashing = "2.0.0"
-casper-types = { version = "3.0.0", features = ["std", "sdk"] }
+casper-types = { version = "3.0.0", features = ["std"] }
 clap = { version = "4", features = ["cargo", "deprecated", "wrap_help"] }
 clap_complete = "4"
 hex-buffer-serde = "0.4.0"
@@ -54,6 +54,9 @@ uint = "0.9.4"
 
 [dev-dependencies]
 tempfile = "3.7.1"
+
+[features]
+sdk = ["casper-types/sdk"]
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["git"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ num-traits = "0.2.15"
 once_cell = "1"
 rand = "0.8.5"
 reqwest = { version = "0.11.13", features = ["json"] }
-schemars = "0.8.13"
+schemars = "0.8"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "1.0.34"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ num-traits = "0.2.15"
 once_cell = "1"
 rand = "0.8.5"
 reqwest = { version = "0.11.13", features = ["json"] }
-schemars = "=0.8.5"
+schemars = "0.8.5"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "1.0.34"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-casper-hashing = { version = "2.0.0" }
 async-trait = "0.1.59"
 base16 = "0.2.1"
+casper-hashing = "2.0.0"
 casper-types = { version = "3.0.0", features = ["std"] }
 clap = { version = "4", features = ["cargo", "deprecated"] }
 clap_complete = "4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ num-traits = "0.2.15"
 once_cell = "1"
 rand = "0.8.5"
 reqwest = { version = "0.11.13", features = ["json"] }
-schemars = "0.8"
+schemars = "0.8.5"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "1.0.34"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "casper-client"
-version = "2.0.0" # when updating, also update 'html_root_url' in lib.rs
-authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>", "Zachary Showalter <zach@casperlabs.io>"]
+# when updating, also update 'html_root_url' in lib.rs
+version = "2.0.0"
+authors = [
+  "Marc Brinkmann <marc@casperlabs.io>",
+  "Fraser Hutchison <fraser@casperlabs.io>",
+  "Zachary Showalter <zach@casperlabs.io>",
+]
 edition = "2021"
 description = "A client library and binary for interacting with the Casper network"
 documentation = "https://docs.rs/casper-client"
@@ -23,7 +28,7 @@ doc = false
 async-trait = "0.1.59"
 base16 = "0.2.1"
 casper-hashing = "2.0.0"
-casper-types = { version = "3.0.0", features = ["std"] }
+casper-types = { version = "3.0.0", features = ["std", "sdk"] }
 clap = { version = "4", features = ["cargo", "deprecated", "wrap_help"] }
 clap_complete = "4"
 hex-buffer-serde = "0.4.0"
@@ -38,7 +43,13 @@ schemars = "0.8"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "1.0.34"
-tokio = { version = "1.23.0", features = ["macros", "net", "rt-multi-thread", "sync", "time", ]}
+tokio = { version = "1.23.0", features = [
+  "macros",
+  "net",
+  "rt-multi-thread",
+  "sync",
+  "time",
+] }
 uint = "0.9.4"
 
 [dev-dependencies]
@@ -48,13 +59,13 @@ tempfile = "3.7.1"
 vergen = { version = "7", default-features = false, features = ["git"] }
 
 [patch.crates-io]
-casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
-casper-types = { git = "https://github.com/casper-network/casper-node", branch = "dev"}
+casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.5" }
+casper-types = { git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.5" }
 
 [package.metadata.deb]
 features = ["vendored-openssl"]
 revision = "0"
-assets = [["./target/release/casper-client", "/usr/bin/casper-client", "755"], ]
+assets = [["./target/release/casper-client", "/usr/bin/casper-client", "755"]]
 extended-description = """
 Package for Casper Client to connect to Casper Node.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,10 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-casper-hashing = { version = "2.0.0", git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.6" }
+casper-hashing = { version = "2.0.0" }
 async-trait = "0.1.59"
 base16 = "0.2.1"
-casper-types = { version = "3.0.0", git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.6", features = [
-  "std",
-] }
+casper-types = { version = "3.0.0", features = ["std"] }
 clap = { version = "4", features = ["cargo", "deprecated"] }
 clap_complete = "4"
 hex-buffer-serde = "0.4.0"
@@ -57,6 +55,10 @@ sdk = ["casper-types/sdk"]
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["git"] }
+
+[patch.crates-io]
+casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
+casper-types = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
 
 [package.metadata.deb]
 features = ["vendored-openssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,8 @@ tempfile = "3.8.1"
 vergen = { version = "7", default-features = false, features = ["git"] }
 
 [patch.crates-io]
-casper-hashing = { git = "https://github.com/Fraser999/casper-node", branch = "rustSDK-1.6" }
-casper-types = { git = "https://github.com/Fraser999/casper-node", branch = "rustSDK-1.6" }
+casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
+casper-types = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
 
 [package.metadata.deb]
 features = ["vendored-openssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-casper-hashing = { version = "2.0.0", path = "../casper-node/hashing" }
+casper-hashing = { version = "2.0.0", git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.6" }
 async-trait = "0.1.59"
 base16 = "0.2.1"
-casper-types = { version = "3.0.0", path = "../casper-node/types", default-features = false, features = [
+casper-types = { version = "3.0.0", git = "https://github.com/casper-network/casper-node", default-features = false, branch = "rustSDK-1.6", features = [
   "std",
 ] }
 clap = { version = "4", features = ["cargo", "deprecated"] }
@@ -53,8 +53,8 @@ uint = "0.9.4"
 tempfile = "3.7.1"
 
 [features]
-default = ["std-output"]
-std-output = ["casper-types/std-output"]
+default = ["std-fs-io"]
+std-fs-io = ["casper-types/std-fs-io"]
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["git"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ itertools = "0.11.0"
 jsonrpc-lite = "0.6.0"
 num-traits = "0.2.15"
 once_cell = "1"
-rand = "0.8.5"
+rand = "=0.8.5"
 reqwest = { version = "0.11.13", features = ["json"] }
 schemars = "0.8.5"
 serde = { version = "1", default-features = false, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-casper-hashing = { version = "2.0.0", git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.5" }
+casper-hashing = { version = "2.0.0", git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.6" }
 async-trait = "0.1.59"
 base16 = "0.2.1"
-casper-types = { version = "3.0.0", git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.5", features = [
+casper-types = { version = "3.0.0", git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.6", features = [
   "std",
 ] }
 clap = { version = "4", features = ["cargo", "deprecated"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-casper-hashing = { version = "2.0.0", git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.6" }
+casper-hashing = { version = "2.0.0", path = "../casper-node/hashing" }
 async-trait = "0.1.59"
 base16 = "0.2.1"
-casper-types = { version = "3.0.0", git = "https://github.com/casper-network/casper-node", branch = "rustSDK-1.6", features = [
+casper-types = { version = "3.0.0", path = "../casper-node/types", default-features = false, features = [
   "std",
 ] }
 clap = { version = "4", features = ["cargo", "deprecated"] }
@@ -53,7 +53,8 @@ uint = "0.9.4"
 tempfile = "3.7.1"
 
 [features]
-sdk = ["casper-types/sdk"]
+default = ["std-output"]
+std-output = ["casper-types/std-output"]
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["git"] }

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -124,7 +124,7 @@ pub async fn speculative_put_deploy(
 /// `force` is true, and a file exists at `maybe_output_path`, it will be overwritten.  If `force`
 /// is false and a file exists at `maybe_output_path`, [`Error::FileAlreadyExists`] is returned
 /// and the file will not be written.
-/// With sdk feature file is not written
+/// Without the std-fs-io feature the file is not written
 /// Returns the Deploy
 pub fn make_deploy(
     #[allow(unused_variables)] maybe_output_path: &str,
@@ -135,7 +135,7 @@ pub fn make_deploy(
 ) -> Result<Deploy, CliError> {
     let deploy =
         deploy::with_payment_and_session(deploy_params, payment_params, session_params, true)?;
-    #[cfg(feature = "std-output")]
+    #[cfg(feature = "std-fs-io")]
     {
         let output = parse::output_kind(maybe_output_path, force);
         let _ = crate::output_deploy(output, &deploy).map_err(CliError::from);
@@ -150,23 +150,27 @@ pub fn make_deploy(
 /// `force` is true, and a file exists at `maybe_output_path`, it will be overwritten.  If `force`
 /// is false and a file exists at `maybe_output_path`, [`Error::FileAlreadyExists`] is returned
 /// and the file will not be written.
-/// Method not available with the sdk feature, use deploy.sign() directly
+#[cfg(feature = "std-fs-io")]
 pub fn sign_deploy_file(
     input_path: &str,
     secret_key_path: &str,
     maybe_output_path: &str,
     force: bool,
 ) -> Result<(), CliError> {
-    #[cfg(not(feature = "std-output"))]
-    {
-        return Ok(());
-    }
-    #[cfg(feature = "std-output")]
-    {
-        let secret_key = parse::secret_key_from_file(secret_key_path)?;
-        let output = parse::output_kind(maybe_output_path, force);
-        crate::sign_deploy_file(input_path, &secret_key, output).map_err(CliError::from)
-    }
+    let secret_key = parse::secret_key_from_file(secret_key_path)?;
+    let output = parse::output_kind(maybe_output_path, force);
+    crate::sign_deploy_file(input_path, &secret_key, output).map_err(CliError::from)
+}
+
+/// Method not available without the std-fs-io feature, use deploy.sign() directly
+#[cfg(not(feature = "std-fs-io"))]
+pub fn sign_deploy_file(
+    _input_path: &str,
+    _secret_key_path: &str,
+    _maybe_output_path: &str,
+    _force: bool,
+) -> Result<(), CliError> {
+    Ok(())
 }
 
 /// Reads a previously-saved [`Deploy`] from a file and sends it to the network for execution.
@@ -291,7 +295,7 @@ pub async fn speculative_transfer(
 /// `force` is true, and a file exists at `maybe_output_path`, it will be overwritten.  If `force`
 /// is false and a file exists at `maybe_output_path`, [`Error::FileAlreadyExists`] is returned
 /// and the file will not be written.
-/// With sdk feature file is not written
+/// Without the std-fs-io feature, the file is not written
 /// Returns the Deploy
 pub fn make_transfer(
     #[allow(unused_variables)] maybe_output_path: &str,
@@ -311,7 +315,7 @@ pub fn make_transfer(
         payment_params,
         true,
     )?;
-    #[cfg(feature = "std-output")]
+    #[cfg(feature = "std-fs-io")]
     {
         let output = parse::output_kind(maybe_output_path, force);
         let _ = crate::output_deploy(output, &deploy).map_err(CliError::from);

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -27,14 +27,11 @@ mod dictionary_item_str_params;
 mod error;
 mod json_args;
 mod parse;
+pub use parse::account_identifier as parse_account_identifier;
+pub use parse::purse_identifier as parse_purse_identifier;
 mod payment_str_params;
 mod session_str_params;
 mod simple_args;
-#[cfg(feature = "sdk")]
-pub use parse::account_identifier as parse_account_identifier;
-#[cfg(feature = "sdk")]
-pub use parse::purse_identifier as parse_purse_identifier;
-#[cfg(feature = "sdk")]
 pub use simple_args::insert_arg;
 
 #[cfg(test)]
@@ -138,7 +135,7 @@ pub fn make_deploy(
 ) -> Result<Deploy, CliError> {
     let deploy =
         deploy::with_payment_and_session(deploy_params, payment_params, session_params, true)?;
-    #[cfg(not(any(feature = "sdk")))]
+    #[cfg(feature = "std-output")]
     {
         let output = parse::output_kind(maybe_output_path, force);
         let _ = crate::output_deploy(output, &deploy).map_err(CliError::from);
@@ -154,16 +151,22 @@ pub fn make_deploy(
 /// is false and a file exists at `maybe_output_path`, [`Error::FileAlreadyExists`] is returned
 /// and the file will not be written.
 /// Method not available with the sdk feature, use deploy.sign() directly
-#[cfg(not(any(feature = "sdk")))]
 pub fn sign_deploy_file(
     input_path: &str,
     secret_key_path: &str,
     maybe_output_path: &str,
     force: bool,
 ) -> Result<(), CliError> {
-    let secret_key = parse::secret_key_from_file(secret_key_path)?;
-    let output = parse::output_kind(maybe_output_path, force);
-    crate::sign_deploy_file(input_path, &secret_key, output).map_err(CliError::from)
+    #[cfg(not(feature = "std-output"))]
+    {
+        return Ok(());
+    }
+    #[cfg(feature = "std-output")]
+    {
+        let secret_key = parse::secret_key_from_file(secret_key_path)?;
+        let output = parse::output_kind(maybe_output_path, force);
+        crate::sign_deploy_file(input_path, &secret_key, output).map_err(CliError::from)
+    }
 }
 
 /// Reads a previously-saved [`Deploy`] from a file and sends it to the network for execution.
@@ -308,7 +311,7 @@ pub fn make_transfer(
         payment_params,
         true,
     )?;
-    #[cfg(not(any(feature = "sdk")))]
+    #[cfg(feature = "std-output")]
     {
         let output = parse::output_kind(maybe_output_path, force);
         let _ = crate::output_deploy(output, &deploy).map_err(CliError::from);

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -127,6 +127,8 @@ pub async fn speculative_put_deploy(
 /// `force` is true, and a file exists at `maybe_output_path`, it will be overwritten.  If `force`
 /// is false and a file exists at `maybe_output_path`, [`Error::FileAlreadyExists`] is returned
 /// and the file will not be written.
+/// With sdk feature file is not written
+/// Returns the Deploy
 pub fn make_deploy(
     #[allow(unused_variables)] maybe_output_path: &str,
     deploy_params: DeployStrParams<'_>,
@@ -151,6 +153,7 @@ pub fn make_deploy(
 /// `force` is true, and a file exists at `maybe_output_path`, it will be overwritten.  If `force`
 /// is false and a file exists at `maybe_output_path`, [`Error::FileAlreadyExists`] is returned
 /// and the file will not be written.
+/// Method not available with the sdk feature, use deploy.sign() directly
 #[cfg(not(any(feature = "sdk")))]
 pub fn sign_deploy_file(
     input_path: &str,
@@ -285,6 +288,8 @@ pub async fn speculative_transfer(
 /// `force` is true, and a file exists at `maybe_output_path`, it will be overwritten.  If `force`
 /// is false and a file exists at `maybe_output_path`, [`Error::FileAlreadyExists`] is returned
 /// and the file will not be written.
+/// With sdk feature file is not written
+/// Returns the Deploy
 pub fn make_transfer(
     #[allow(unused_variables)] maybe_output_path: &str,
     amount: &str,

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -31,7 +31,12 @@ mod payment_str_params;
 mod session_str_params;
 mod simple_args;
 #[cfg(feature = "sdk")]
+pub use parse::account_identifier as parse_account_identifier;
+#[cfg(feature = "sdk")]
+pub use parse::purse_identifier as parse_purse_identifier;
+#[cfg(feature = "sdk")]
 pub use simple_args::insert_arg;
+
 #[cfg(test)]
 mod tests;
 

--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -102,6 +102,41 @@ pub fn new_transfer(
     Ok(deploy)
 }
 
+/// Retrieves a `SecretKey` based on the provided secret key string and configuration options.
+///
+/// # Arguments
+///
+/// * `secret_key` - A string representing the secret key. If empty, a `None` option is returned.
+/// * `allow_unsigned_deploy` - A boolean indicating whether unsigned deploys are allowed.
+///
+/// # Returns
+///
+/// Returns a `Result` containing an `Option<SecretKey>`. If a valid secret key is provided and the `sdk` feature is enabled,
+/// the `Result` contains `Some(SecretKey)`. If the `sdk` feature is disabled, the `Result` contains `Some(SecretKey)` parsed from the provided file.
+/// If `secret_key` is empty and `allow_unsigned_deploy` is `true`, the `Result` contains `None`. If `secret_key` is empty and `allow_unsigned_deploy` is `false`,
+/// an `Err` variant with a `CliError::InvalidArgument` is returned.
+///
+/// # Errors
+///
+/// Returns an `Err` variant with a `CliError::Core` or `CliError::InvalidArgument` if there are issues with parsing the secret key.
+///
+/// # Examples
+///
+/// ```
+/// use casper_client::CliError;
+///
+/// match get_maybe_secret_key("path/to/secret_key.pem", true) {
+///     Ok(Some(secret_key)) => {
+///         println!("Secret Key: {:?}", secret_key);
+///     }
+///     Ok(None) => {
+///         println!("No secret key provided, unsigned deploys allowed.");
+///     }
+///     Err(error) => {
+///         eprintln!("Error: {:?}", error);
+///     }
+/// }
+/// ```
 fn get_maybe_secret_key(
     secret_key: &str,
     allow_unsigned_deploy: bool,

--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -142,7 +142,11 @@ fn get_maybe_secret_key(
     allow_unsigned_deploy: bool,
 ) -> Result<Option<SecretKey>, CliError> {
     if !secret_key.is_empty() {
-        #[cfg(not(feature = "std-output"))]
+        #[cfg(feature = "std-fs-io")]
+        {
+            Ok(Some(parse::secret_key_from_file(secret_key)?))
+        }
+        #[cfg(not(feature = "std-fs-io"))]
         {
             let secret_key: SecretKey = match SecretKey::from_pem(secret_key) {
                 Ok(key) => key,
@@ -154,10 +158,6 @@ fn get_maybe_secret_key(
                 }
             };
             Ok(Some(secret_key))
-        }
-        #[cfg(feature = "std-output")]
-        {
-            Ok(Some(parse::secret_key_from_file(secret_key)?))
         }
     } else if !allow_unsigned_deploy {
         Err(CliError::InvalidArgument {

--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -1,6 +1,6 @@
-#[cfg(feature = "sdk")]
-use casper_types::SecretKey;
-use casper_types::{account::AccountHash, AsymmetricType, PublicKey, UIntParseError, URef, U512};
+use casper_types::{
+    account::AccountHash, AsymmetricType, PublicKey, SecretKey, UIntParseError, URef, U512,
+};
 
 use super::{parse, CliError, DeployStrParams, PaymentStrParams, SessionStrParams};
 use crate::{

--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -142,7 +142,7 @@ fn get_maybe_secret_key(
     allow_unsigned_deploy: bool,
 ) -> Result<Option<SecretKey>, CliError> {
     if !secret_key.is_empty() {
-        #[cfg(feature = "sdk")]
+        #[cfg(not(feature = "std-output"))]
         {
             let secret_key: SecretKey = match SecretKey::from_pem(secret_key) {
                 Ok(key) => key,
@@ -155,7 +155,7 @@ fn get_maybe_secret_key(
             };
             Ok(Some(secret_key))
         }
-        #[cfg(not(feature = "sdk"))]
+        #[cfg(feature = "std-output")]
         {
             Ok(Some(parse::secret_key_from_file(secret_key)?))
         }

--- a/lib/cli/deploy_str_params.rs
+++ b/lib/cli/deploy_str_params.rs
@@ -1,7 +1,8 @@
 /// Container for `Deploy` construction options.
 #[derive(Default, Debug)]
 pub struct DeployStrParams<'a> {
-    /// Path to secret key file.
+    /// Path to secret key file if the `std-fs-io` feature is enabled (enabled by default), or a
+    /// PEM-encoded secret key if not.
     ///
     /// If `secret_key` is empty, the new deploy will not be signed and will need to be signed (e.g.
     /// via [`sign_deploy_file`](super::sign_deploy_file)) at least once in order to be made valid.

--- a/lib/cli/error.rs
+++ b/lib/cli/error.rs
@@ -113,7 +113,7 @@ pub enum CliError {
     ConflictingArguments {
         /// Contextual description of where this error occurred including relevant paths,
         /// filenames, etc.
-        context: &'static str,
+        context: String,
         /// Arguments passed, with their values.
         args: Vec<String>,
     },

--- a/lib/cli/json_args.rs
+++ b/lib/cli/json_args.rs
@@ -16,8 +16,9 @@ use casper_types::{
 use crate::cli::CliError;
 pub use error::{Error, ErrorDetails};
 
+/// Represents a JSON argument with a name, type, and value.
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub(super) struct JsonArg {
+pub struct JsonArg {
     name: String,
     #[serde(rename = "type")]
     cl_type: CLType,

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -1,7 +1,7 @@
 //! This module contains structs and helpers which are used by multiple subcommands related to
 //! creating deploys.
 
-#[cfg(feature = "std-output")]
+#[cfg(feature = "std-fs-io")]
 use std::path::Path;
 use std::{convert::TryInto, fs, io, str::FromStr};
 
@@ -9,7 +9,7 @@ use rand::Rng;
 use serde::{self, Deserialize};
 
 use casper_hashing::Digest;
-#[cfg(feature = "std-output")]
+#[cfg(feature = "std-fs-io")]
 use casper_types::SecretKey;
 use casper_types::{
     account::AccountHash,
@@ -19,7 +19,7 @@ use casper_types::{
 };
 
 use super::{simple_args, CliError, PaymentStrParams, SessionStrParams};
-#[cfg(feature = "std-output")]
+#[cfg(feature = "std-fs-io")]
 use crate::OutputKind;
 use crate::{
     types::{BlockHash, DeployHash, ExecutableDeployItem, TimeDiff, Timestamp},
@@ -45,7 +45,7 @@ pub(super) fn verbosity(verbosity_level: u64) -> Verbosity {
     }
 }
 
-#[cfg(feature = "std-output")]
+#[cfg(feature = "std-fs-io")]
 pub(super) fn output_kind(maybe_output_path: &str, force: bool) -> OutputKind {
     if maybe_output_path.is_empty() {
         OutputKind::Stdout
@@ -54,7 +54,7 @@ pub(super) fn output_kind(maybe_output_path: &str, force: bool) -> OutputKind {
     }
 }
 
-#[cfg(feature = "std-output")]
+#[cfg(feature = "std-fs-io")]
 pub(super) fn secret_key_from_file<P: AsRef<Path>>(
     secret_key_path: P,
 ) -> Result<SecretKey, CliError> {

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -1,22 +1,28 @@
 //! This module contains structs and helpers which are used by multiple subcommands related to
 //! creating deploys.
 
-use std::{convert::TryInto, fs, io, path::Path, str::FromStr};
+#[cfg(not(any(feature = "sdk")))]
+use std::path::Path;
+use std::{convert::TryInto, fs, io, str::FromStr};
 
 use rand::Rng;
 use serde::{self, Deserialize};
 
 use casper_hashing::Digest;
+#[cfg(not(any(feature = "sdk")))]
+use casper_types::SecretKey;
 use casper_types::{
     account::AccountHash, bytesrepr, crypto, AsymmetricType, CLValue, HashAddr, Key, NamedArg,
-    PublicKey, RuntimeArgs, SecretKey, UIntParseError, URef, U512,
+    PublicKey, RuntimeArgs, UIntParseError, URef, U512,
 };
 
 use super::{simple_args, CliError, PaymentStrParams, SessionStrParams};
+#[cfg(not(any(feature = "sdk")))]
+use crate::OutputKind;
 use crate::{
     types::{BlockHash, DeployHash, ExecutableDeployItem, TimeDiff, Timestamp},
-    AccountIdentifier, BlockIdentifier, GlobalStateIdentifier, JsonRpcId, OutputKind,
-    PurseIdentifier, Verbosity,
+    AccountIdentifier, BlockIdentifier, GlobalStateIdentifier, JsonRpcId, PurseIdentifier,
+    Verbosity,
 };
 
 pub(super) fn rpc_id(maybe_rpc_id: &str) -> JsonRpcId {
@@ -37,6 +43,7 @@ pub(super) fn verbosity(verbosity_level: u64) -> Verbosity {
     }
 }
 
+#[cfg(not(any(feature = "sdk")))]
 pub(super) fn output_kind(maybe_output_path: &str, force: bool) -> OutputKind {
     if maybe_output_path.is_empty() {
         OutputKind::Stdout
@@ -45,6 +52,7 @@ pub(super) fn output_kind(maybe_output_path: &str, force: bool) -> OutputKind {
     }
 }
 
+#[cfg(not(any(feature = "sdk")))]
 pub(super) fn secret_key_from_file<P: AsRef<Path>>(
     secret_key_path: P,
 ) -> Result<SecretKey, CliError> {

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -1,7 +1,7 @@
 //! This module contains structs and helpers which are used by multiple subcommands related to
 //! creating deploys.
 
-#[cfg(not(any(feature = "sdk")))]
+#[cfg(feature = "std-output")]
 use std::path::Path;
 use std::{convert::TryInto, fs, io, str::FromStr};
 
@@ -9,7 +9,7 @@ use rand::Rng;
 use serde::{self, Deserialize};
 
 use casper_hashing::Digest;
-#[cfg(not(any(feature = "sdk")))]
+#[cfg(feature = "std-output")]
 use casper_types::SecretKey;
 use casper_types::{
     account::AccountHash,
@@ -19,7 +19,7 @@ use casper_types::{
 };
 
 use super::{simple_args, CliError, PaymentStrParams, SessionStrParams};
-#[cfg(not(any(feature = "sdk")))]
+#[cfg(feature = "std-output")]
 use crate::OutputKind;
 use crate::{
     types::{BlockHash, DeployHash, ExecutableDeployItem, TimeDiff, Timestamp},
@@ -45,7 +45,7 @@ pub(super) fn verbosity(verbosity_level: u64) -> Verbosity {
     }
 }
 
-#[cfg(not(any(feature = "sdk")))]
+#[cfg(feature = "std-output")]
 pub(super) fn output_kind(maybe_output_path: &str, force: bool) -> OutputKind {
     if maybe_output_path.is_empty() {
         OutputKind::Stdout
@@ -54,7 +54,7 @@ pub(super) fn output_kind(maybe_output_path: &str, force: bool) -> OutputKind {
     }
 }
 
-#[cfg(not(any(feature = "sdk")))]
+#[cfg(feature = "std-output")]
 pub(super) fn secret_key_from_file<P: AsRef<Path>>(
     secret_key_path: P,
 ) -> Result<SecretKey, CliError> {

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -405,6 +405,24 @@ macro_rules! check_exactly_one_not_empty {
     }}
 }
 
+/// Checks if conflicting arguments are provided for parsing session information.
+///
+/// # Arguments
+///
+/// * `context` - A string indicating the context in which the arguments are checked.
+/// * `simple` - A vector of strings representing simple arguments.
+/// * `json` - A string representing JSON-formatted arguments.
+/// * `complex` - A string representing complex arguments.
+///
+/// # Returns
+///
+/// Returns a `Result` with an empty `Ok(())` variant if no conflicting arguments are found. If conflicting arguments are provided,
+/// an `Err` variant with a `CliError::ConflictingArguments` is returned.
+///
+/// # Errors
+///
+/// Returns an `Err` variant with a `CliError::ConflictingArguments` if conflicting arguments are provided.
+///
 fn check_no_conflicting_arg_types(
     context: &str,
     simple: &Vec<&str>,
@@ -425,6 +443,21 @@ fn check_no_conflicting_arg_types(
     Ok(())
 }
 
+/// Parses session parameters and constructs an `ExecutableDeployItem` accordingly.
+///
+/// # Arguments
+///
+/// * `params` - A struct containing session-related parameters including hashes, names, paths, bytes, and arguments.
+///
+/// # Returns
+///
+/// Returns a `Result` containing an `ExecutableDeployItem` if the session parameters are valid.
+///
+/// # Errors
+///
+/// Returns an `Err` variant with a `CliError` if there are issues with parsing session parameters,
+/// conflicting arguments, or invalid entry points.
+///
 pub(super) fn session_executable_deploy_item(
     params: SessionStrParams,
 ) -> Result<ExecutableDeployItem, CliError> {

--- a/lib/cli/payment_str_params.rs
+++ b/lib/cli/payment_str_params.rs
@@ -99,7 +99,7 @@ use crate::cli;
 ///
 /// **Note** while multiple payment args can be specified for a single payment code instance, only
 /// one of `payment_args_simple`, `payment_args_json` or `payment_args_complex` may be used.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct PaymentStrParams<'a> {
     pub(super) payment_amount: &'a str,
     pub(super) payment_hash: &'a str,

--- a/lib/cli/payment_str_params.rs
+++ b/lib/cli/payment_str_params.rs
@@ -1,3 +1,5 @@
+use casper_types::bytesrepr::Bytes;
+
 #[cfg(doc)]
 use crate::cli;
 
@@ -107,6 +109,7 @@ pub struct PaymentStrParams<'a> {
     pub(super) payment_package_hash: &'a str,
     pub(super) payment_package_name: &'a str,
     pub(super) payment_path: &'a str,
+    pub(super) payment_bytes: Bytes,
     pub(super) payment_args_simple: Vec<&'a str>,
     pub(super) payment_args_json: &'a str,
     pub(super) payment_args_complex: &'a str,
@@ -129,6 +132,27 @@ impl<'a> PaymentStrParams<'a> {
     ) -> Self {
         Self {
             payment_path,
+            payment_args_simple,
+            payment_args_json,
+            payment_args_complex,
+            ..Default::default()
+        }
+    }
+
+    /// Constructs a `PaymentStrParams` using payment bytes.
+    ///
+    /// * `payment_bytes` are the bytes of the compiled Wasm payment code.
+    /// * See the struct docs for a description of [`payment_args_simple`](#payment_args_simple),
+    ///   [`payment_args_json`](#payment_args_json) and
+    ///   [`payment_args_complex`](#payment_args_complex).
+    pub fn with_bytes(
+        payment_bytes: Bytes,
+        payment_args_simple: Vec<&'a str>,
+        payment_args_json: &'a str,
+        payment_args_complex: &'a str,
+    ) -> Self {
+        Self {
+            payment_bytes,
             payment_args_simple,
             payment_args_json,
             payment_args_complex,

--- a/lib/cli/session_str_params.rs
+++ b/lib/cli/session_str_params.rs
@@ -1,3 +1,5 @@
+use casper_types::bytesrepr::Bytes;
+
 /// Container for session-related arguments used while constructing a `Deploy`.
 ///
 /// ## `session_args_simple`
@@ -29,13 +31,14 @@
 ///
 /// **Note** while multiple session args can be specified for a single session code instance, only
 /// one of `session_args_simple`, `session_args_json` or `session_args_complex` may be used.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct SessionStrParams<'a> {
     pub(super) session_hash: &'a str,
     pub(super) session_name: &'a str,
     pub(super) session_package_hash: &'a str,
     pub(super) session_package_name: &'a str,
     pub(super) session_path: &'a str,
+    pub(super) session_bytes: Bytes,
     pub(super) session_args_simple: Vec<&'a str>,
     pub(super) session_args_json: &'a str,
     pub(super) session_args_complex: &'a str,
@@ -59,6 +62,27 @@ impl<'a> SessionStrParams<'a> {
     ) -> Self {
         Self {
             session_path,
+            session_args_simple,
+            session_args_json,
+            session_args_complex,
+            ..Default::default()
+        }
+    }
+
+    /// Constructs a `SessionStrParams` using session bytes.
+    ///
+    /// * `session_bytes` are the bytes of the compiled Wasm session code.
+    /// * See the struct docs for a description of [`session_args_simple`](#session_args_simple),
+    ///   [`session_args_json`](#session_args_json) and
+    ///   [`session_args_complex`](#session_args_complex).
+    pub fn with_bytes(
+        session_bytes: Bytes,
+        session_args_simple: Vec<&'a str>,
+        session_args_json: &'a str,
+        session_args_complex: &'a str,
+    ) -> Self {
+        Self {
+            session_bytes,
             session_args_simple,
             session_args_json,
             session_args_complex,

--- a/lib/cli/simple_args.rs
+++ b/lib/cli/simple_args.rs
@@ -676,7 +676,7 @@ mod tests {
         const ARG_GIBBERISH: &str = "asdf|1234(..)";
         const ARG_UNQUOTED: &str = "name:u32=0"; // value needs single quotes to be valid
         const EMPTY: &str = "";
-        const LARGE_2K_INPUT: &str = r#"
+        const LARGE_2K_INPUT: &str = r"
 eJy2irIizK6zT0XOklyBAY1KVUsAbyF6eJUYBmRPHqX2rONbaEieJt4Ci1eZYjBdHdEq46oMBH0LeiQO8RIJb95
 SJGEp83RxakDj7trunJVvMbj2KZFnpJOyEauFa35dlaVG9Ki7hjFy4BLlDyA0Wgwk20RXFkbgKQIQVvR16RPffR
 WO86WqZ3gMuOh447svZRYfhbRF3NVBaWRz7SJ9Zm3w8djisvS0Y3GSnpzKnSEQirApqomfQTHTrU9ww2SMgdGuu
@@ -701,7 +701,7 @@ Q8d1wPtqKgayVtgdIaMbvsnXMkRqITkf3o8Qh495pm1wkKArTGFGODXc1cCKheFUEtJWdK92DHH7OuRE
 PKzSUg2k18wyf9XCy1pQKv31wii3rWrWMCbxOWmhuzw1N9tqO8U97NsThRSoPAjpd05G2roia4m4CaPWTAUmVky
 RfiWoA7bglAh4Aoz2LN2ezFleTNJjjLw3n9bYPg5BdRL8n8wimhXDo9SW46A5YS62C08ZOVtvfn82YRaYkuKKz7
 3NJ25PnQG6diMm4Lm3wi22yR7lY7oYYJjLNcaLYOI6HOvaJ
-"#;
+";
 
         check_insert_invalid_arg(ARG_BAD_TYPE);
         check_insert_invalid_arg(ARG_GIBBERISH);

--- a/lib/cli/simple_args.rs
+++ b/lib/cli/simple_args.rs
@@ -344,7 +344,7 @@ fn split_arg(arg: &str) -> Result<(&str, &str, &str), CliError> {
 }
 
 /// Insert a value built from a single arg into `runtime_args`.
-pub(super) fn insert_arg(arg: &str, runtime_args: &mut RuntimeArgs) -> Result<(), CliError> {
+pub fn insert_arg(arg: &str, runtime_args: &mut RuntimeArgs) -> Result<(), CliError> {
     let (name, initial_type, value) = split_arg(arg)?;
     let (simple_type, optional_status, trimmed_value) =
         get_simple_type_and_optional_status(initial_type, value)?;

--- a/lib/cli/tests.rs
+++ b/lib/cli/tests.rs
@@ -182,7 +182,7 @@ fn should_fail_to_create_large_deploy() {
 #[test]
 fn should_read_deploy() {
     let bytes = SAMPLE_DEPLOY.as_bytes();
-    assert!(matches!(crate::read_deploy(bytes), Ok(_)));
+    assert!(crate::read_deploy(bytes).is_ok());
 }
 
 #[test]

--- a/lib/error.rs
+++ b/lib/error.rs
@@ -30,6 +30,12 @@ pub enum Error {
     #[error("deploy requires session account - use `with_account` or `with_secret_key`")]
     DeployMissingSessionAccount,
 
+    /// Failed to build [`Deploy`] due to missing timestamp.
+    ///
+    /// Call [`DeployBuilder::with_timestamp`] before calling [`DeployBuilder::build`].
+    #[error("deploy requires timestamp - use `with_timestamp`")]
+    DeployMissingTimestamp,
+
     /// Failed to build [`Deploy`] due to missing payment code.
     ///
     /// Call [`DeployBuilder::with_standard_payment`] or [`DeployBuilder::with_payment`] before

--- a/lib/error.rs
+++ b/lib/error.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "std-fs-io")]
 use std::{io, path::PathBuf};
 
 use thiserror::Error;
@@ -125,6 +126,7 @@ pub enum Error {
     },
 
     /// Failed to create new file because it already exists.
+    #[cfg(feature = "std-fs-io")]
     #[error("file at {} already exists", .0.display())]
     FileAlreadyExists(PathBuf),
 
@@ -137,6 +139,7 @@ pub enum Error {
     UnsupportedAlgorithm(String),
 
     /// Context-adding wrapper for `std::io::Error`.
+    #[cfg(feature = "std-fs-io")]
     #[error("input/output error: {context}: {error}")]
     IoError {
         /// Contextual description of where this error occurred including relevant paths,

--- a/lib/json_rpc/call.rs
+++ b/lib/json_rpc/call.rs
@@ -16,6 +16,7 @@ static CLIENT: OnceCell<Client> = OnceCell::new();
 pub(crate) struct Call {
     rpc_id: JsonRpcId,
     node_address: String,
+    #[allow(dead_code)]
     verbosity: Verbosity,
 }
 
@@ -53,6 +54,7 @@ impl Call {
             None => JsonRpc::request(&self.rpc_id, method),
         };
 
+        #[cfg(not(any(feature = "sdk")))]
         crate::json_pretty_print(&rpc_request, self.verbosity)?;
 
         let client = CLIENT.get_or_init(Client::new);
@@ -85,6 +87,7 @@ impl Call {
                     error,
                 })?;
 
+        #[cfg(not(any(feature = "sdk")))]
         crate::json_pretty_print(&rpc_response, self.verbosity)?;
 
         let response_kind = match &rpc_response {

--- a/lib/json_rpc/call.rs
+++ b/lib/json_rpc/call.rs
@@ -54,7 +54,7 @@ impl Call {
             None => JsonRpc::request(&self.rpc_id, method),
         };
 
-        #[cfg(not(any(feature = "sdk")))]
+        #[cfg(feature = "std-output")]
         crate::json_pretty_print(&rpc_request, self.verbosity)?;
 
         let client = CLIENT.get_or_init(Client::new);
@@ -87,7 +87,7 @@ impl Call {
                     error,
                 })?;
 
-        #[cfg(not(any(feature = "sdk")))]
+        #[cfg(feature = "std-output")]
         crate::json_pretty_print(&rpc_response, self.verbosity)?;
 
         let response_kind = match &rpc_response {

--- a/lib/json_rpc/call.rs
+++ b/lib/json_rpc/call.rs
@@ -54,7 +54,7 @@ impl Call {
             None => JsonRpc::request(&self.rpc_id, method),
         };
 
-        #[cfg(feature = "std-output")]
+        #[cfg(feature = "std-fs-io")]
         crate::json_pretty_print(&rpc_request, self.verbosity)?;
 
         let client = CLIENT.get_or_init(Client::new);
@@ -87,7 +87,7 @@ impl Call {
                     error,
                 })?;
 
-        #[cfg(feature = "std-output")]
+        #[cfg(feature = "std-fs-io")]
         crate::json_pretty_print(&rpc_response, self.verbosity)?;
 
         let response_kind = match &rpc_response {

--- a/lib/json_rpc/call.rs
+++ b/lib/json_rpc/call.rs
@@ -16,7 +16,7 @@ static CLIENT: OnceCell<Client> = OnceCell::new();
 pub(crate) struct Call {
     rpc_id: JsonRpcId,
     node_address: String,
-    #[allow(dead_code)]
+    #[cfg_attr(not(feature = "std-fs-io"), allow(dead_code))]
     verbosity: Verbosity,
 }
 

--- a/lib/keygen.rs
+++ b/lib/keygen.rs
@@ -1,10 +1,11 @@
 //! Cryptographic key generation.
 
-use std::{fs, path::Path};
-
-use casper_types::{AsymmetricType, PublicKey, SecretKey};
-
+#[cfg(feature = "std-fs-io")]
 use crate::Error;
+#[cfg(feature = "std-fs-io")]
+use casper_types::{AsymmetricType, PublicKey, SecretKey};
+#[cfg(feature = "std-fs-io")]
+use std::{fs, path::Path};
 
 /// Default filename for the PEM-encoded secret key file.
 pub const SECRET_KEY_PEM: &str = "secret_key.pem";
@@ -30,6 +31,7 @@ pub const SECP256K1: &str = "secp256k1";
 ///
 /// If `force` is true, existing files will be overwritten. If `force` is false and any of the
 /// files exist, [`Error::FileAlreadyExists`] is returned and no files are written.
+#[cfg(feature = "std-fs-io")]
 pub fn generate_files(output_dir: &str, algorithm: &str, force: bool) -> Result<(), Error> {
     if output_dir.is_empty() {
         return Err(Error::EmptyKeygenPath);

--- a/lib/keygen.rs
+++ b/lib/keygen.rs
@@ -1,11 +1,10 @@
 //! Cryptographic key generation.
 
-#[cfg(feature = "std-fs-io")]
-use crate::Error;
-#[cfg(feature = "std-fs-io")]
-use casper_types::{AsymmetricType, PublicKey, SecretKey};
-#[cfg(feature = "std-fs-io")]
 use std::{fs, path::Path};
+
+use casper_types::{AsymmetricType, PublicKey, SecretKey};
+
+use crate::Error;
 
 /// Default filename for the PEM-encoded secret key file.
 pub const SECRET_KEY_PEM: &str = "secret_key.pem";
@@ -31,7 +30,6 @@ pub const SECP256K1: &str = "secp256k1";
 ///
 /// If `force` is true, existing files will be overwritten. If `force` is false and any of the
 /// files exist, [`Error::FileAlreadyExists`] is returned and no files are written.
-#[cfg(feature = "std-fs-io")]
 pub fn generate_files(output_dir: &str, algorithm: &str, force: bool) -> Result<(), Error> {
     if output_dir.is_empty() {
         return Err(Error::EmptyKeygenPath);

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -38,7 +38,6 @@
 pub mod cli;
 mod error;
 mod json_rpc;
-#[cfg(all(feature = "std", feature = "std-output"))]
 pub mod keygen;
 mod output_kind;
 pub mod rpcs;

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -38,6 +38,7 @@
 pub mod cli;
 mod error;
 mod json_rpc;
+#[cfg(not(any(feature = "sdk")))]
 pub mod keygen;
 mod output_kind;
 pub mod rpcs;

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -38,7 +38,7 @@
 pub mod cli;
 mod error;
 mod json_rpc;
-#[cfg(not(any(feature = "sdk")))]
+#[cfg(all(feature = "std", feature = "std-output"))]
 pub mod keygen;
 mod output_kind;
 pub mod rpcs;

--- a/lib/rpcs.rs
+++ b/lib/rpcs.rs
@@ -13,3 +13,5 @@ pub use v1_5_0::{
     get_dictionary_item::DictionaryItemIdentifier, query_balance::PurseIdentifier,
     query_global_state::GlobalStateIdentifier,
 };
+
+pub use v1_6_0::get_account::AccountIdentifier;

--- a/lib/rpcs/v1_4_5/get_account.rs
+++ b/lib/rpcs/v1_4_5/get_account.rs
@@ -27,7 +27,7 @@ impl GetAccountParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `state_get_account_info` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetAccountResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_auction_info.rs
+++ b/lib/rpcs/v1_4_5/get_auction_info.rs
@@ -19,7 +19,7 @@ impl GetAuctionInfoParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `state_get_auction_info` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetAuctionInfoResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_balance.rs
+++ b/lib/rpcs/v1_4_5/get_balance.rs
@@ -22,7 +22,7 @@ impl GetBalanceParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `state_get_balance` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetBalanceResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_block.rs
+++ b/lib/rpcs/v1_4_5/get_block.rs
@@ -19,7 +19,7 @@ impl GetBlockParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `chain_get_block` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetBlockResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_block_transfers.rs
+++ b/lib/rpcs/v1_4_5/get_block_transfers.rs
@@ -19,7 +19,7 @@ impl GetBlockTransfersParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `chain_get_block_transfers` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetBlockTransfersResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_deploy.rs
+++ b/lib/rpcs/v1_4_5/get_deploy.rs
@@ -23,7 +23,7 @@ impl GetDeployParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to an `info_get_deploy` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetDeployResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_dictionary_item.rs
+++ b/lib/rpcs/v1_4_5/get_dictionary_item.rs
@@ -10,7 +10,7 @@ use crate::{types::StoredValue, Error};
 pub(crate) const GET_DICTIONARY_ITEM_METHOD: &str = "state_get_dictionary_item";
 
 /// The identifier for a dictionary item.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub enum DictionaryItemIdentifier {
     /// A dictionary item identified via an [`Account`]'s named keys.
@@ -116,7 +116,7 @@ impl GetDictionaryItemParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `state_get_dictionary_item` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetDictionaryItemResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_era_info.rs
+++ b/lib/rpcs/v1_4_5/get_era_info.rs
@@ -40,7 +40,7 @@ pub struct EraSummary {
 
 /// The `result` field of a successful JSON-RPC response to a `chain_get_era_info_by_switch_block`
 /// request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetEraInfoResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_node_status.rs
+++ b/lib/rpcs/v1_4_5/get_node_status.rs
@@ -46,7 +46,7 @@ pub struct NextUpgrade {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `info_get_status` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetNodeStatusResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_peers.rs
+++ b/lib/rpcs/v1_4_5/get_peers.rs
@@ -15,7 +15,7 @@ pub struct PeerEntry {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `info_get_peers` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetPeersResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_state_root_hash.rs
+++ b/lib/rpcs/v1_4_5/get_state_root_hash.rs
@@ -20,7 +20,7 @@ impl GetStateRootHashParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `chain_get_state_root_hash` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetStateRootHashResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/get_validator_changes.rs
+++ b/lib/rpcs/v1_4_5/get_validator_changes.rs
@@ -40,7 +40,7 @@ pub struct ValidatorChanges {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `info_get_validator_changes` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetValidatorChangesResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/list_rpcs.rs
+++ b/lib/rpcs/v1_4_5/list_rpcs.rs
@@ -137,7 +137,7 @@ pub struct OpenRpcSchema {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `rpc.discover` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ListRpcsResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/put_deploy.rs
+++ b/lib/rpcs/v1_4_5/put_deploy.rs
@@ -19,7 +19,7 @@ impl PutDeployParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to an `account_put_deploy` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct PutDeployResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_4_5/query_global_state.rs
+++ b/lib/rpcs/v1_4_5/query_global_state.rs
@@ -37,7 +37,7 @@ impl QueryGlobalStateParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `query_global_state` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct QueryGlobalStateResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_5_0.rs
+++ b/lib/rpcs/v1_5_0.rs
@@ -9,10 +9,6 @@ pub(crate) mod speculative_exec;
 
 // The following RPCs are all unchanged from v1.4.5, so we just re-export them.
 
-pub(crate) mod get_account {
-    pub use crate::rpcs::v1_4_5::get_account::GetAccountResult;
-}
-
 pub(crate) mod get_auction_info {
     pub use crate::rpcs::v1_4_5::get_auction_info::GetAuctionInfoResult;
     pub(crate) use crate::rpcs::v1_4_5::get_auction_info::{
@@ -85,7 +81,5 @@ pub(crate) mod put_deploy {
 }
 
 pub(crate) mod query_global_state {
-    pub use crate::rpcs::v1_4_5::query_global_state::{
-        GlobalStateIdentifier, QueryGlobalStateResult,
-    };
+    pub use crate::rpcs::v1_4_5::query_global_state::GlobalStateIdentifier;
 }

--- a/lib/rpcs/v1_5_0/get_chainspec.rs
+++ b/lib/rpcs/v1_5_0/get_chainspec.rs
@@ -39,7 +39,7 @@ impl Display for ChainspecRawBytes {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `info_get_chainspec` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetChainspecResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_5_0/get_deploy.rs
+++ b/lib/rpcs/v1_5_0/get_deploy.rs
@@ -6,7 +6,7 @@ pub(crate) use crate::rpcs::v1_4_5::get_deploy::{GetDeployParams, GET_DEPLOY_MET
 use crate::types::{BlockHashAndHeight, Deploy, ExecutionResult};
 
 /// The `result` field of a successful JSON-RPC response to an `info_get_deploy` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetDeployResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_5_0/get_era_summary.rs
+++ b/lib/rpcs/v1_5_0/get_era_summary.rs
@@ -19,7 +19,7 @@ impl GetEraSummaryParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `chain_get_era_summary` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetEraSummaryResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_5_0/get_node_status.rs
+++ b/lib/rpcs/v1_5_0/get_node_status.rs
@@ -59,7 +59,7 @@ pub struct BlockSynchronizerStatus {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `info_get_status` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetNodeStatusResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_5_0/query_balance.rs
+++ b/lib/rpcs/v1_5_0/query_balance.rs
@@ -40,7 +40,7 @@ impl QueryBalanceParams {
 }
 
 /// Result for "query_balance" RPC response.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct QueryBalanceResult {
     /// The RPC API version.
     pub api_version: ProtocolVersion,

--- a/lib/rpcs/v1_5_0/speculative_exec.rs
+++ b/lib/rpcs/v1_5_0/speculative_exec.rs
@@ -25,7 +25,7 @@ impl SpeculativeExecParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `speculative_exec` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct SpeculativeExecResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_6_0.rs
+++ b/lib/rpcs/v1_6_0.rs
@@ -70,9 +70,7 @@ pub(crate) mod get_block_transfers {
 }
 
 pub(crate) mod get_dictionary_item {
-    pub use crate::rpcs::v1_5_0::get_dictionary_item::{
-        DictionaryItemIdentifier, GetDictionaryItemResult,
-    };
+    pub use crate::rpcs::v1_5_0::get_dictionary_item::GetDictionaryItemResult;
     pub(crate) use crate::rpcs::v1_5_0::get_dictionary_item::{
         GetDictionaryItemParams, GET_DICTIONARY_ITEM_METHOD,
     };

--- a/lib/rpcs/v1_6_0.rs
+++ b/lib/rpcs/v1_6_0.rs
@@ -70,7 +70,9 @@ pub(crate) mod get_block_transfers {
 }
 
 pub(crate) mod get_dictionary_item {
-    pub use crate::rpcs::v1_5_0::get_dictionary_item::GetDictionaryItemResult;
+    pub use crate::rpcs::v1_5_0::get_dictionary_item::{
+        DictionaryItemIdentifier, GetDictionaryItemResult,
+    };
     pub(crate) use crate::rpcs::v1_5_0::get_dictionary_item::{
         GetDictionaryItemParams, GET_DICTIONARY_ITEM_METHOD,
     };

--- a/lib/rpcs/v1_6_0/get_account.rs
+++ b/lib/rpcs/v1_6_0/get_account.rs
@@ -38,7 +38,7 @@ impl GetAccountParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `state_get_account_info` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct GetAccountResult {
     /// The JSON-RPC server version.

--- a/lib/rpcs/v1_6_0/query_global_state.rs
+++ b/lib/rpcs/v1_6_0/query_global_state.rs
@@ -38,7 +38,7 @@ impl QueryGlobalStateParams {
 }
 
 /// The `result` field of a successful JSON-RPC response to a `query_global_state` request.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct QueryGlobalStateResult {
     /// The JSON-RPC server version.

--- a/lib/types/block.rs
+++ b/lib/types/block.rs
@@ -61,6 +61,12 @@ impl Display for BlockHash {
     }
 }
 
+impl AsRef<[u8]> for BlockHash {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
 impl ToBytes for BlockHash {
     fn write_bytes(&self, buffer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
         self.0.write_bytes(buffer)

--- a/lib/types/deploy.rs
+++ b/lib/types/deploy.rs
@@ -406,9 +406,9 @@ impl<'a> DeployBuilder<'a> {
     ///     [`with_payment`](Self::with_payment)
     pub fn new<C: Into<String>>(chain_name: C, session: ExecutableDeployItem) -> Self {
         // Timestamp::now() not available with feature sdk, use default() instead
-        #[cfg(feature = "std-output")]
+        #[cfg(feature = "std-fs-io")]
         let timestamp = Timestamp::now();
-        #[cfg(not(feature = "std-output"))]
+        #[cfg(not(feature = "std-fs-io"))]
         let timestamp = Timestamp::default();
 
         DeployBuilder {

--- a/lib/types/deploy.rs
+++ b/lib/types/deploy.rs
@@ -196,11 +196,20 @@ impl ToBytes for Approval {
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct Deploy {
-    hash: DeployHash,
-    header: DeployHeader,
-    payment: ExecutableDeployItem,
-    session: ExecutableDeployItem,
-    approvals: Vec<Approval>,
+    /// The unique identifier for the deploy.
+    pub hash: DeployHash,
+
+    /// The header information for the deploy.
+    pub header: DeployHeader,
+
+    /// The payment logic for the deploy.
+    pub payment: ExecutableDeployItem,
+
+    /// The session logic for the deploy.
+    pub session: ExecutableDeployItem,
+
+    /// List of approvals for the deploy.
+    pub approvals: Vec<Approval>,
 }
 
 /// Used when constructing a `Deploy`.
@@ -396,10 +405,15 @@ impl<'a> DeployBuilder<'a> {
     ///     [`with_standard_payment`](Self::with_standard_payment) or
     ///     [`with_payment`](Self::with_payment)
     pub fn new<C: Into<String>>(chain_name: C, session: ExecutableDeployItem) -> Self {
+        #[cfg(not(any(feature = "sdk")))]
+        let timestamp = Timestamp::now();
+        #[cfg(feature = "sdk")]
+        let timestamp = Timestamp::default();
+
         DeployBuilder {
             account: None,
             secret_key: None,
-            timestamp: Timestamp::now(),
+            timestamp,
             ttl: Deploy::DEFAULT_TTL,
             gas_price: Deploy::DEFAULT_GAS_PRICE,
             dependencies: vec![],

--- a/lib/types/deploy.rs
+++ b/lib/types/deploy.rs
@@ -405,6 +405,7 @@ impl<'a> DeployBuilder<'a> {
     ///     [`with_standard_payment`](Self::with_standard_payment) or
     ///     [`with_payment`](Self::with_payment)
     pub fn new<C: Into<String>>(chain_name: C, session: ExecutableDeployItem) -> Self {
+        // Timestamp::now() not available with feature sdk, use default() instead
         #[cfg(not(any(feature = "sdk")))]
         let timestamp = Timestamp::now();
         #[cfg(feature = "sdk")]

--- a/lib/types/deploy.rs
+++ b/lib/types/deploy.rs
@@ -45,6 +45,12 @@ impl Display for DeployHash {
     }
 }
 
+impl AsRef<[u8]> for DeployHash {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
 impl ToBytes for DeployHash {
     fn write_bytes(&self, buffer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
         self.0.write_bytes(buffer)

--- a/lib/types/deploy.rs
+++ b/lib/types/deploy.rs
@@ -406,9 +406,9 @@ impl<'a> DeployBuilder<'a> {
     ///     [`with_payment`](Self::with_payment)
     pub fn new<C: Into<String>>(chain_name: C, session: ExecutableDeployItem) -> Self {
         // Timestamp::now() not available with feature sdk, use default() instead
-        #[cfg(not(any(feature = "sdk")))]
+        #[cfg(feature = "std-output")]
         let timestamp = Timestamp::now();
-        #[cfg(feature = "sdk")]
+        #[cfg(not(feature = "std-output"))]
         let timestamp = Timestamp::default();
 
         DeployBuilder {

--- a/lib/types/executable_deploy_item.rs
+++ b/lib/types/executable_deploy_item.rs
@@ -198,8 +198,7 @@ impl ExecutableDeployItem {
     }
 
     /// Returns the runtime arguments.
-    #[cfg(test)]
-    pub(crate) fn args(&self) -> &RuntimeArgs {
+    pub fn args(&self) -> &RuntimeArgs {
         match self {
             ExecutableDeployItem::ModuleBytes { args, .. }
             | ExecutableDeployItem::StoredContractByHash { args, .. }

--- a/lib/types/execution_result.rs
+++ b/lib/types/execution_result.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use super::BlockHash;
 
 /// The execution result of a single deploy.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ExecutionResult {
     /// The block hash.

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -118,20 +118,7 @@ impl ClientCommand for Keygen {
         let algorithm = algorithm::get(matches);
         let force = common::force::get(matches);
 
-        // Check if the std-fs-io feature is enabled
-        #[cfg(feature = "std-fs-io")]
-        {
-            // If std-fs-io feature is enabled, generate key files and return success message
-            keygen::generate_files(&output_dir, algorithm, force)?;
-            Ok(Success::Output(format!("Wrote files to {}", output_dir)))
-        }
-
-        // If std-fs-io feature is not enabled, return an error message
-        #[cfg(not(feature = "std-fs-io"))]
-        {
-            Ok(Success::Output(format!(
-                "keygen not available without std-fs-io feature"
-            )))
-        }
+        keygen::generate_files(&output_dir, algorithm, force)?;
+        Ok(Success::Output(format!("Wrote files to {}", output_dir)))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,7 @@ fn cli() -> Command {
         ))
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     let arg_matches = cli().get_matches();
     let (subcommand_name, matches) = arg_matches.subcommand().unwrap_or_else(|| {


### PR DESCRIPTION
This PR intends to pull changes made for the Rust SDK. It is adding a `std-fs-io` default feature and affects several methods or expose them accordingly to be able to compile the client with 

````shell
cargo build --lib --no-default-features --target wasm32-unknown-unknown
````

This PR has a strong dependency on PR against node 1.6 https://github.com/casper-network/casper-node/pull/4348

Mainly adds some `#[cfg(feature = "std-fs-io")]` where it is possible or not to use io/fs, or prevent sending to std with `json_pretty_print` and returning deploys 
Changes the way secret key is loaded in `with_payment_and_session()`
Publicizes some methods outside the crate 
Adds `session_bytes` to `session_executable_deploy_item()` and adds `check_no_conflicting_arg_types() `(might require additional unit tests)
Adds `with_bytes()` to `SessionStrParams `
Adds some `Clone` attributes to some structs
Removes rt-multi-thread, `The default runtime flavor is 'multi_thread', but the 'rt-multi-thread' feature is disabled.` switching (flavor = "current_thread") to tokio main. Please check this change is legit.
 
 For simplicity for now keeping new get_maybe_secret_key() as one function and not two as per previous PR for 2.0
 
 https://github.com/casper-ecosystem/rustSDK/issues/4
 https://github.com/casper-ecosystem/rustSDK/issues/5
 https://github.com/casper-ecosystem/rustSDK/issues/13