### PR TITLE
Add support for addressable entity requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add `make-transaction` command for creating transactions to support node 2.0.0.
 * Add `sign-transaction` command for signing transactions to support node 2.0.0.
 * Add `put-transaction` command for sending transactions to support node 2.0.0.
+* Add support for new node RPC method `state_get_entity`, used in the binary's new `get-entity` subcommand.
 
 ### Changed
 * Update to match change to node RPC `info_get_deploy`.

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -45,13 +45,12 @@ use casper_types::{Digest, URef};
 use crate::{
     rpcs::{
         results::{
-            GetAccountResult, GetAuctionInfoResult, GetBalanceResult, GetBlockResult,
-            GetBlockTransfersResult, GetChainspecResult, GetDeployResult, GetDictionaryItemResult,
-            GetEraInfoResult, GetEraSummaryResult, GetNodeStatusResult, GetPeersResult,
-            GetStateRootHashResult, GetValidatorChangesResult, ListRpcsResult, QueryBalanceResult,
-            QueryGlobalStateResult,
+            GetAccountResult, GetAddressableEntityResult, GetAuctionInfoResult, GetBalanceResult,
+            GetBlockResult, GetBlockTransfersResult, GetChainspecResult, GetDeployResult,
+            GetDictionaryItemResult, GetEraInfoResult, GetEraSummaryResult, GetNodeStatusResult,
+            GetPeersResult, GetStateRootHashResult, GetValidatorChangesResult, ListRpcsResult,
+            QueryBalanceResult, QueryGlobalStateResult,
         },
-        v2_0_0::get_entity::GetAddressableEntityResult,
         DictionaryItemIdentifier,
     },
     SuccessResponse,

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -51,6 +51,7 @@ use crate::{
             GetStateRootHashResult, GetValidatorChangesResult, ListRpcsResult, QueryBalanceResult,
             QueryGlobalStateResult,
         },
+        v2_0_0::get_entity::GetAddressableEntityResult,
         DictionaryItemIdentifier,
     },
     SuccessResponse,
