### PR TITLE
Sign transaction command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.  The format
 ### Added
 * Add module to support node 2.0.0 RPCs.
 * Add `make-transaction` command for creating transactions to support node 2.0.0.
+* Add `sign-transaction` command for signing transactions to support node 2.0.0.
 
 ### Changed
 * Update to match change to node RPC `info_get_deploy`.

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -73,7 +73,7 @@ pub use json_args::{
 pub use payment_str_params::PaymentStrParams;
 pub use session_str_params::SessionStrParams;
 pub use simple_args::help as simple_args_help;
-pub use transaction::make_transaction;
+pub use transaction::{make_transaction, sign_transaction_file};
 pub use transaction_builder_params::TransactionBuilderParams;
 pub use transaction_str_params::TransactionStrParams;
 /// Retrieves a [`Deploy`] from the network.

--- a/lib/cli/transaction.rs
+++ b/lib/cli/transaction.rs
@@ -90,6 +90,24 @@ pub fn make_transaction(
     crate::output_transaction(output, &transaction).map_err(CliError::from)
 }
 
+/// Reads a previously-saved [`TransactionV1`] from a file, cryptographically signs it, and outputs it to a
+/// file or stdout.
+///
+/// `maybe_output_path` specifies the output file path, or if empty, will print it to `stdout`.  If
+/// `force` is true, and a file exists at `maybe_output_path`, it will be overwritten.  If `force`
+/// is false and a file exists at `maybe_output_path`, [`Error::FileAlreadyExists`] is returned
+/// and the file will not be written.
+pub fn sign_transaction_file(
+    input_path: &str,
+    secret_key_path: &str,
+    maybe_output_path: &str,
+    force: bool,
+) -> Result<(), CliError> {
+    let output = parse::output_kind(maybe_output_path, force);
+    let secret_key = parse::secret_key_from_file(secret_key_path)?;
+    crate::sign_transaction_file(input_path, &secret_key, output).map_err(CliError::from)
+}
+
 pub fn make_transaction_builder(
     transaction_builder_params: TransactionBuilderParams,
 ) -> Result<TransactionV1Builder, CliError> {

--- a/lib/cli/transaction.rs
+++ b/lib/cli/transaction.rs
@@ -100,10 +100,10 @@ pub fn make_transaction(
 pub fn sign_transaction_file(
     input_path: &str,
     secret_key_path: &str,
-    maybe_output_path: &str,
+    maybe_output_path: Option<&str>,
     force: bool,
 ) -> Result<(), CliError> {
-    let output = parse::output_kind(maybe_output_path, force);
+    let output = parse::output_kind(maybe_output_path.unwrap_or(""), force);
     let secret_key = parse::secret_key_from_file(secret_key_path)?;
     crate::sign_transaction_file(input_path, &secret_key, output).map_err(CliError::from)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ use keygen::Keygen;
 use list_rpcs::ListRpcs;
 use query_balance::QueryBalance;
 use query_global_state::QueryGlobalState;
-use transaction::MakeTransaction;
+use transaction::{MakeTransaction, SignTransaction};
 
 const APP_NAME: &str = "Casper client";
 
@@ -74,6 +74,7 @@ enum DisplayOrder {
     MakeDeploy,
     MakeTransaction,
     SignDeploy,
+    SignTransaction,
     SendDeploy,
     Transfer,
     MakeTransfer,
@@ -110,6 +111,9 @@ fn cli() -> Command {
             DisplayOrder::MakeTransaction as usize,
         ))
         .subcommand(SignDeploy::build(DisplayOrder::SignDeploy as usize))
+        .subcommand(SignTransaction::build(
+            DisplayOrder::SignTransaction as usize,
+        ))
         .subcommand(SendDeploy::build(DisplayOrder::SendDeploy as usize))
         .subcommand(Transfer::build(DisplayOrder::Transfer as usize))
         .subcommand(MakeTransfer::build(DisplayOrder::MakeTransfer as usize))
@@ -162,6 +166,7 @@ async fn main() {
         MakeDeploy::NAME => MakeDeploy::run(matches).await,
         MakeTransaction::NAME => MakeTransaction::run(matches).await,
         SignDeploy::NAME => SignDeploy::run(matches).await,
+        SignTransaction::NAME => SignTransaction::run(matches).await,
         SendDeploy::NAME => SendDeploy::run(matches).await,
         Transfer::NAME => Transfer::run(matches).await,
         MakeTransfer::NAME => MakeTransfer::run(matches).await,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,4 +1,6 @@
 mod creation_common;
 mod make;
+mod sign;
 
 pub use make::MakeTransaction;
+pub use sign::SignTransaction;

--- a/src/transaction/sign.rs
+++ b/src/transaction/sign.rs
@@ -1,0 +1,51 @@
+use async_trait::async_trait;
+use clap::{ArgMatches, Command};
+
+use casper_client::cli::CliError;
+
+use super::creation_common;
+use crate::{command::ClientCommand, common, Success};
+
+pub struct SignTransaction;
+
+#[async_trait]
+impl ClientCommand for SignTransaction {
+    const NAME: &'static str = "sign-transaction";
+    const ABOUT: &'static str =
+        "Read a previously-saved transaction from a file, cryptographically sign it, and output it to a \
+        file or stdout";
+
+    fn build(display_order: usize) -> Command {
+        Command::new(Self::NAME)
+            .about(Self::ABOUT)
+            .display_order(display_order)
+            .arg(
+                common::secret_key::arg(creation_common::DisplayOrder::SecretKey as usize, "")
+                    .required(true),
+            )
+            .arg(creation_common::transaction_path::arg())
+            .arg(creation_common::output::arg())
+            .arg(common::force::arg(
+                creation_common::DisplayOrder::Force as usize,
+                true,
+            ))
+    }
+
+    async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
+        let input_path = creation_common::transaction_path::get(matches);
+        let secret_key = common::secret_key::get(matches).unwrap_or_default();
+        let maybe_output_path = creation_common::output::get(matches).unwrap_or_default();
+        let force = common::force::get(matches);
+        casper_client::cli::sign_transaction_file(input_path, secret_key, maybe_output_path, force)
+            .map(|_| {
+                Success::Output(if maybe_output_path.is_empty() {
+                    String::new()
+                } else {
+                    format!(
+                        "Signed the transaction at {} and wrote to {}",
+                        input_path, maybe_output_path
+                    )
+                })
+            })
+    }
+}

--- a/src/transaction/sign.rs
+++ b/src/transaction/sign.rs
@@ -36,16 +36,18 @@ impl ClientCommand for SignTransaction {
         let secret_key = common::secret_key::get(matches).unwrap_or_default();
         let maybe_output_path = creation_common::output::get(matches).unwrap_or_default();
         let force = common::force::get(matches);
+        let output = if maybe_output_path.is_empty(){
+            String::new()
+        } else {
+            format!(
+                "Signed the transaction at {} and wrote to {}",
+                input_path, maybe_output_path
+            )
+        };
+
         casper_client::cli::sign_transaction_file(input_path, secret_key, maybe_output_path, force)
             .map(|_| {
-                Success::Output(if maybe_output_path.is_empty() {
-                    String::new()
-                } else {
-                    format!(
-                        "Signed the transaction at {} and wrote to {}",
-                        input_path, maybe_output_path
-                    )
-                })
+                Success::Output(output)
             })
     }
 }

--- a/src/transaction/sign.rs
+++ b/src/transaction/sign.rs
@@ -45,6 +45,13 @@ impl ClientCommand for SignTransaction {
             )
         };
 
+        // convert maybe_output_path to an instance of Option to change the function signature of sign_transaction_file
+        let maybe_output_path = if maybe_output_path.is_empty() {
+            None
+        } else {
+            Some(maybe_output_path)
+        };
+
         casper_client::cli::sign_transaction_file(input_path, secret_key, maybe_output_path, force)
             .map(|_| {
                 Success::Output(output)


### PR DESCRIPTION
# Summary of work done:
- Add a `sign-transaction` command to enable signing previously created transaction files.


### Sample command input/output:


The command specifies the session account twice as I still need to identify and implement the proper inputs via clap arguments
Additionally, the command already supports outputting the transaction to a user specified file location, as long as the directory exists.

```
casper-client  make-transaction transfer --source uref-722e1b3d31bef0ba832121bd2941aae6a246d0d05ac95aa16dd587cc5469871d-001 --target uref-722e1b3d31bef0ba832121bd2941aae6a246d0d05ac95aa16dd587cc5469871d-001 --initiator-address 01722e1b3d31bef0ba832121bd2941aae6a246d0d05ac95aa16dd587cc5469871d --chain-name test -p 10 --transfer-amount 10 --output ~/casper/client-dev/test-transaction
```

Associated output:

```
{
  "hash": "705ed54ff8cfef965cdcd1d1f8f30b4a1bd97d3e25dcf81ab91e786ca2a228e3",
  "header": {
    "chain_name": "test",
    "timestamp": "2024-01-29T20:47:38.961Z",
    "ttl": "30m",
    "body_hash": "fb94fd83178e3acf22546beebf5f44692499d681c4381f6d145d85ff9b5fc152",
    "pricing_mode": {
      "GasPriceMultiplier": 1
    },
    "payment_amount": 10,
    "initiator_addr": {
      "PublicKey": "01722e1b3d31bef0ba832121bd2941aae6a246d0d05ac95aa16dd587cc5469871d"
    }
  },
  "body": {
    "args": [
      [
        "source",
        {
          "cl_type": "URef",
          "bytes": "722e1b3d31bef0ba832121bd2941aae6a246d0d05ac95aa16dd587cc5469871d01",
          "parsed": "uref-722e1b3d31bef0ba832121bd2941aae6a246d0d05ac95aa16dd587cc5469871d-001"
        }
      ],
      [
        "target",
        {
          "cl_type": "URef",
          "bytes": "722e1b3d31bef0ba832121bd2941aae6a246d0d05ac95aa16dd587cc5469871d01",
          "parsed": "uref-722e1b3d31bef0ba832121bd2941aae6a246d0d05ac95aa16dd587cc5469871d-001"
        }
      ],
      [
        "amount",
        {
          "cl_type": "U512",
          "bytes": "010a",
          "parsed": "10"
        }
      ]
    ],
    "target": "Native",
    "entry_point": "Transfer",
    "scheduling": "Standard"
  },
  "approvals": []
}

```

Relevant command to sign the above transaction:
```
casper-client sign-transaction --secret-key ~/casper/keys/client-dev/secret_key.pem --transaction-path ~/casper/client-dev/test-transaction --output ~/casper/client-dev/test-transaction-signed
```

Associated output:
```
{
  "hash": "705ed54ff8cfef965cdcd1d1f8f30b4a1bd97d3e25dcf81ab91e786ca2a228e3",
  "header": {
    "chain_name": "test",
    "timestamp": "2024-01-29T20:47:38.961Z",
    "ttl": "30m",
    "body_hash": "fb94fd83178e3acf22546beebf5f44692499d681c4381f6d145d85ff9b5fc152",
    "pricing_mode": {
      "GasPriceMultiplier": 1
    },
    "payment_amount": 10,
    "initiator_addr": {
      "PublicKey": "01722e1b3d31bef0ba832121bd2941aae6a246d0d05ac95aa16dd587cc5469871d"
    }
  },
  "body": {
    "args": [
      [
        "source",
        {
          "cl_type": "URef",
          "bytes": "722e1b3d31bef0ba832121bd2941aae6a246d0d05ac95aa16dd587cc5469871d01",
          "parsed": "uref-722e1b3d31bef0ba832121bd2941aae6a246d0d05ac95aa16dd587cc5469871d-001"
        }
      ],
      [
        "target",
        {
          "cl_type": "URef",
          "bytes": "722e1b3d31bef0ba832121bd2941aae6a246d0d05ac95aa16dd587cc5469871d01",
          "parsed": "uref-722e1b3d31bef0ba832121bd2941aae6a246d0d05ac95aa16dd587cc5469871d-001"
        }
      ],
      [
        "amount",
        {
          "cl_type": "U512",
          "bytes": "010a",
          "parsed": "10"
        }
      ]
    ],
    "target": "Native",
    "entry_point": "Transfer",
    "scheduling": "Standard"
  },
  "approvals": [
    {
      "signer": "01722e1b3d31bef0ba832121bd2941aae6a246d0d05ac95aa16dd587cc5469871d",
      "signature": "01275c5f4b31eb30d7419820d51d7d23ab5e4860c870401c9f086b2b12aafbc9350ad9aa2be74ef49ce72c079591bf490dce0cc9e2e4caf6c1c4a243ba9e3dbb08"
    }
  ]
}
```


# Associated ticket(s):
- #121 
- [Sign Transaction commnd ](https://app.zenhub.com/workspaces/casperlabs-sdks-64b185bf2cb87924e7759d9d/issues/gh/casper-ecosystem/casper-client-rs/121)