### PR TITLE
Put transaction command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add module to support node 2.0.0 RPCs.
 * Add `make-transaction` command for creating transactions to support node 2.0.0.
 * Add `sign-transaction` command for signing transactions to support node 2.0.0.
+* Add `put-transaction` command for sending transactions to support node 2.0.0.
 
 ### Changed
 * Update to match change to node RPC `info_get_deploy`.

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -73,7 +73,7 @@ pub use json_args::{
 pub use payment_str_params::PaymentStrParams;
 pub use session_str_params::SessionStrParams;
 pub use simple_args::help as simple_args_help;
-pub use transaction::{make_transaction, sign_transaction_file};
+pub use transaction::{make_transaction, put_transaction, sign_transaction_file};
 pub use transaction_builder_params::TransactionBuilderParams;
 pub use transaction_str_params::TransactionStrParams;
 /// Retrieves a [`Deploy`] from the network.

--- a/lib/cli/json_args.rs
+++ b/lib/cli/json_args.rs
@@ -135,7 +135,7 @@ fn write_json_to_bytesrepr(
                 Key::Bid(_) if mapped_variant == "Bid" => {}
                 Key::Withdraw(_) if mapped_variant == "Withdraw" => {}
                 Key::Dictionary(_) if mapped_variant == "Dictionary" => {}
-                Key::SystemContractRegistry if mapped_variant == "SystemContractRegistry" => {}
+                Key::SystemEntityRegistry if mapped_variant == "SystemEntityRegistry" => {}
                 Key::Unbond(_) if mapped_variant == "Unbond" => {}
                 Key::ChainspecRegistry if mapped_variant == "ChainspecRegistry" => {}
                 _ => return Err(ErrorDetails::KeyObjectHasInvalidVariant),

--- a/lib/cli/json_args/help.rs
+++ b/lib/cli/json_args/help.rs
@@ -77,7 +77,7 @@ static ALL_INFO_AND_EXAMPLES: Lazy<Vec<InfoAndExamples>> = Lazy::new(|| {
                 r#"{"name":"entry_point_name","type":"Key","value":"dictionary-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}"#,
                 r#"{"name":"entry_point_name","type":"Key","value":{"Dictionary":"dictionary-201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"}}"#,
                 r#"{"name":"entry_point_name","type":"Key","value":"system-contract-registry-0000000000000000000000000000000000000000000000000000000000000000"}"#,
-                r#"{"name":"entry_point_name","type":"Key","value":{"SystemContractRegistry":"system-contract-registry-0000000000000000000000000000000000000000000000000000000000000000"}}"#,
+                r#"{"name":"entry_point_name","type":"Key","value":{"SystemEntityRegistry":"system-contract-registry-0000000000000000000000000000000000000000000000000000000000000000"}}"#,
                 r#"{"name":"entry_point_name","type":"Key","value":"chainspec-registry-1111111111111111111111111111111111111111111111111111111111111111"}"#,
                 r#"{"name":"entry_point_name","type":"Key","value":{"ChainspecRegistry":"chainspec-registry-1111111111111111111111111111111111111111111111111111111111111111"}}"#,
             ],

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -5,7 +5,11 @@ use std::{fs, path::Path, str::FromStr};
 
 use rand::Rng;
 
-use casper_types::{account::AccountHash, bytesrepr::Bytes, crypto, AsymmetricType, BlockHash, DeployHash, Digest, ExecutableDeployItem, HashAddr, Key, NamedArg, PricingMode, PublicKey, RuntimeArgs, SecretKey, TimeDiff, Timestamp, UIntParseError, URef, U512, TransactionV1};
+use casper_types::{
+    account::AccountHash, bytesrepr::Bytes, crypto, AsymmetricType, BlockHash, DeployHash, Digest,
+    ExecutableDeployItem, HashAddr, Key, NamedArg, PricingMode, PublicKey, RuntimeArgs, SecretKey,
+    TimeDiff, Timestamp, TransactionV1, UIntParseError, URef, U512,
+};
 
 use super::{simple_args, CliError, PaymentStrParams, SessionStrParams};
 use crate::{
@@ -185,7 +189,7 @@ fn standard_payment(value: &str) -> Result<RuntimeArgs, CliError> {
 ///
 /// # Original Author
 /// This function was modified from one of the same name written by Gregory Roussac for the 1.6 SDK
-fn check_no_conflicting_arg_types(simple: &Vec<&str>, json: &str) -> Result<(), CliError> {
+fn check_no_conflicting_arg_types(simple: &[&str], json: &str) -> Result<(), CliError> {
     let count = [!simple.is_empty(), !json.is_empty()]
         .iter()
         .filter(|&&x| x)
@@ -412,18 +416,21 @@ pub fn transaction_module_bytes(session_path: &str) -> Result<Bytes, CliError> {
 }
 
 /// Parse a transaction file into a `TransactionV1` to be sent to the network
-pub fn transaction_from_file(transaction_path: &str) -> Result<TransactionV1, CliError>{
+pub fn transaction_from_file(transaction_path: &str) -> Result<TransactionV1, CliError> {
     let transaction_bytes = fs::read(transaction_path).map_err(|error| crate::Error::IoError {
         context: format!("unable to read transaction file at '{}'", transaction_path),
         error,
     })?;
-    let transaction_str = std::str::from_utf8(&transaction_bytes).map_err(|error| crate::Error::Utf8Error{
-        context: "transaction_from_file",
-        error,
-    })?;
-    let transaction: TransactionV1 = serde_json::from_str(transaction_str).map_err(|error| crate::Error::FailedToDecodeFromJson {
-        context: "transaction",
-        error,
+    let transaction_str =
+        std::str::from_utf8(&transaction_bytes).map_err(|error| crate::Error::Utf8Error {
+            context: "transaction_from_file",
+            error,
+        })?;
+    let transaction: TransactionV1 = serde_json::from_str(transaction_str).map_err(|error| {
+        crate::Error::FailedToDecodeFromJson {
+            context: "transaction",
+            error,
+        }
     })?;
     Ok(transaction)
 }

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -5,11 +5,7 @@ use std::{fs, path::Path, str::FromStr};
 
 use rand::Rng;
 
-use casper_types::{
-    account::AccountHash, bytesrepr::Bytes, crypto, AsymmetricType, BlockHash, DeployHash, Digest,
-    ExecutableDeployItem, HashAddr, Key, NamedArg, PricingMode, PublicKey, RuntimeArgs, SecretKey,
-    TimeDiff, Timestamp, UIntParseError, URef, U512,
-};
+use casper_types::{account::AccountHash, bytesrepr::Bytes, crypto, AsymmetricType, BlockHash, DeployHash, Digest, ExecutableDeployItem, HashAddr, Key, NamedArg, PricingMode, PublicKey, RuntimeArgs, SecretKey, TimeDiff, Timestamp, UIntParseError, URef, U512, TransactionV1};
 
 use super::{simple_args, CliError, PaymentStrParams, SessionStrParams};
 use crate::{
@@ -413,6 +409,23 @@ pub fn transaction_module_bytes(session_path: &str) -> Result<Bytes, CliError> {
         error,
     })?;
     Ok(Bytes::from(module_bytes))
+}
+
+/// Parse a transaction file into a `TransactionV1` to be sent to the network
+pub fn transaction_from_file(transaction_path: &str) -> Result<TransactionV1, CliError>{
+    let transaction_bytes = fs::read(transaction_path).map_err(|error| crate::Error::IoError {
+        context: format!("unable to read transaction file at '{}'", transaction_path),
+        error,
+    })?;
+    let transaction_str = std::str::from_utf8(&transaction_bytes).map_err(|error| crate::Error::Utf8Error{
+        context: "transaction_from_file",
+        error,
+    })?;
+    let transaction: TransactionV1 = serde_json::from_str(transaction_str).map_err(|error| crate::Error::FailedToDecodeFromJson {
+        context: "transaction",
+        error,
+    })?;
+    Ok(transaction)
 }
 /// Parses a URef from a formatted string for the purposes of creating transactions.
 pub fn uref(uref_str: &str) -> Result<URef, CliError> {

--- a/lib/cli/tests.rs
+++ b/lib/cli/tests.rs
@@ -807,11 +807,11 @@ mod transaction {
 
     #[test]
     fn should_create_invocable_entity_transaction() {
-        let entity_addr: EntityAddr = EntityAddr::new_contract_entity_addr([0u8; 32]);
-        let entity_hash_addr = entity_addr.value();
+        let entity_addr: EntityAddr = EntityAddr::new_account_entity_addr([0u8; 32]);
+        let hash_addr = entity_addr.value();
         let entry_point = String::from("test-entry-point");
         let target = &TransactionTarget::Stored {
-            id: TransactionInvocationTarget::InvocableEntity(entity_hash_addr),
+            id: TransactionInvocationTarget::InvocableEntity(hash_addr),
             runtime: TransactionRuntime::VmCasperV1,
         };
 

--- a/lib/cli/tests.rs
+++ b/lib/cli/tests.rs
@@ -807,10 +807,11 @@ mod transaction {
 
     #[test]
     fn should_create_invocable_entity_transaction() {
-        let entity_addr: EntityAddr = vec![0u8; 32].as_slice().try_into().unwrap();
+        let entity_addr: EntityAddr = EntityAddr::new_contract_entity_addr([0u8; 32]);
+        let entity_hash_addr = entity_addr.value();
         let entry_point = String::from("test-entry-point");
         let target = &TransactionTarget::Stored {
-            id: TransactionInvocationTarget::InvocableEntity(entity_addr),
+            id: TransactionInvocationTarget::InvocableEntity(entity_hash_addr),
             runtime: TransactionRuntime::VmCasperV1,
         };
 

--- a/lib/cli/transaction.rs
+++ b/lib/cli/transaction.rs
@@ -1,6 +1,9 @@
-use crate::cli::{parse, CliError, TransactionBuilderParams, TransactionStrParams};
-use crate::rpcs::results::PutTransactionResult;
-use crate::SuccessResponse;
+use crate::{
+    cli::{parse, CliError, TransactionBuilderParams, TransactionStrParams},
+    put_transaction as put_transaction_rpc_handler,
+    rpcs::results::PutTransactionResult,
+    SuccessResponse,
+};
 use casper_types::{
     InitiatorAddr, Transaction, TransactionSessionKind, TransactionV1, TransactionV1Builder,
 };
@@ -109,7 +112,7 @@ pub async fn put_transaction(
     let rpc_id = parse::rpc_id(rpc_id_str);
     let verbosity_level = parse::verbosity(verbosity_level);
     let transaction = create_transaction(builder_params, transaction_params, false)?;
-    crate::put_transaction(
+    put_transaction_rpc_handler(
         rpc_id,
         node_address,
         verbosity_level,

--- a/lib/error.rs
+++ b/lib/error.rs
@@ -149,6 +149,15 @@ pub enum Error {
     /// Failed to validate response.
     #[error("invalid response: {0}")]
     ResponseFailedValidation(#[from] ValidateResponseError),
+
+    /// An error that occurs when attempting to use a non UTF-8 string for a transaction.
+    #[error("invalid UTF-8 string: {context}: {error}")]
+    Utf8Error {
+        /// Contextual description of where this error occurred.
+        context: &'static str,
+        /// Underlying error.
+        error: std::str::Utf8Error,
+    },
 }
 
 impl From<ToBytesError> for Error {

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -55,7 +55,7 @@ use serde::Serialize;
 
 #[cfg(doc)]
 use casper_types::{account::Account, Block, StoredValue, Transfer};
-use casper_types::{Deploy, DeployHash, Digest, Key, SecretKey, TransactionV1, URef};
+use casper_types::{Deploy, DeployHash, Digest, Key, SecretKey, Transaction, TransactionV1, URef};
 
 pub use error::Error;
 use json_rpc::JsonRpcCall;
@@ -68,7 +68,7 @@ use rpcs::{
         GetBlockTransfersResult, GetChainspecResult, GetDeployResult, GetDictionaryItemResult,
         GetEraInfoResult, GetEraSummaryResult, GetNodeStatusResult, GetPeersResult,
         GetStateRootHashResult, GetValidatorChangesResult, ListRpcsResult, PutDeployResult,
-        QueryBalanceResult, QueryGlobalStateResult, SpeculativeExecResult,
+        QueryBalanceResult, QueryGlobalStateResult, SpeculativeExecResult, PutTransactionResult
     },
     v2_0_0::{
         get_account::{AccountIdentifier, GetAccountParams, GET_ACCOUNT_METHOD},
@@ -90,6 +90,7 @@ use rpcs::{
         query_balance::{PurseIdentifier, QueryBalanceParams, QUERY_BALANCE_METHOD},
         query_global_state::{QueryGlobalStateParams, QUERY_GLOBAL_STATE_METHOD},
         speculative_exec::{SpeculativeExecParams, SPECULATIVE_EXEC_METHOD},
+        put_transaction::{PutTransactionParams, PUT_TRANSACTION_METHOD}
     },
     DictionaryItemIdentifier,
 };
@@ -115,6 +116,22 @@ pub async fn put_deploy(
 ) -> Result<SuccessResponse<PutDeployResult>, Error> {
     JsonRpcCall::new(rpc_id, node_address, verbosity)
         .send_request(PUT_DEPLOY_METHOD, Some(PutDeployParams::new(deploy)))
+        .await
+}
+
+/// Puts a [`Transaction`] to the network for execution
+///
+/// Sends a JSON-RPC `account_put_transaction` request to the specified node.
+///
+/// For details of the parameters, see [the module docs](crate#common-parameters).
+pub async fn put_transaction(
+    rpc_id: JsonRpcId,
+    node_address: &str,
+    verbosity: Verbosity,
+    transaction: Transaction,
+) -> Result<SuccessResponse<PutTransactionResult>, Error> {
+    JsonRpcCall::new(rpc_id, node_address, verbosity)
+        .send_request(PUT_TRANSACTION_METHOD, Some(PutTransactionParams::new(transaction)))
         .await
 }
 

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -68,7 +68,7 @@ use rpcs::{
         GetBlockTransfersResult, GetChainspecResult, GetDeployResult, GetDictionaryItemResult,
         GetEraInfoResult, GetEraSummaryResult, GetNodeStatusResult, GetPeersResult,
         GetStateRootHashResult, GetValidatorChangesResult, ListRpcsResult, PutDeployResult,
-        QueryBalanceResult, QueryGlobalStateResult, SpeculativeExecResult, PutTransactionResult
+        PutTransactionResult, QueryBalanceResult, QueryGlobalStateResult, SpeculativeExecResult,
     },
     v2_0_0::{
         get_account::{AccountIdentifier, GetAccountParams, GET_ACCOUNT_METHOD},
@@ -87,10 +87,10 @@ use rpcs::{
         get_validator_changes::GET_VALIDATOR_CHANGES_METHOD,
         list_rpcs::LIST_RPCS_METHOD,
         put_deploy::{PutDeployParams, PUT_DEPLOY_METHOD},
+        put_transaction::{PutTransactionParams, PUT_TRANSACTION_METHOD},
         query_balance::{PurseIdentifier, QueryBalanceParams, QUERY_BALANCE_METHOD},
         query_global_state::{QueryGlobalStateParams, QUERY_GLOBAL_STATE_METHOD},
         speculative_exec::{SpeculativeExecParams, SPECULATIVE_EXEC_METHOD},
-        put_transaction::{PutTransactionParams, PUT_TRANSACTION_METHOD}
     },
     DictionaryItemIdentifier,
 };
@@ -131,7 +131,10 @@ pub async fn put_transaction(
     transaction: Transaction,
 ) -> Result<SuccessResponse<PutTransactionResult>, Error> {
     JsonRpcCall::new(rpc_id, node_address, verbosity)
-        .send_request(PUT_TRANSACTION_METHOD, Some(PutTransactionParams::new(transaction)))
+        .send_request(
+            PUT_TRANSACTION_METHOD,
+            Some(PutTransactionParams::new(transaction)),
+        )
         .await
 }
 

--- a/lib/rpcs/results.rs
+++ b/lib/rpcs/results.rs
@@ -28,3 +28,4 @@ pub use super::v2_0_0::put_deploy::PutDeployResult;
 pub use super::v2_0_0::query_balance::QueryBalanceResult;
 pub use super::v2_0_0::query_global_state::QueryGlobalStateResult;
 pub use super::v2_0_0::speculative_exec::SpeculativeExecResult;
+pub use super::v2_0_0::put_transaction::PutTransactionResult;

--- a/lib/rpcs/results.rs
+++ b/lib/rpcs/results.rs
@@ -25,7 +25,7 @@ pub use super::v2_0_0::list_rpcs::{
     SchemaParam,
 };
 pub use super::v2_0_0::put_deploy::PutDeployResult;
+pub use super::v2_0_0::put_transaction::PutTransactionResult;
 pub use super::v2_0_0::query_balance::QueryBalanceResult;
 pub use super::v2_0_0::query_global_state::QueryGlobalStateResult;
 pub use super::v2_0_0::speculative_exec::SpeculativeExecResult;
-pub use super::v2_0_0::put_transaction::PutTransactionResult;

--- a/lib/rpcs/v1_5_0.rs
+++ b/lib/rpcs/v1_5_0.rs
@@ -10,6 +10,8 @@ pub(crate) mod speculative_exec;
 // The following RPCs are all unchanged from v1.4.5, so we just re-export them.
 
 pub(crate) mod get_account {
+    // This lint should be re-enabled once the client is updated to handle multiple different node
+    // node versions.
     #[allow(unused_imports)]
     pub use crate::rpcs::v1_4_5::get_account::GetAccountResult;
     // This lint should be re-enabled once the client is updated to handle multiple different node

--- a/lib/rpcs/v1_5_0.rs
+++ b/lib/rpcs/v1_5_0.rs
@@ -10,6 +10,7 @@ pub(crate) mod speculative_exec;
 // The following RPCs are all unchanged from v1.4.5, so we just re-export them.
 
 pub(crate) mod get_account {
+    #[allow(unused_imports)]
     pub use crate::rpcs::v1_4_5::get_account::GetAccountResult;
     // This lint should be re-enabled once the client is updated to handle multiple different node
     // node versions.

--- a/lib/rpcs/v1_6_0.rs
+++ b/lib/rpcs/v1_6_0.rs
@@ -10,6 +10,8 @@ pub(crate) mod get_chainspec {
 }
 
 pub(crate) mod get_deploy {
+    // This lint should be re-enabled once the client is updated to handle multiple different node
+    // node versions.
     #[allow(unused_imports)]
     pub use crate::rpcs::v1_5_0::get_deploy::GetDeployResult;
     // This lint should be re-enabled once the client is updated to handle multiple different node
@@ -58,6 +60,8 @@ pub(crate) mod get_balance {
 }
 
 pub(crate) mod get_block {
+    // This lint should be re-enabled once the client is updated to handle multiple different node
+    // node versions.
     #[allow(unused_imports)]
     pub use crate::rpcs::v1_5_0::get_block::GetBlockResult;
     pub(crate) use crate::rpcs::v1_5_0::get_block::{GetBlockParams, GET_BLOCK_METHOD};

--- a/lib/rpcs/v1_6_0.rs
+++ b/lib/rpcs/v1_6_0.rs
@@ -10,6 +10,7 @@ pub(crate) mod get_chainspec {
 }
 
 pub(crate) mod get_deploy {
+    #[allow(unused_imports)]
     pub use crate::rpcs::v1_5_0::get_deploy::GetDeployResult;
     // This lint should be re-enabled once the client is updated to handle multiple different node
     // node versions.
@@ -57,6 +58,7 @@ pub(crate) mod get_balance {
 }
 
 pub(crate) mod get_block {
+    #[allow(unused_imports)]
     pub use crate::rpcs::v1_5_0::get_block::GetBlockResult;
     pub(crate) use crate::rpcs::v1_5_0::get_block::{GetBlockParams, GET_BLOCK_METHOD};
 }

--- a/lib/rpcs/v2_0_0.rs
+++ b/lib/rpcs/v2_0_0.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod get_block;
 pub(crate) mod get_deploy;
+pub(crate) mod put_transaction;
 
 // The following RPCs are all unchanged from v1.6.0, so we just re-export them.
 

--- a/lib/rpcs/v2_0_0/put_transaction.rs
+++ b/lib/rpcs/v2_0_0/put_transaction.rs
@@ -1,0 +1,30 @@
+use serde::{Deserialize, Serialize};
+
+use casper_types::{Transaction, TransactionHash, ProtocolVersion};
+
+pub(crate) const PUT_TRANSACTION_METHOD: &str = "account_put_transaction";
+
+/// Params for "account_put_transaction" RPC request.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct PutTransactionParams {
+    /// The `Transaction`.
+    pub transaction: Transaction,
+}
+
+
+impl PutTransactionParams {
+    pub(crate) fn new(transaction: Transaction) -> Self {
+        PutTransactionParams { transaction }
+    }
+}
+
+/// Result for "account_put_transaction" RPC response.
+#[derive(PartialEq, Eq, Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct PutTransactionResult {
+    /// The RPC API version.
+    pub api_version: ProtocolVersion,
+    /// The transaction hash.
+    pub transaction_hash: TransactionHash,
+}

--- a/lib/rpcs/v2_0_0/put_transaction.rs
+++ b/lib/rpcs/v2_0_0/put_transaction.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use casper_types::{Transaction, TransactionHash, ProtocolVersion};
+use casper_types::{ProtocolVersion, Transaction, TransactionHash};
 
 pub(crate) const PUT_TRANSACTION_METHOD: &str = "account_put_transaction";
 
@@ -11,7 +11,6 @@ pub struct PutTransactionParams {
     /// The `Transaction`.
     pub transaction: Transaction,
 }
-
 
 impl PutTransactionParams {
     pub(crate) fn new(transaction: Transaction) -> Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ use keygen::Keygen;
 use list_rpcs::ListRpcs;
 use query_balance::QueryBalance;
 use query_global_state::QueryGlobalState;
-use transaction::{MakeTransaction, SignTransaction, PutTransaction};
+use transaction::{MakeTransaction, PutTransaction, SignTransaction};
 
 const APP_NAME: &str = "Casper client";
 
@@ -108,9 +108,7 @@ fn cli() -> Command {
         .about("A client for interacting with the Casper network")
         .subcommand(PutDeploy::build(DisplayOrder::PutDeploy as usize))
         .subcommand(MakeDeploy::build(DisplayOrder::MakeDeploy as usize))
-        .subcommand(PutTransaction::build(
-            DisplayOrder::PutTransaction as usize,
-        ))
+        .subcommand(PutTransaction::build(DisplayOrder::PutTransaction as usize))
         .subcommand(MakeTransaction::build(
             DisplayOrder::MakeTransaction as usize,
         ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ use keygen::Keygen;
 use list_rpcs::ListRpcs;
 use query_balance::QueryBalance;
 use query_global_state::QueryGlobalState;
-use transaction::{MakeTransaction, SignTransaction};
+use transaction::{MakeTransaction, SignTransaction, PutTransaction};
 
 const APP_NAME: &str = "Casper client";
 
@@ -72,6 +72,7 @@ static VERSION: Lazy<String> =
 enum DisplayOrder {
     PutDeploy,
     MakeDeploy,
+    PutTransaction,
     MakeTransaction,
     SignDeploy,
     SignTransaction,
@@ -107,6 +108,9 @@ fn cli() -> Command {
         .about("A client for interacting with the Casper network")
         .subcommand(PutDeploy::build(DisplayOrder::PutDeploy as usize))
         .subcommand(MakeDeploy::build(DisplayOrder::MakeDeploy as usize))
+        .subcommand(PutTransaction::build(
+            DisplayOrder::PutTransaction as usize,
+        ))
         .subcommand(MakeTransaction::build(
             DisplayOrder::MakeTransaction as usize,
         ))
@@ -164,6 +168,7 @@ async fn main() {
     let result = match subcommand_name {
         PutDeploy::NAME => PutDeploy::run(matches).await,
         MakeDeploy::NAME => MakeDeploy::run(matches).await,
+        PutTransaction::NAME => PutTransaction::run(matches).await,
         MakeTransaction::NAME => MakeTransaction::run(matches).await,
         SignDeploy::NAME => SignDeploy::run(matches).await,
         SignTransaction::NAME => SignTransaction::run(matches).await,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,6 +1,7 @@
 mod creation_common;
 mod make;
 mod sign;
+mod put;
 
 pub use make::MakeTransaction;
 pub use sign::SignTransaction;

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,7 +1,8 @@
 mod creation_common;
 mod make;
-mod sign;
 mod put;
+mod sign;
 
 pub use make::MakeTransaction;
 pub use sign::SignTransaction;
+pub use put::PutTransaction;

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -4,5 +4,5 @@ mod put;
 mod sign;
 
 pub use make::MakeTransaction;
-pub use sign::SignTransaction;
 pub use put::PutTransaction;
+pub use sign::SignTransaction;

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -614,7 +614,7 @@ pub(super) mod entity_addr {
                 error,
             })?;
         match entity_addr {
-            Key::AddressableEntity(_, entity_addr) => Ok(entity_addr),
+            Key::AddressableEntity(entity_addr) => Ok(entity_addr),
             _ => Err(CliError::from(Error::InvalidKeyVariant {
                 expected_variant: "AddressibleEntity".to_string(),
                 actual: entity_addr,

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -524,9 +524,9 @@ pub(super) mod transaction_path {
     const ARG_VALUE_NAME: &str = common::ARG_PATH;
     const ARG_HELP: &str = "Path to input transaction file";
 
-    pub fn arg(required: bool) -> Arg {
+    pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
-            .required(required)
+            .required(true)
             .long(ARG_NAME)
             .short(ARG_SHORT)
             .value_name(ARG_VALUE_NAME)
@@ -1304,7 +1304,7 @@ pub(super) mod session {
 
     fn add_args(add_bid_subcommand: Command) -> Command {
         add_bid_subcommand
-            .arg(transaction_path::arg(true))
+            .arg(transaction_path::arg())
             .arg(session_entry_point::arg())
     }
 }

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -5,10 +5,11 @@ use std::process;
 
 use clap::{Arg, ArgAction, ArgGroup, ArgMatches, Command};
 
-use casper_client::cli::{CliError, json_args_help, simple_args_help, TransactionBuilderParams, TransactionStrParams};
+use casper_client::cli::{
+    json_args_help, simple_args_help, CliError, TransactionBuilderParams, TransactionStrParams,
+};
 
 use crate::common;
-use crate::transaction::creation_common::invocable_entity_alias::run;
 
 const SESSION_ARG_GROUP: &str = "session-args";
 
@@ -946,31 +947,6 @@ pub(super) mod add_bid {
         Ok((params, transaction_str_params))
     }
 
-    pub fn put_transaction_run(
-        matches: &ArgMatches,
-    ) -> Result<
-        (
-            TransactionBuilderParams,
-            TransactionStrParams,
-            &str,
-            &str,
-            u64,
-        ),
-        CliError>{
-        let node_address = common::node_address::get(matches);
-        let rpc_id = common::rpc_id::get(matches);
-        let verbosity_level = common::verbose::get(matches);
-
-        let (transaction_builder_params, transaction_str_params) = run(matches)?;
-        Ok((
-            transaction_builder_params,
-            transaction_str_params,
-            node_address,
-            rpc_id,
-            verbosity_level,
-        ))
-    }
-
     fn add_args(add_bid_subcommand: Command) -> Command {
         add_bid_subcommand
             .arg(delegation_rate::arg())
@@ -1008,35 +984,7 @@ pub(super) mod withdraw_bid {
 
         Ok((params, transaction_str_params))
     }
-    ///
-    /// Parse the args for this command when it is set up for the put-transaction subcommand.
-    ///
-    /// Returns a tuple of the transaction builder params, the transaction str params, a string representing the node address, a string representing rpc_id, and a u64 representing the verbosity level.
-    pub fn put_transaction_run(
-        matches: &ArgMatches,
-    ) -> Result<
-        (
-            TransactionBuilderParams,
-            TransactionStrParams,
-            &str,
-            &str,
-            u64,
-        ),
-        CliError,
-    > {
-        let node_address = common::node_address::get(matches);
-        let rpc_id = common::rpc_id::get(matches);
-        let verbosity_level = common::verbose::get(matches);
 
-        let (transaction_builder_params, transaction_str_params) = run(matches)?;
-        Ok((
-            transaction_builder_params,
-            transaction_str_params,
-            node_address,
-            rpc_id,
-            verbosity_level,
-        ))
-    }
     fn add_args(add_bid_subcommand: Command) -> Command {
         add_bid_subcommand
             .arg(public_key::arg(DisplayOrder::PublicKey as usize))
@@ -1081,38 +1029,6 @@ pub(super) mod delegate {
         Ok((params, transaction_str_params))
     }
 
-    ///
-    /// Parse the args for this command when it is set up for the put-transaction subcommand.
-    ///
-    /// Returns a tuple of the transaction builder params, the transaction str params, a string representing the node address, a string representing rpc_id, and a u64 representing the verbosity level.
-    pub fn put_transaction_run(
-        matches: &ArgMatches,
-    ) -> Result<
-        (
-            TransactionBuilderParams,
-            TransactionStrParams,
-            &str,
-            &str,
-            u64,
-        ),
-        CliError,
-    > {
-        let node_address = common::node_address::get(matches);
-        let rpc_id = common::rpc_id::get(matches);
-        let verbosity_level = common::verbose::get(matches);
-
-        let (transaction_builder_params, transaction_str_params) = run(matches)?;
-        Ok((
-            transaction_builder_params,
-            transaction_str_params,
-            node_address,
-            rpc_id,
-            verbosity_level,
-        ))
-    }
-
-
-
     fn add_args(add_bid_subcommand: Command) -> Command {
         add_bid_subcommand
             .arg(delegator::arg())
@@ -1156,36 +1072,6 @@ pub(super) mod undelegate {
         };
         let transaction_str_params = build_transaction_str_params(matches);
         Ok((params, transaction_str_params))
-    }
-
-    ///
-    /// Parse the args for this command when it is set up for the put-transaction subcommand.
-    ///
-    /// Returns a tuple of the transaction builder params, the transaction str params, a string representing the node address, a string representing rpc_id, and a u64 representing the verbosity level.
-    pub fn put_transaction_run(
-        matches: &ArgMatches,
-    ) -> Result<
-        (
-            TransactionBuilderParams,
-            TransactionStrParams,
-            &str,
-            &str,
-            u64,
-        ),
-        CliError,
-    > {
-        let node_address = common::node_address::get(matches);
-        let rpc_id = common::rpc_id::get(matches);
-        let verbosity_level = common::verbose::get(matches);
-
-        let (transaction_builder_params, transaction_str_params) = run(matches)?;
-        Ok((
-            transaction_builder_params,
-            transaction_str_params,
-            node_address,
-            rpc_id,
-            verbosity_level,
-        ))
     }
 
     fn add_args(add_bid_subcommand: Command) -> Command {
@@ -1236,36 +1122,6 @@ pub(super) mod redelegate {
         Ok((params, transaction_str_params))
     }
 
-    ///
-    /// Parse the args for this command when it is set up for the put-transaction subcommand.
-    ///
-    /// Returns a tuple of the transaction builder params, the transaction str params, a string representing the node address, a string representing rpc_id, and a u64 representing the verbosity level.
-    pub fn put_transaction_run(
-        matches: &ArgMatches,
-    ) -> Result<
-        (
-            TransactionBuilderParams,
-            TransactionStrParams,
-            &str,
-            &str,
-            u64,
-        ),
-        CliError,
-    > {
-        let node_address = common::node_address::get(matches);
-        let rpc_id = common::rpc_id::get(matches);
-        let verbosity_level = common::verbose::get(matches);
-
-        let (transaction_builder_params, transaction_str_params) = run(matches)?;
-        Ok((
-            transaction_builder_params,
-            transaction_str_params,
-            node_address,
-            rpc_id,
-            verbosity_level,
-        ))
-    }
-
     fn add_args(add_bid_subcommand: Command) -> Command {
         add_bid_subcommand
             .arg(delegator::arg())
@@ -1310,36 +1166,6 @@ pub(super) mod invocable_entity {
         Ok((params, transaction_str_params))
     }
 
-    ///
-    /// Parse the args for this command when it is set up for the put-transaction subcommand.
-    ///
-    /// Returns a tuple of the transaction builder params, the transaction str params, a string representing the node address, a string representing rpc_id, and a u64 representing the verbosity level.
-    pub fn put_transaction_run(
-        matches: &ArgMatches,
-    ) -> Result<
-        (
-            TransactionBuilderParams,
-            TransactionStrParams,
-            &str,
-            &str,
-            u64,
-        ),
-        CliError,
-    > {
-        let node_address = common::node_address::get(matches);
-        let rpc_id = common::rpc_id::get(matches);
-        let verbosity_level = common::verbose::get(matches);
-
-        let (transaction_builder_params, transaction_str_params) = run(matches)?;
-        Ok((
-            transaction_builder_params,
-            transaction_str_params,
-            node_address,
-            rpc_id,
-            verbosity_level,
-        ))
-    }
-
     fn add_args(add_bid_subcommand: Command) -> Command {
         add_bid_subcommand
             .arg(entity_addr::arg())
@@ -1377,32 +1203,6 @@ pub(super) mod invocable_entity_alias {
         };
         let transaction_str_params = build_transaction_str_params(matches);
         Ok((params, transaction_str_params))
-    }
-
-    pub fn put_transaction_run(
-        matches: &ArgMatches,
-    ) -> Result<
-        (
-            TransactionBuilderParams,
-            TransactionStrParams,
-            &str,
-            &str,
-            u64,
-        ),
-        CliError,
-    > {
-        let node_address = common::node_address::get(matches);
-        let rpc_id = common::rpc_id::get(matches);
-        let verbosity_level = common::verbose::get(matches);
-
-        let (transaction_builder_params, transaction_str_params) = run(matches)?;
-        Ok((
-            transaction_builder_params,
-            transaction_str_params,
-            node_address,
-            rpc_id,
-            verbosity_level,
-        ))
     }
 
     fn add_args(add_bid_subcommand: Command) -> Command {
@@ -1448,32 +1248,6 @@ pub(super) mod package {
         Ok((params, transaction_str_params))
     }
 
-    pub fn put_transaction_run(
-        matches: &ArgMatches,
-    ) -> Result<
-        (
-            TransactionBuilderParams,
-            TransactionStrParams,
-            &str,
-            &str,
-            u64,
-        ),
-        CliError,
-    > {
-        let node_address = common::node_address::get(matches);
-        let rpc_id = common::rpc_id::get(matches);
-        let verbosity_level = common::verbose::get(matches);
-
-        let (transaction_builder_params, transaction_str_params) = run(matches)?;
-        Ok((
-            transaction_builder_params,
-            transaction_str_params,
-            node_address,
-            rpc_id,
-            verbosity_level,
-        ))
-    }
-
     fn add_args(add_bid_subcommand: Command) -> Command {
         add_bid_subcommand
             .arg(package_addr::arg())
@@ -1516,32 +1290,6 @@ pub(super) mod package_alias {
         };
         let transaction_str_params = build_transaction_str_params(matches);
         Ok((params, transaction_str_params))
-    }
-
-    pub fn put_transaction_run(
-        matches: &ArgMatches,
-    ) -> Result<
-        (
-            TransactionBuilderParams,
-            TransactionStrParams,
-            &str,
-            &str,
-            u64,
-        ),
-        CliError,
-    > {
-        let node_address = common::node_address::get(matches);
-        let rpc_id = common::rpc_id::get(matches);
-        let verbosity_level = common::verbose::get(matches);
-
-        let (transaction_builder_params, transaction_str_params) = run(matches)?;
-        Ok((
-            transaction_builder_params,
-            transaction_str_params,
-            node_address,
-            rpc_id,
-            verbosity_level,
-        ))
     }
 
     fn add_args(add_bid_subcommand: Command) -> Command {
@@ -1809,19 +1557,23 @@ pub(super) fn build_transaction_str_params(matches: &ArgMatches) -> TransactionS
 pub(super) fn add_rpc_args(subcommand: Command) -> Command {
     subcommand
         .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
-        .arg(common::node_address::arg(DisplayOrder::NodeAddress as usize))
+        .arg(common::node_address::arg(
+            DisplayOrder::NodeAddress as usize,
+        ))
         .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
 }
 
-pub(super) fn put_transaction_run(
+pub(super) fn parse_rpc_args_and_run(
     matches: &ArgMatches,
-    subcommand_run: fn(&ArgMatches) -> Result<(TransactionBuilderParams, TransactionStrParams), CliError>,
+    subcommand_run: fn(
+        &ArgMatches,
+    ) -> Result<(TransactionBuilderParams, TransactionStrParams), CliError>,
 ) -> Result<
     (
         TransactionBuilderParams,
         TransactionStrParams,
-        &'static str,
-        &'static str,
+        &str,
+        &str,
         u64,
     ),
     CliError,

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -5,9 +5,10 @@ use std::process;
 
 use clap::{Arg, ArgAction, ArgGroup, ArgMatches, Command};
 
-use casper_client::cli::{json_args_help, simple_args_help, TransactionStrParams};
+use casper_client::cli::{CliError, json_args_help, simple_args_help, TransactionBuilderParams, TransactionStrParams};
 
 use crate::common;
+use crate::transaction::creation_common::invocable_entity_alias::run;
 
 const SESSION_ARG_GROUP: &str = "session-args";
 
@@ -918,6 +919,10 @@ pub(super) mod add_bid {
         apply_common_creation_options(add_args(Command::new(NAME).about(ABOUT)), false, false)
     }
 
+    pub fn put_transaction_build() -> Command {
+        add_rpc_args(build())
+    }
+
     pub fn run(
         matches: &ArgMatches,
     ) -> Result<(TransactionBuilderParams, TransactionStrParams), CliError> {
@@ -941,6 +946,31 @@ pub(super) mod add_bid {
         Ok((params, transaction_str_params))
     }
 
+    pub fn put_transaction_run(
+        matches: &ArgMatches,
+    ) -> Result<
+        (
+            TransactionBuilderParams,
+            TransactionStrParams,
+            &str,
+            &str,
+            u64,
+        ),
+        CliError>{
+        let node_address = common::node_address::get(matches);
+        let rpc_id = common::rpc_id::get(matches);
+        let verbosity_level = common::verbose::get(matches);
+
+        let (transaction_builder_params, transaction_str_params) = run(matches)?;
+        Ok((
+            transaction_builder_params,
+            transaction_str_params,
+            node_address,
+            rpc_id,
+            verbosity_level,
+        ))
+    }
+
     fn add_args(add_bid_subcommand: Command) -> Command {
         add_bid_subcommand
             .arg(delegation_rate::arg())
@@ -960,6 +990,10 @@ pub(super) mod withdraw_bid {
         apply_common_creation_options(add_args(Command::new(NAME).about(ABOUT)), false, false)
     }
 
+    pub fn put_transaction_build() -> Command {
+        add_rpc_args(build())
+    }
+
     pub fn run(
         matches: &ArgMatches,
     ) -> Result<(TransactionBuilderParams, TransactionStrParams), CliError> {
@@ -974,7 +1008,35 @@ pub(super) mod withdraw_bid {
 
         Ok((params, transaction_str_params))
     }
+    ///
+    /// Parse the args for this command when it is set up for the put-transaction subcommand.
+    ///
+    /// Returns a tuple of the transaction builder params, the transaction str params, a string representing the node address, a string representing rpc_id, and a u64 representing the verbosity level.
+    pub fn put_transaction_run(
+        matches: &ArgMatches,
+    ) -> Result<
+        (
+            TransactionBuilderParams,
+            TransactionStrParams,
+            &str,
+            &str,
+            u64,
+        ),
+        CliError,
+    > {
+        let node_address = common::node_address::get(matches);
+        let rpc_id = common::rpc_id::get(matches);
+        let verbosity_level = common::verbose::get(matches);
 
+        let (transaction_builder_params, transaction_str_params) = run(matches)?;
+        Ok((
+            transaction_builder_params,
+            transaction_str_params,
+            node_address,
+            rpc_id,
+            verbosity_level,
+        ))
+    }
     fn add_args(add_bid_subcommand: Command) -> Command {
         add_bid_subcommand
             .arg(public_key::arg(DisplayOrder::PublicKey as usize))
@@ -991,6 +1053,10 @@ pub(super) mod delegate {
 
     pub fn build() -> Command {
         apply_common_creation_options(add_args(Command::new(NAME).about(ABOUT)), false, false)
+    }
+
+    pub fn put_transaction_build() -> Command {
+        add_rpc_args(build())
     }
 
     pub fn run(
@@ -1015,6 +1081,38 @@ pub(super) mod delegate {
         Ok((params, transaction_str_params))
     }
 
+    ///
+    /// Parse the args for this command when it is set up for the put-transaction subcommand.
+    ///
+    /// Returns a tuple of the transaction builder params, the transaction str params, a string representing the node address, a string representing rpc_id, and a u64 representing the verbosity level.
+    pub fn put_transaction_run(
+        matches: &ArgMatches,
+    ) -> Result<
+        (
+            TransactionBuilderParams,
+            TransactionStrParams,
+            &str,
+            &str,
+            u64,
+        ),
+        CliError,
+    > {
+        let node_address = common::node_address::get(matches);
+        let rpc_id = common::rpc_id::get(matches);
+        let verbosity_level = common::verbose::get(matches);
+
+        let (transaction_builder_params, transaction_str_params) = run(matches)?;
+        Ok((
+            transaction_builder_params,
+            transaction_str_params,
+            node_address,
+            rpc_id,
+            verbosity_level,
+        ))
+    }
+
+
+
     fn add_args(add_bid_subcommand: Command) -> Command {
         add_bid_subcommand
             .arg(delegator::arg())
@@ -1033,6 +1131,10 @@ pub(super) mod undelegate {
 
     pub fn build() -> Command {
         apply_common_creation_options(add_args(Command::new(NAME).about(ABOUT)), false, false)
+    }
+
+    pub fn put_transaction_build() -> Command {
+        add_rpc_args(build())
     }
 
     pub fn run(
@@ -1056,6 +1158,36 @@ pub(super) mod undelegate {
         Ok((params, transaction_str_params))
     }
 
+    ///
+    /// Parse the args for this command when it is set up for the put-transaction subcommand.
+    ///
+    /// Returns a tuple of the transaction builder params, the transaction str params, a string representing the node address, a string representing rpc_id, and a u64 representing the verbosity level.
+    pub fn put_transaction_run(
+        matches: &ArgMatches,
+    ) -> Result<
+        (
+            TransactionBuilderParams,
+            TransactionStrParams,
+            &str,
+            &str,
+            u64,
+        ),
+        CliError,
+    > {
+        let node_address = common::node_address::get(matches);
+        let rpc_id = common::rpc_id::get(matches);
+        let verbosity_level = common::verbose::get(matches);
+
+        let (transaction_builder_params, transaction_str_params) = run(matches)?;
+        Ok((
+            transaction_builder_params,
+            transaction_str_params,
+            node_address,
+            rpc_id,
+            verbosity_level,
+        ))
+    }
+
     fn add_args(add_bid_subcommand: Command) -> Command {
         add_bid_subcommand
             .arg(delegator::arg())
@@ -1073,6 +1205,10 @@ pub(super) mod redelegate {
 
     pub fn build() -> Command {
         apply_common_creation_options(add_args(Command::new(NAME).about(ABOUT)), false, false)
+    }
+
+    pub fn put_transaction_build() -> Command {
+        add_rpc_args(build())
     }
 
     pub fn run(
@@ -1100,6 +1236,36 @@ pub(super) mod redelegate {
         Ok((params, transaction_str_params))
     }
 
+    ///
+    /// Parse the args for this command when it is set up for the put-transaction subcommand.
+    ///
+    /// Returns a tuple of the transaction builder params, the transaction str params, a string representing the node address, a string representing rpc_id, and a u64 representing the verbosity level.
+    pub fn put_transaction_run(
+        matches: &ArgMatches,
+    ) -> Result<
+        (
+            TransactionBuilderParams,
+            TransactionStrParams,
+            &str,
+            &str,
+            u64,
+        ),
+        CliError,
+    > {
+        let node_address = common::node_address::get(matches);
+        let rpc_id = common::rpc_id::get(matches);
+        let verbosity_level = common::verbose::get(matches);
+
+        let (transaction_builder_params, transaction_str_params) = run(matches)?;
+        Ok((
+            transaction_builder_params,
+            transaction_str_params,
+            node_address,
+            rpc_id,
+            verbosity_level,
+        ))
+    }
+
     fn add_args(add_bid_subcommand: Command) -> Command {
         add_bid_subcommand
             .arg(delegator::arg())
@@ -1121,6 +1287,10 @@ pub(super) mod invocable_entity {
         apply_common_args(add_args(Command::new(NAME).about(ABOUT)))
     }
 
+    pub fn put_transaction_build() -> Command {
+        add_rpc_args(build())
+    }
+
     pub fn run(
         matches: &ArgMatches,
     ) -> Result<(TransactionBuilderParams, TransactionStrParams), CliError> {
@@ -1138,6 +1308,36 @@ pub(super) mod invocable_entity {
         };
         let transaction_str_params = build_transaction_str_params(matches);
         Ok((params, transaction_str_params))
+    }
+
+    ///
+    /// Parse the args for this command when it is set up for the put-transaction subcommand.
+    ///
+    /// Returns a tuple of the transaction builder params, the transaction str params, a string representing the node address, a string representing rpc_id, and a u64 representing the verbosity level.
+    pub fn put_transaction_run(
+        matches: &ArgMatches,
+    ) -> Result<
+        (
+            TransactionBuilderParams,
+            TransactionStrParams,
+            &str,
+            &str,
+            u64,
+        ),
+        CliError,
+    > {
+        let node_address = common::node_address::get(matches);
+        let rpc_id = common::rpc_id::get(matches);
+        let verbosity_level = common::verbose::get(matches);
+
+        let (transaction_builder_params, transaction_str_params) = run(matches)?;
+        Ok((
+            transaction_builder_params,
+            transaction_str_params,
+            node_address,
+            rpc_id,
+            verbosity_level,
+        ))
     }
 
     fn add_args(add_bid_subcommand: Command) -> Command {
@@ -1158,6 +1358,10 @@ pub(super) mod invocable_entity_alias {
         apply_common_args(add_args(Command::new(NAME).about(ABOUT)))
     }
 
+    pub fn put_transaction_build() -> Command {
+        add_rpc_args(build())
+    }
+
     pub fn run(
         matches: &ArgMatches,
     ) -> Result<(TransactionBuilderParams, TransactionStrParams), CliError> {
@@ -1173,6 +1377,32 @@ pub(super) mod invocable_entity_alias {
         };
         let transaction_str_params = build_transaction_str_params(matches);
         Ok((params, transaction_str_params))
+    }
+
+    pub fn put_transaction_run(
+        matches: &ArgMatches,
+    ) -> Result<
+        (
+            TransactionBuilderParams,
+            TransactionStrParams,
+            &str,
+            &str,
+            u64,
+        ),
+        CliError,
+    > {
+        let node_address = common::node_address::get(matches);
+        let rpc_id = common::rpc_id::get(matches);
+        let verbosity_level = common::verbose::get(matches);
+
+        let (transaction_builder_params, transaction_str_params) = run(matches)?;
+        Ok((
+            transaction_builder_params,
+            transaction_str_params,
+            node_address,
+            rpc_id,
+            verbosity_level,
+        ))
     }
 
     fn add_args(add_bid_subcommand: Command) -> Command {
@@ -1191,6 +1421,10 @@ pub(super) mod package {
 
     pub fn build() -> Command {
         apply_common_args(add_args(Command::new(NAME).about(ABOUT)))
+    }
+
+    pub fn put_transaction_build() -> Command {
+        add_rpc_args(build())
     }
 
     pub fn run(
@@ -1214,6 +1448,32 @@ pub(super) mod package {
         Ok((params, transaction_str_params))
     }
 
+    pub fn put_transaction_run(
+        matches: &ArgMatches,
+    ) -> Result<
+        (
+            TransactionBuilderParams,
+            TransactionStrParams,
+            &str,
+            &str,
+            u64,
+        ),
+        CliError,
+    > {
+        let node_address = common::node_address::get(matches);
+        let rpc_id = common::rpc_id::get(matches);
+        let verbosity_level = common::verbose::get(matches);
+
+        let (transaction_builder_params, transaction_str_params) = run(matches)?;
+        Ok((
+            transaction_builder_params,
+            transaction_str_params,
+            node_address,
+            rpc_id,
+            verbosity_level,
+        ))
+    }
+
     fn add_args(add_bid_subcommand: Command) -> Command {
         add_bid_subcommand
             .arg(package_addr::arg())
@@ -1231,6 +1491,10 @@ pub(super) mod package_alias {
 
     pub fn build() -> Command {
         apply_common_args(add_args(Command::new(NAME).about(ABOUT)))
+    }
+
+    pub fn put_transaction_build() -> Command {
+        add_rpc_args(build())
     }
 
     pub fn run(
@@ -1254,6 +1518,32 @@ pub(super) mod package_alias {
         Ok((params, transaction_str_params))
     }
 
+    pub fn put_transaction_run(
+        matches: &ArgMatches,
+    ) -> Result<
+        (
+            TransactionBuilderParams,
+            TransactionStrParams,
+            &str,
+            &str,
+            u64,
+        ),
+        CliError,
+    > {
+        let node_address = common::node_address::get(matches);
+        let rpc_id = common::rpc_id::get(matches);
+        let verbosity_level = common::verbose::get(matches);
+
+        let (transaction_builder_params, transaction_str_params) = run(matches)?;
+        Ok((
+            transaction_builder_params,
+            transaction_str_params,
+            node_address,
+            rpc_id,
+            verbosity_level,
+        ))
+    }
+
     fn add_args(add_bid_subcommand: Command) -> Command {
         add_bid_subcommand
             .arg(package_alias_arg::arg())
@@ -1272,6 +1562,10 @@ pub(super) mod session {
 
     pub fn build() -> Command {
         apply_common_args(add_args(Command::new(NAME).about(ABOUT)))
+    }
+
+    pub fn put_transaction_build() -> Command {
+        add_rpc_args(build())
     }
 
     pub fn run(
@@ -1320,6 +1614,10 @@ pub(super) mod transfer {
 
     pub fn build() -> Command {
         apply_common_creation_options(add_args(Command::new(NAME).about(ABOUT)), false, false)
+    }
+
+    pub fn put_transaction_build() -> Command {
+        add_rpc_args(build())
     }
 
     pub fn run(
@@ -1507,4 +1805,37 @@ pub(super) fn build_transaction_str_params(matches: &ArgMatches) -> TransactionS
         output_path: maybe_output_path,
         payment_amount,
     }
+}
+pub(super) fn add_rpc_args(subcommand: Command) -> Command {
+    subcommand
+        .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
+        .arg(common::node_address::arg(DisplayOrder::NodeAddress as usize))
+        .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
+}
+
+pub(super) fn put_transaction_run(
+    matches: &ArgMatches,
+    subcommand_run: fn(&ArgMatches) -> Result<(TransactionBuilderParams, TransactionStrParams), CliError>,
+) -> Result<
+    (
+        TransactionBuilderParams,
+        TransactionStrParams,
+        &'static str,
+        &'static str,
+        u64,
+    ),
+    CliError,
+> {
+    let node_address = common::node_address::get(matches);
+    let rpc_id = common::rpc_id::get(matches);
+    let verbosity_level = common::verbose::get(matches);
+
+    let (transaction_builder_params, transaction_str_params) = subcommand_run(matches)?;
+    Ok((
+        transaction_builder_params,
+        transaction_str_params,
+        node_address,
+        rpc_id,
+        verbosity_level,
+    ))
 }

--- a/src/transaction/put.rs
+++ b/src/transaction/put.rs
@@ -8,7 +8,9 @@ use super::creation_common::{
     redelegate, session, transfer, undelegate, withdraw_bid,
 };
 
-use crate::{command::ClientCommand, transaction::creation_common::parse_rpc_args_and_run, Success};
+use crate::{
+    command::ClientCommand, transaction::creation_common::parse_rpc_args_and_run, Success,
+};
 
 pub struct PutTransaction;
 const ALIAS: &str = "put-txn";

--- a/src/transaction/put.rs
+++ b/src/transaction/put.rs
@@ -1,0 +1,88 @@
+use async_trait::async_trait;
+use clap::{ArgMatches, Command};
+
+use casper_client::cli::CliError;
+
+use super::creation_common::{
+    add_bid, delegate, invocable_entity, invocable_entity_alias, package, package_alias,
+    redelegate, session, transfer, undelegate, withdraw_bid, DisplayOrder,
+};
+
+use crate::{command::ClientCommand, common, Success};
+
+pub struct PutTransaction;
+const ALIAS: &str = "put-txn";
+#[async_trait]
+impl ClientCommand for PutTransaction {
+    const NAME: &'static str = "put-transaction";
+
+    const ABOUT: &'static str =
+        "Create a transaction and output it to a file or stdout. As a file, the transaction can subsequently \
+        be signed by other parties using the 'sign-transaction' subcommand and then sent to the network \
+        for execution using the 'send-transaction' subcommand";
+
+    fn build(display_order: usize) -> Command {
+        Command::new(Self::NAME)
+            .about(Self::ABOUT)
+            .alias(ALIAS)
+            .subcommand_required(true)
+            .subcommand(withdraw_bid::build())
+            .subcommand(add_bid::build())
+            .subcommand(delegate::build())
+            .subcommand(undelegate::build())
+            .subcommand(redelegate::build())
+            .subcommand(invocable_entity::build())
+            .subcommand(invocable_entity_alias::build())
+            .subcommand(package::build())
+            .subcommand(package_alias::build())
+            .subcommand(session::build())
+            .subcommand(transfer::build())
+            .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
+            .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
+            .arg(common::node_address::arg(
+                DisplayOrder::NodeAddress as usize,
+            ))
+            .display_order(display_order)
+    }
+
+    async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
+        let rpc_id = common::rpc_id::get(matches);
+        let node_address = common::node_address::get(matches);
+        let verbosity_level = common::verbose::get(matches);
+        if let Some((subcommand, matches)) = matches.subcommand() {
+            let (transaction_builder_params, transaction_str_params) = match subcommand {
+                add_bid::NAME => add_bid::run(matches)?,
+                withdraw_bid::NAME => withdraw_bid::run(matches)?,
+                delegate::NAME => delegate::run(matches)?,
+                undelegate::NAME => undelegate::run(matches)?,
+                redelegate::NAME => redelegate::run(matches)?,
+                invocable_entity::NAME => invocable_entity::run(matches)?,
+                invocable_entity_alias::NAME => invocable_entity_alias::run(matches)?,
+                package::NAME => package::run(matches)?,
+                package_alias::NAME => package_alias::run(matches)?,
+                session::NAME => session::run(matches)?,
+                transfer::NAME => transfer::run(matches)?,
+                _ => {
+                    return Err(CliError::InvalidArgument {
+                        context: "Make Transaction",
+                        error: "failure to provide recognized subcommand".to_string(),
+                    })
+                }
+            };
+            casper_client::cli::put_transaction(
+                rpc_id,
+                node_address,
+                verbosity_level,
+                transaction_builder_params,
+                transaction_str_params,
+            )
+            .await
+            .map(Success::from)
+        } else {
+            return Err(CliError::InvalidArgument {
+                context: "Put Transaction",
+                error: "Failure to supply subcommand".to_string(),
+            });
+        }
+    }
+}

--- a/src/transaction/put.rs
+++ b/src/transaction/put.rs
@@ -8,7 +8,7 @@ use super::creation_common::{
     redelegate, session, transfer, undelegate, withdraw_bid,
 };
 
-use crate::{command::ClientCommand, Success};
+use crate::{command::ClientCommand, transaction::creation_common::parse_rpc_args_and_run, Success};
 
 pub struct PutTransaction;
 const ALIAS: &str = "put-txn";
@@ -49,17 +49,19 @@ impl ClientCommand for PutTransaction {
                 rpc_id,
                 verbosity_level,
             ) = match subcommand {
-                add_bid::NAME => add_bid::put_transaction_run(matches)?,
-                withdraw_bid::NAME => withdraw_bid::put_transaction_run(matches)?,
-                delegate::NAME => delegate::put_transaction_run(matches)?,
-                undelegate::NAME => undelegate::put_transaction_run(matches)?,
-                redelegate::NAME => redelegate::put_transaction_run(matches)?,
-                invocable_entity::NAME => invocable_entity::put_transaction_run(matches)?,
-                invocable_entity_alias::NAME => invocable_entity_alias::put_transaction_run(matches)?,
-                package::NAME => package::put_transaction_run(matches)?,
-                package_alias::NAME => package_alias::run(matches)?,
-                session::NAME => session::run(matches)?,
-                transfer::NAME => transfer::run(matches)?,
+                add_bid::NAME => parse_rpc_args_and_run(matches, add_bid::run)?,
+                withdraw_bid::NAME => parse_rpc_args_and_run(matches, withdraw_bid::run)?,
+                delegate::NAME => parse_rpc_args_and_run(matches, delegate::run)?,
+                undelegate::NAME => parse_rpc_args_and_run(matches, undelegate::run)?,
+                redelegate::NAME => parse_rpc_args_and_run(matches, redelegate::run)?,
+                invocable_entity::NAME => parse_rpc_args_and_run(matches, invocable_entity::run)?,
+                invocable_entity_alias::NAME => {
+                    parse_rpc_args_and_run(matches, invocable_entity_alias::run)?
+                }
+                package::NAME => parse_rpc_args_and_run(matches, package::run)?,
+                package_alias::NAME => parse_rpc_args_and_run(matches, package_alias::run)?,
+                session::NAME => parse_rpc_args_and_run(matches, session::run)?,
+                transfer::NAME => parse_rpc_args_and_run(matches, transfer::run)?,
                 _ => {
                     return Err(CliError::InvalidArgument {
                         context: "Make Transaction",

--- a/src/transaction/put.rs
+++ b/src/transaction/put.rs
@@ -5,10 +5,10 @@ use casper_client::cli::CliError;
 
 use super::creation_common::{
     add_bid, delegate, invocable_entity, invocable_entity_alias, package, package_alias,
-    redelegate, session, transfer, undelegate, withdraw_bid, DisplayOrder,
+    redelegate, session, transfer, undelegate, withdraw_bid,
 };
 
-use crate::{command::ClientCommand, common, Success};
+use crate::{command::ClientCommand, Success};
 
 pub struct PutTransaction;
 const ALIAS: &str = "put-txn";
@@ -26,39 +26,37 @@ impl ClientCommand for PutTransaction {
             .about(Self::ABOUT)
             .alias(ALIAS)
             .subcommand_required(true)
-            .subcommand(withdraw_bid::build())
-            .subcommand(add_bid::build())
-            .subcommand(delegate::build())
-            .subcommand(undelegate::build())
-            .subcommand(redelegate::build())
-            .subcommand(invocable_entity::build())
-            .subcommand(invocable_entity_alias::build())
-            .subcommand(package::build())
-            .subcommand(package_alias::build())
-            .subcommand(session::build())
-            .subcommand(transfer::build())
-            .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
-            .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
-            .arg(common::node_address::arg(
-                DisplayOrder::NodeAddress as usize,
-            ))
+            .subcommand(withdraw_bid::put_transaction_build())
+            .subcommand(add_bid::put_transaction_build())
+            .subcommand(delegate::put_transaction_build())
+            .subcommand(undelegate::put_transaction_build())
+            .subcommand(redelegate::put_transaction_build())
+            .subcommand(invocable_entity::put_transaction_build())
+            .subcommand(invocable_entity_alias::put_transaction_build())
+            .subcommand(package::put_transaction_build())
+            .subcommand(package_alias::put_transaction_build())
+            .subcommand(session::put_transaction_build())
+            .subcommand(transfer::put_transaction_build())
             .display_order(display_order)
     }
 
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
-        let rpc_id = common::rpc_id::get(matches);
-        let node_address = common::node_address::get(matches);
-        let verbosity_level = common::verbose::get(matches);
         if let Some((subcommand, matches)) = matches.subcommand() {
-            let (transaction_builder_params, transaction_str_params) = match subcommand {
-                add_bid::NAME => add_bid::run(matches)?,
-                withdraw_bid::NAME => withdraw_bid::run(matches)?,
-                delegate::NAME => delegate::run(matches)?,
-                undelegate::NAME => undelegate::run(matches)?,
-                redelegate::NAME => redelegate::run(matches)?,
-                invocable_entity::NAME => invocable_entity::run(matches)?,
-                invocable_entity_alias::NAME => invocable_entity_alias::run(matches)?,
-                package::NAME => package::run(matches)?,
+            let (
+                transaction_builder_params,
+                transaction_str_params,
+                node_address,
+                rpc_id,
+                verbosity_level,
+            ) = match subcommand {
+                add_bid::NAME => add_bid::put_transaction_run(matches)?,
+                withdraw_bid::NAME => withdraw_bid::put_transaction_run(matches)?,
+                delegate::NAME => delegate::put_transaction_run(matches)?,
+                undelegate::NAME => undelegate::put_transaction_run(matches)?,
+                redelegate::NAME => redelegate::put_transaction_run(matches)?,
+                invocable_entity::NAME => invocable_entity::put_transaction_run(matches)?,
+                invocable_entity_alias::NAME => invocable_entity_alias::put_transaction_run(matches)?,
+                package::NAME => package::put_transaction_run(matches)?,
                 package_alias::NAME => package_alias::run(matches)?,
                 session::NAME => session::run(matches)?,
                 transfer::NAME => transfer::run(matches)?,

--- a/src/transaction/sign.rs
+++ b/src/transaction/sign.rs
@@ -23,7 +23,7 @@ impl ClientCommand for SignTransaction {
                 common::secret_key::arg(creation_common::DisplayOrder::SecretKey as usize, "")
                     .required(true),
             )
-            .arg(creation_common::transaction_path::arg(true))
+            .arg(creation_common::transaction_path::arg())
             .arg(creation_common::output::arg())
             .arg(common::force::arg(
                 creation_common::DisplayOrder::Force as usize,

--- a/src/transaction/sign.rs
+++ b/src/transaction/sign.rs
@@ -23,7 +23,7 @@ impl ClientCommand for SignTransaction {
                 common::secret_key::arg(creation_common::DisplayOrder::SecretKey as usize, "")
                     .required(true),
             )
-            .arg(creation_common::transaction_path::arg())
+            .arg(creation_common::transaction_path::arg(true))
             .arg(creation_common::output::arg())
             .arg(common::force::arg(
                 creation_common::DisplayOrder::Force as usize,
@@ -32,11 +32,11 @@ impl ClientCommand for SignTransaction {
     }
 
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
-        let input_path = creation_common::transaction_path::get(matches);
+        let input_path = creation_common::transaction_path::get(matches).unwrap_or_default();
         let secret_key = common::secret_key::get(matches).unwrap_or_default();
         let maybe_output_path = creation_common::output::get(matches).unwrap_or_default();
         let force = common::force::get(matches);
-        let output = if maybe_output_path.is_empty(){
+        let output = if maybe_output_path.is_empty() {
             String::new()
         } else {
             format!(
@@ -53,8 +53,6 @@ impl ClientCommand for SignTransaction {
         };
 
         casper_client::cli::sign_transaction_file(input_path, secret_key, maybe_output_path, force)
-            .map(|_| {
-                Success::Output(output)
-            })
+            .map(|_| Success::Output(output))
     }
 }


### PR DESCRIPTION
# Summary of work done:
- Add a `put-transaction` command to enable sending transactions to casper networks via JSON-RPC

# Areas of note for reviewers:
- the location of arguments in the command. As the top level command needs to have several args that it previously did not, there might be some desire to migrate the `node-address` and `rpc-id` args to the inner subcommands and optionally pass it back to the main command.
- I had to silence some clippy warnings in v1_6_0.rs and v1_5_0.rs as some warnings arose related to unused result exports. I'm under the impression these are still worth exporting until the client can handle multiple different node versions. 

### Sample command input/output:


```
casper-client put-txn --node-address http://localhost:11101/rpc session --transaction-path ~/casper/casper-checkpoint/checkpoint_contract/contract/target/wasm32-unknown-unknown/release/contract.wasm --session-entry-point test --chain-name casper-net-1 --secret-key ~/casper/casper-node/utils/nctl/assets/net-1/users/user-1/secret_key.pem --payment-amount 10

```

Associated output:

```
{
  "jsonrpc": "2.0",
  "id": 2007083436180091612,
  "result": {
    "api_version": "1.0.0",
    "transaction_hash": {
      "Version1": "16148cbb254970a85e6df685d721606709167a602915e7604d7f92682f2683fb"
    }
  }
}

```

# Associated ticket(s):
- #127 
- [Put Transaction command ](https://app.zenhub.com/workspaces/casperlabs-sdks-64b185bf2cb87924e7759d9d/issues/gh/casper-ecosystem/casper-client-rs/127)