@@ -337,6 +338,34 @@ pub async fn get_account(
         verbosity,
         maybe_block_id,
         account_identifier,
+    )
+    .await
+    .map_err(CliError::from)
+}
+
+/// Retrieves an [`EntityOrAccount`] at a given [`Block`].
+///
+/// `public_key` is the public key as a formatted string associated with the `Account`.
+///
+/// For details of other parameters, see [the module docs](crate::cli#common-parameters).
+pub async fn get_entity(
+    maybe_rpc_id: &str,
+    node_address: &str,
+    verbosity_level: u64,
+    maybe_block_id: &str,
+    account_identifier: &str,
+) -> Result<SuccessResponse<GetAddressableEntityResult>, CliError> {
+    let rpc_id = parse::rpc_id(maybe_rpc_id);
+    let verbosity = parse::verbosity(verbosity_level);
+    let maybe_block_id = parse::block_identifier(maybe_block_id)?;
+    let entity_identifier = parse::entity_identifier(account_identifier)?;
+
+    crate::get_entity(
+        rpc_id,
+        node_address,
+        verbosity,
+        maybe_block_id,
+        entity_identifier,
     )
     .await
     .map_err(CliError::from)

--- a/lib/cli/error.rs
+++ b/lib/cli/error.rs
@@ -44,6 +44,15 @@ pub enum CliError {
         error: casper_types::addressable_entity::FromStrError,
     },
 
+    /// Failed to parse an [`AddressableEntityHash`] from a formatted string.
+    #[error("failed to parse {context} as an addressable entity hash: {error}")]
+    FailedToParseAddressableEntityHash {
+        /// Contextual description of where this error occurred.
+        context: &'static str,
+        /// The actual error raised.
+        error: casper_types::addressable_entity::FromStrError,
+    },
+
     /// Failed to parse a [`URef`] from a formatted string.
     #[error("failed to parse '{context}' as a uref: {error}")]
     FailedToParseURef {

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -64,11 +64,12 @@ pub use output_kind::OutputKind;
 use rpcs::{
     common::{BlockIdentifier, GlobalStateIdentifier},
     results::{
-        GetAccountResult, GetAuctionInfoResult, GetBalanceResult, GetBlockResult,
-        GetBlockTransfersResult, GetChainspecResult, GetDeployResult, GetDictionaryItemResult,
-        GetEraInfoResult, GetEraSummaryResult, GetNodeStatusResult, GetPeersResult,
-        GetStateRootHashResult, GetValidatorChangesResult, ListRpcsResult, PutDeployResult,
-        PutTransactionResult, QueryBalanceResult, QueryGlobalStateResult, SpeculativeExecResult,
+        GetAccountResult, GetAddressableEntityResult, GetAuctionInfoResult, GetBalanceResult,
+        GetBlockResult, GetBlockTransfersResult, GetChainspecResult, GetDeployResult,
+        GetDictionaryItemResult, GetEraInfoResult, GetEraSummaryResult, GetNodeStatusResult,
+        GetPeersResult, GetStateRootHashResult, GetValidatorChangesResult, ListRpcsResult,
+        PutDeployResult, PutTransactionResult, QueryBalanceResult, QueryGlobalStateResult,
+        SpeculativeExecResult,
     },
     v2_0_0::{
         get_account::{AccountIdentifier, GetAccountParams, GET_ACCOUNT_METHOD},
@@ -79,10 +80,7 @@ use rpcs::{
         get_chainspec::GET_CHAINSPEC_METHOD,
         get_deploy::{GetDeployParams, GET_DEPLOY_METHOD},
         get_dictionary_item::{GetDictionaryItemParams, GET_DICTIONARY_ITEM_METHOD},
-        get_entity::{
-            EntityIdentifier, GetAddressableEntityParams, GetAddressableEntityResult,
-            GET_ENTITY_METHOD,
-        },
+        get_entity::{EntityIdentifier, GetAddressableEntityParams, GET_ENTITY_METHOD},
         get_era_info::{GetEraInfoParams, GET_ERA_INFO_METHOD},
         get_era_summary::{GetEraSummaryParams, GET_ERA_SUMMARY_METHOD},
         get_node_status::GET_NODE_STATUS_METHOD,

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -79,6 +79,10 @@ use rpcs::{
         get_chainspec::GET_CHAINSPEC_METHOD,
         get_deploy::{GetDeployParams, GET_DEPLOY_METHOD},
         get_dictionary_item::{GetDictionaryItemParams, GET_DICTIONARY_ITEM_METHOD},
+        get_entity::{
+            EntityIdentifier, GetAddressableEntityParams, GetAddressableEntityResult,
+            GET_ENTITY_METHOD,
+        },
         get_era_info::{GetEraInfoParams, GET_ERA_INFO_METHOD},
         get_era_summary::{GetEraSummaryParams, GET_ERA_SUMMARY_METHOD},
         get_node_status::GET_NODE_STATUS_METHOD,
@@ -438,6 +442,24 @@ pub async fn get_account(
     let params = GetAccountParams::new(account_identifier, maybe_block_identifier);
     JsonRpcCall::new(rpc_id, node_address, verbosity)
         .send_request(GET_ACCOUNT_METHOD, Some(params))
+        .await
+}
+
+/// Retrieves an [`EntityOrAccount`] at a given [`Block`].
+///
+/// Sends a JSON-RPC `state_get_entity` request to the specified node.
+///
+/// For details of the parameters, see [the module docs](crate#common-parameters).
+pub async fn get_entity(
+    rpc_id: JsonRpcId,
+    node_address: &str,
+    verbosity: Verbosity,
+    maybe_block_identifier: Option<BlockIdentifier>,
+    entity_identifier: EntityIdentifier,
+) -> Result<SuccessResponse<GetAddressableEntityResult>, Error> {
+    let params = GetAddressableEntityParams::new(entity_identifier, maybe_block_identifier);
+    JsonRpcCall::new(rpc_id, node_address, verbosity)
+        .send_request(GET_ENTITY_METHOD, Some(params))
         .await
 }
 

--- a/lib/rpcs.rs
+++ b/lib/rpcs.rs
@@ -13,5 +13,6 @@ pub(crate) mod v2_0_0;
 
 pub use v2_0_0::{
     get_account::AccountIdentifier, get_dictionary_item::DictionaryItemIdentifier,
-    query_balance::PurseIdentifier, query_global_state::GlobalStateIdentifier,
+    get_entity::EntityIdentifier, query_balance::PurseIdentifier,
+    query_global_state::GlobalStateIdentifier,
 };

--- a/lib/rpcs/results.rs
+++ b/lib/rpcs/results.rs
@@ -8,6 +8,7 @@ pub use super::v2_0_0::get_block_transfers::GetBlockTransfersResult;
 pub use super::v2_0_0::get_chainspec::GetChainspecResult;
 pub use super::v2_0_0::get_deploy::{DeployExecutionInfo, GetDeployResult};
 pub use super::v2_0_0::get_dictionary_item::GetDictionaryItemResult;
+pub use super::v2_0_0::get_entity::GetAddressableEntityResult;
 pub use super::v2_0_0::get_era_info::{EraSummary, GetEraInfoResult};
 pub use super::v2_0_0::get_era_summary::GetEraSummaryResult;
 pub use super::v2_0_0::get_node_status::{

--- a/lib/rpcs/v2_0_0.rs
+++ b/lib/rpcs/v2_0_0.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod get_block;
 pub(crate) mod get_deploy;
+pub(crate) mod get_entity;
 pub(crate) mod put_transaction;
 
 // The following RPCs are all unchanged from v1.6.0, so we just re-export them.

--- a/lib/rpcs/v2_0_0/get_entity.rs
+++ b/lib/rpcs/v2_0_0/get_entity.rs
@@ -1,0 +1,67 @@
+use casper_types::{
+    account::{Account, AccountHash},
+    AddressableEntity, AddressableEntityHash, ProtocolVersion, PublicKey,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::rpcs::common::BlockIdentifier;
+
+pub(crate) const GET_ENTITY_METHOD: &str = "chain_get_entity";
+
+/// Identifier of an addressable entity.
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub enum EntityIdentifier {
+    /// The public key of an account.
+    PublicKey(PublicKey),
+    /// The account hash of an account.
+    AccountHash(AccountHash),
+    /// The hash of an addressable entity representing an account.
+    EntityHashForAccount(AddressableEntityHash),
+    /// The hash of an addressable entity representing a contract.
+    EntityHashForContract(AddressableEntityHash),
+}
+
+/// An addressable entity or a legacy account.
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EntityOrAccount {
+    /// An addressable entity.
+    AddressableEntity(AddressableEntity),
+    /// A legacy account.
+    LegacyAccount(Account),
+}
+
+/// Params for "state_get_entity" RPC request
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct GetAddressableEntityParams {
+    /// The identifier of the entity.
+    entity_identifier: EntityIdentifier,
+    /// The block identifier.
+    block_identifier: Option<BlockIdentifier>,
+}
+
+impl GetAddressableEntityParams {
+    /// Returns a new `GetAddressableEntityParams`.
+    pub fn new(
+        entity_identifier: EntityIdentifier,
+        block_identifier: Option<BlockIdentifier>,
+    ) -> Self {
+        GetAddressableEntityParams {
+            entity_identifier,
+            block_identifier,
+        }
+    }
+}
+
+/// Result for "state_get_entity" RPC response.
+#[derive(PartialEq, Eq, Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct GetAddressableEntityResult {
+    /// The RPC API version.
+    pub api_version: ProtocolVersion,
+    /// The addressable entity or a legacy account.
+    pub entity: EntityOrAccount,
+    /// The Merkle proof.
+    pub merkle_proof: String,
+}

--- a/lib/rpcs/v2_0_0/get_entity.rs
+++ b/lib/rpcs/v2_0_0/get_entity.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::rpcs::common::BlockIdentifier;
 
-pub(crate) const GET_ENTITY_METHOD: &str = "chain_get_entity";
+pub(crate) const GET_ENTITY_METHOD: &str = "state_get_entity";
 
 /// Identifier of an addressable entity.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]

--- a/src/common.rs
+++ b/src/common.rs
@@ -349,6 +349,41 @@ pub(super) mod account_identifier {
     }
 }
 
+pub(super) mod entity_identifier {
+    use super::*;
+
+    pub(super) const ARG_NAME: &str = "entity-identifier";
+    const ARG_SHORT: char = 'e';
+    const ARG_VALUE_NAME: &str = "FORMATTED STRING or PATH";
+    const ARG_HELP: &str =
+        "The identifier for an addressable entity or an account. This can be an entity hash, a public \
+        key or an account hash. To provide an entity hash, it must be formatted as \
+        \"contract-addressable-entity-<HEX STRING>\" or \"account-addressable-entity-<HEX STRING>\". \
+        To provide a public key, it must be a properly formatted public key. The public key may be \
+        read in from a file, in which case enter the path to the file as the --account-identifier \
+        argument. The file should be one of the two public key files generated via the `keygen` \
+        subcommand; \"public_key_hex\" or \"public_key.pem\". To provide an account hash, it must \
+        be formatted as \"account-hash-<HEX STRING>\"";
+
+    pub fn arg(order: usize, is_required: bool) -> Arg {
+        Arg::new(ARG_NAME)
+            .long(ARG_NAME)
+            .short(ARG_SHORT)
+            .required(is_required)
+            .value_name(ARG_VALUE_NAME)
+            .help(ARG_HELP)
+            .display_order(order)
+    }
+
+    pub fn get(matches: &ArgMatches) -> Result<String, CliError> {
+        let value = matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_default();
+        public_key::try_read_from_file(value)
+    }
+}
+
 /// Handles providing the arg for and retrieval of the purse URef.
 pub(super) mod purse_uref {
     use super::*;

--- a/src/get_entity.rs
+++ b/src/get_entity.rs
@@ -1,0 +1,77 @@
+use std::str;
+
+use async_trait::async_trait;
+use clap::{ArgMatches, Command};
+
+use casper_client::cli::CliError;
+
+use crate::{command::ClientCommand, common, Success};
+
+/// Legacy name of command.
+const COMMAND_ALIAS: &str = "get-entity";
+const ENTITY_IDENTIFIER_IS_REQUIRED: bool = true;
+const PUBLIC_KEY_IDENTIFIER_ALIAS: &str = "public-key";
+const PUBLIC_KEY_IDENTIFIER_SHORT_ALIAS: char = 'p';
+const ACCOUNT_HASH_IDENTIFIER_ALIAS: &str = "account-hash";
+const ACCOUNT_HASH_IDENTIFIER_SHORT_ALIAS: char = 'a';
+
+pub struct GetEntity;
+
+/// This struct defines the order in which the args are shown for this subcommand's help message.
+enum DisplayOrder {
+    Verbose,
+    NodeAddress,
+    RpcId,
+    BlockIdentifier,
+    EntityIdentifier,
+}
+
+#[async_trait]
+impl ClientCommand for GetEntity {
+    const NAME: &'static str = "get-entity";
+    const ABOUT: &'static str = "Retrieve information for an addressable entity from the network";
+
+    fn build(display_order: usize) -> Command {
+        Command::new(Self::NAME)
+            .alias(COMMAND_ALIAS)
+            .about(Self::ABOUT)
+            .display_order(display_order)
+            .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
+            .arg(common::node_address::arg(
+                DisplayOrder::NodeAddress as usize,
+            ))
+            .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
+            .arg(common::block_identifier::arg(
+                DisplayOrder::BlockIdentifier as usize,
+                true,
+            ))
+            .arg(
+                common::entity_identifier::arg(
+                    DisplayOrder::EntityIdentifier as usize,
+                    ENTITY_IDENTIFIER_IS_REQUIRED,
+                )
+                .alias(PUBLIC_KEY_IDENTIFIER_ALIAS)
+                .short_alias(PUBLIC_KEY_IDENTIFIER_SHORT_ALIAS)
+                .alias(ACCOUNT_HASH_IDENTIFIER_ALIAS)
+                .short_alias(ACCOUNT_HASH_IDENTIFIER_SHORT_ALIAS),
+            )
+    }
+
+    async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
+        let maybe_rpc_id = common::rpc_id::get(matches);
+        let node_address = common::node_address::get(matches);
+        let verbosity_level = common::verbose::get(matches);
+        let block_identifier = common::block_identifier::get(matches);
+        let entity_idenfitier = common::entity_identifier::get(matches)?;
+
+        casper_client::cli::get_entity(
+            maybe_rpc_id,
+            node_address,
+            verbosity_level,
+            block_identifier,
+            &entity_idenfitier,
+        )
+        .await
+        .map(Success::from)
+    }
+}

--- a/src/get_entity.rs
+++ b/src/get_entity.rs
@@ -7,8 +7,6 @@ use casper_client::cli::CliError;
 
 use crate::{command::ClientCommand, common, Success};
 
-/// Legacy name of command.
-const COMMAND_ALIAS: &str = "get-entity";
 const ENTITY_IDENTIFIER_IS_REQUIRED: bool = true;
 const PUBLIC_KEY_IDENTIFIER_ALIAS: &str = "public-key";
 const PUBLIC_KEY_IDENTIFIER_SHORT_ALIAS: char = 'p';
@@ -33,7 +31,6 @@ impl ClientCommand for GetEntity {
 
     fn build(display_order: usize) -> Command {
         Command::new(Self::NAME)
-            .alias(COMMAND_ALIAS)
             .about(Self::ABOUT)
             .display_order(display_order)
             .arg(common::verbose::arg(DisplayOrder::Verbose as usize))

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod get_auction_info;
 mod get_balance;
 mod get_chainspec;
 mod get_dictionary_item;
+mod get_entity;
 mod get_era_info;
 mod get_era_summary;
 mod get_node_status;
@@ -25,6 +26,7 @@ use std::process;
 
 use clap::{crate_version, Command};
 use get_balance::GetBalance;
+use get_entity::GetEntity;
 use once_cell::sync::Lazy;
 
 use casper_client::{cli, rpcs::results::GetChainspecResult, SuccessResponse};
@@ -91,6 +93,7 @@ enum DisplayOrder {
     QueryBalance,
     GetDictionaryItem,
     GetAccount,
+    GetEntity,
     GetAuctionInfo,
     GetValidatorChanges,
     GetPeers,
@@ -139,6 +142,7 @@ fn cli() -> Command {
             DisplayOrder::GetDictionaryItem as usize,
         ))
         .subcommand(GetAccount::build(DisplayOrder::GetAccount as usize))
+        .subcommand(GetEntity::build(DisplayOrder::GetEntity as usize))
         .subcommand(GetAuctionInfo::build(DisplayOrder::GetAuctionInfo as usize))
         .subcommand(GetValidatorChanges::build(
             DisplayOrder::GetValidatorChanges as usize,
@@ -185,6 +189,7 @@ async fn main() {
         QueryBalance::NAME => QueryBalance::run(matches).await,
         GetDictionaryItem::NAME => GetDictionaryItem::run(matches).await,
         GetAccount::NAME => GetAccount::run(matches).await,
+        GetEntity::NAME => GetEntity::run(matches).await,
         GetAuctionInfo::NAME => GetAuctionInfo::run(matches).await,
         GetValidatorChanges::NAME => GetValidatorChanges::run(matches).await,
         GetPeers::NAME => GetPeers::run(matches).await,


### PR DESCRIPTION
We will need to support a new endpoint that allows retrieval of addressable entities with fallback for legacy accounts.
The endpoint has been added to the RPC sidecar in this PR: https://github.com/zajko/event-sidecar/pull/10.
There's a test for it in casper-test which uses the code added here: https://github.com/casper-network/casper-test/pull/146