### PR TITLE
Patch to address updated signature of `Key::AddressableEntity`

### DIFF
--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -615,7 +615,7 @@ pub(super) mod entity_addr {
                 error,
             })?;
         match entity_addr {
-            Key::AddressableEntity(_, entity_addr) => Ok(entity_addr),
+            Key::AddressableEntity(entity_addr) => Ok(entity_addr),
             _ => Err(CliError::from(Error::InvalidKeyVariant {
                 expected_variant: "AddressibleEntity".to_string(),
                 actual: entity_addr,


### PR DESCRIPTION
Recent changes to `casper-types::Key::AddressableEntity` were causing the casper-client to fail to compile for nctl-test
This commit updates the client to support the new `AddressableEntity` signature