### PR TITLE
Send transaction command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add `sign-transaction` command for signing transactions to support node 2.0.0.
 * Add `put-transaction` command for sending transactions to support node 2.0.0.
 * Add support for new node RPC method `state_get_entity`, used in the binary's new `get-entity` subcommand.
+* Add `send-transaciton` command for sending previously made and signed transaction files to the network.
 
 ### Changed
 * Update to match change to node RPC `info_get_deploy`.

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -73,7 +73,10 @@ pub use json_args::{
 pub use payment_str_params::PaymentStrParams;
 pub use session_str_params::SessionStrParams;
 pub use simple_args::help as simple_args_help;
-pub use transaction::{make_transaction, put_transaction, sign_transaction_file};
+pub use transaction::{
+    make_transaction, put_transaction, send_transaction_file, sign_transaction_file,
+    speculative_send_transaction_file,
+};
 pub use transaction_builder_params::TransactionBuilderParams;
 pub use transaction_str_params::TransactionStrParams;
 /// Retrieves a [`Deploy`] from the network.

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -8,7 +8,7 @@ use rand::Rng;
 use casper_types::{
     account::AccountHash, bytesrepr::Bytes, crypto, AddressableEntityHash, AsymmetricType,
     BlockHash, DeployHash, Digest, ExecutableDeployItem, HashAddr, Key, NamedArg, PricingMode,
-    PublicKey, RuntimeArgs, SecretKey, TimeDiff, Timestamp, TransactionV1, UIntParseError, URef,
+    PublicKey, RuntimeArgs, SecretKey, TimeDiff, Timestamp, UIntParseError, URef,
     U512,
 };
 
@@ -416,25 +416,6 @@ pub fn transaction_module_bytes(session_path: &str) -> Result<Bytes, CliError> {
     Ok(Bytes::from(module_bytes))
 }
 
-/// Parse a transaction file into a `TransactionV1` to be sent to the network
-pub fn transaction_from_file(transaction_path: &str) -> Result<TransactionV1, CliError> {
-    let transaction_bytes = fs::read(transaction_path).map_err(|error| crate::Error::IoError {
-        context: format!("unable to read transaction file at '{}'", transaction_path),
-        error,
-    })?;
-    let transaction_str =
-        std::str::from_utf8(&transaction_bytes).map_err(|error| crate::Error::Utf8Error {
-            context: "transaction_from_file",
-            error,
-        })?;
-    let transaction: TransactionV1 = serde_json::from_str(transaction_str).map_err(|error| {
-        crate::Error::FailedToDecodeFromJson {
-            context: "transaction",
-            error,
-        }
-    })?;
-    Ok(transaction)
-}
 /// Parses a URef from a formatted string for the purposes of creating transactions.
 pub fn uref(uref_str: &str) -> Result<URef, CliError> {
     match URef::from_formatted_str(uref_str) {

--- a/lib/cli/transaction.rs
+++ b/lib/cli/transaction.rs
@@ -1,5 +1,6 @@
 use crate::rpcs::v2_0_0::speculative_exec_transaction::SpeculativeExecTxnResult;
 use crate::{
+    read_transaction_file,
     cli::{parse, CliError, TransactionBuilderParams, TransactionStrParams},
     put_transaction as put_transaction_rpc_handler,
     rpcs::results::PutTransactionResult,
@@ -136,7 +137,7 @@ pub async fn send_transaction_file(
 ) -> Result<SuccessResponse<PutTransactionResult>, CliError> {
     let rpc_id = parse::rpc_id(rpc_id_str);
     let verbosity_level = parse::verbosity(verbosity_level);
-    let transaction = parse::transaction_from_file(input_path)?;
+    let transaction = read_transaction_file(input_path)?;
     put_transaction_rpc_handler(
         rpc_id,
         node_address,
@@ -163,7 +164,7 @@ pub async fn speculative_send_transaction_file(
 ) -> Result<SuccessResponse<SpeculativeExecTxnResult>, CliError> {
     let rpc_id = parse::rpc_id(rpc_id_str);
     let verbosity_level = parse::verbosity(verbosity_level);
-    let transaction = parse::transaction_from_file(input_path).unwrap();
+    let transaction = read_transaction_file(input_path).unwrap();
     let maybe_speculative_exec_height_identifier =
         parse::block_identifier(maybe_speculative_exec_height_identifier)?;
     speculative_exec_txn(

--- a/lib/cli/transaction.rs
+++ b/lib/cli/transaction.rs
@@ -1,8 +1,9 @@
+use crate::rpcs::v2_0_0::speculative_exec_transaction::SpeculativeExecTxnResult;
 use crate::{
     cli::{parse, CliError, TransactionBuilderParams, TransactionStrParams},
     put_transaction as put_transaction_rpc_handler,
     rpcs::results::PutTransactionResult,
-    SuccessResponse,
+    speculative_exec_txn, SuccessResponse,
 };
 use casper_types::{
     InitiatorAddr, Transaction, TransactionSessionKind, TransactionV1, TransactionV1Builder,
@@ -115,6 +116,60 @@ pub async fn put_transaction(
     put_transaction_rpc_handler(
         rpc_id,
         node_address,
+        verbosity_level,
+        Transaction::V1(transaction),
+    )
+    .await
+    .map_err(CliError::from)
+}
+///
+/// Reads a previously-saved [`TransactionV1`] from a file and sends it to the network for execution.
+///
+/// `rpc_id_str` is the RPC ID to use for this request. node_address is the address of the node to send the request to.
+/// verbosity_level is the level of verbosity to use when outputting the response.
+/// the input path is the path to the file containing the transaction to send.
+pub async fn send_transaction_file(
+    rpc_id_str: &str,
+    node_address: &str,
+    verbosity_level: u64,
+    input_path: &str,
+) -> Result<SuccessResponse<PutTransactionResult>, CliError> {
+    let rpc_id = parse::rpc_id(rpc_id_str);
+    let verbosity_level = parse::verbosity(verbosity_level);
+    let transaction = parse::transaction_from_file(input_path)?;
+    put_transaction_rpc_handler(
+        rpc_id,
+        node_address,
+        verbosity_level,
+        Transaction::V1(transaction),
+    )
+    .await
+    .map_err(CliError::from)
+}
+
+///
+/// Reads a previously-saved [`TransactionV1`] from a file and sends it to the network for execution.
+///
+/// `rpc_id_str` is the RPC ID to use for this request. node_address is the address of the node to send the request to.
+/// verbosity_level is the level of verbosity to use when outputting the response.
+/// `maybe_speculative_exec_height_identifier` is the block identifier to use for this request.
+///  the input path is the path to the file containing the transaction to send.
+pub async fn speculative_send_transaction_file(
+    rpc_id_str: &str,
+    node_address: &str,
+    verbosity_level: u64,
+    input_path: &str,
+    maybe_speculative_exec_height_identifier: &str,
+) -> Result<SuccessResponse<SpeculativeExecTxnResult>, CliError> {
+    let rpc_id = parse::rpc_id(rpc_id_str);
+    let verbosity_level = parse::verbosity(verbosity_level);
+    let transaction = parse::transaction_from_file(input_path).unwrap();
+    let maybe_speculative_exec_height_identifier =
+        parse::block_identifier(maybe_speculative_exec_height_identifier)?;
+    speculative_exec_txn(
+        rpc_id,
+        node_address,
+        maybe_speculative_exec_height_identifier,
         verbosity_level,
         Transaction::V1(transaction),
     )

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -69,7 +69,7 @@ use rpcs::{
         GetEraInfoResult, GetEraSummaryResult, GetNodeStatusResult, GetPeersResult,
         GetStateRootHashResult, GetValidatorChangesResult, ListRpcsResult, PutDeployResult,
         PutTransactionResult, QueryBalanceResult, QueryGlobalStateResult, SpeculativeExecResult,
-        SpeculativeExecTxnResult,
+        SpeculativeExecTxnResult, GetAddressableEntityResult,
     },
     v2_0_0::{
         get_account::{AccountIdentifier, GetAccountParams, GET_ACCOUNT_METHOD},

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -69,6 +69,7 @@ use rpcs::{
         GetEraInfoResult, GetEraSummaryResult, GetNodeStatusResult, GetPeersResult,
         GetStateRootHashResult, GetValidatorChangesResult, ListRpcsResult, PutDeployResult,
         PutTransactionResult, QueryBalanceResult, QueryGlobalStateResult, SpeculativeExecResult,
+        SpeculativeExecTxnResult,
     },
     v2_0_0::{
         get_account::{AccountIdentifier, GetAccountParams, GET_ACCOUNT_METHOD},
@@ -91,6 +92,7 @@ use rpcs::{
         query_balance::{PurseIdentifier, QueryBalanceParams, QUERY_BALANCE_METHOD},
         query_global_state::{QueryGlobalStateParams, QUERY_GLOBAL_STATE_METHOD},
         speculative_exec::{SpeculativeExecParams, SPECULATIVE_EXEC_METHOD},
+        speculative_exec_transaction::{SpeculativeExecTxnParams, SPECULATIVE_EXEC_TXN_METHOD},
     },
     DictionaryItemIdentifier,
 };
@@ -154,6 +156,26 @@ pub async fn speculative_exec(
         .send_request(
             SPECULATIVE_EXEC_METHOD,
             Some(SpeculativeExecParams::new(block_identifier, deploy)),
+        )
+        .await
+}
+
+/// Puts a [`Transction`] to a single node for speculative execution on that node only.
+///
+/// Sends a JSON-RPC speculative_exec request to the specified node.
+///
+/// For details of the parameters, see [the module docs](crate#common-parameters).
+pub async fn speculative_exec_txn(
+    rpc_id: JsonRpcId,
+    node_address: &str,
+    block_identifier: Option<BlockIdentifier>,
+    verbosity: Verbosity,
+    transaction: Transaction,
+) -> Result<SuccessResponse<SpeculativeExecTxnResult>, Error> {
+    JsonRpcCall::new(rpc_id, node_address, verbosity)
+        .send_request(
+            SPECULATIVE_EXEC_TXN_METHOD,
+            Some(SpeculativeExecTxnParams::new(block_identifier, transaction)),
         )
         .await
 }

--- a/lib/rpcs/results.rs
+++ b/lib/rpcs/results.rs
@@ -29,3 +29,4 @@ pub use super::v2_0_0::put_transaction::PutTransactionResult;
 pub use super::v2_0_0::query_balance::QueryBalanceResult;
 pub use super::v2_0_0::query_global_state::QueryGlobalStateResult;
 pub use super::v2_0_0::speculative_exec::SpeculativeExecResult;
+pub use super::v2_0_0::speculative_exec_transaction::SpeculativeExecTxnResult;

--- a/lib/rpcs/v2_0_0.rs
+++ b/lib/rpcs/v2_0_0.rs
@@ -3,6 +3,7 @@
 pub(crate) mod get_block;
 pub(crate) mod get_deploy;
 pub(crate) mod put_transaction;
+pub(crate) mod speculative_exec_transaction;
 
 // The following RPCs are all unchanged from v1.6.0, so we just re-export them.
 

--- a/lib/rpcs/v2_0_0/speculative_exec_transaction.rs
+++ b/lib/rpcs/v2_0_0/speculative_exec_transaction.rs
@@ -1,0 +1,44 @@
+use serde::{Deserialize, Serialize};
+
+use casper_types::{
+    contract_messages::Messages, execution::ExecutionResultV2, BlockHash, ProtocolVersion,
+    Transaction,
+};
+
+use crate::rpcs::common::BlockIdentifier;
+
+pub(crate) const SPECULATIVE_EXEC_TXN_METHOD: &str = "speculative_exec_txn";
+
+/// Params for "speculative_exec_txn" RPC request.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct SpeculativeExecTxnParams {
+    /// Block hash on top of which to execute the transaction.
+    pub block_identifier: Option<BlockIdentifier>,
+    /// Transaction to execute.
+    pub transaction: Transaction,
+}
+
+impl SpeculativeExecTxnParams {
+    /// Creates a new `SpeculativeExecTxnParams`.
+    pub fn new(block_identifier: Option<BlockIdentifier>, transaction: Transaction) -> Self {
+        SpeculativeExecTxnParams {
+            block_identifier,
+            transaction,
+        }
+    }
+}
+
+/// Result for "speculative_exec_txn" and "speculative_exec" RPC responses.
+#[derive(PartialEq, Eq, Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct SpeculativeExecTxnResult {
+    /// The RPC API version.
+    pub api_version: ProtocolVersion,
+    /// Hash of the block on top of which the transaction was executed.
+    pub block_hash: BlockHash,
+    /// Result of the execution.
+    pub execution_result: ExecutionResultV2,
+    /// Messages emitted during execution.
+    pub messages: Messages,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ use keygen::Keygen;
 use list_rpcs::ListRpcs;
 use query_balance::QueryBalance;
 use query_global_state::QueryGlobalState;
-use transaction::{MakeTransaction, PutTransaction, SignTransaction};
+use transaction::{MakeTransaction, PutTransaction, SignTransaction, SendTransaction};
 
 const APP_NAME: &str = "Casper client";
 
@@ -77,6 +77,7 @@ enum DisplayOrder {
     SignDeploy,
     SignTransaction,
     SendDeploy,
+    SendTransaction,
     Transfer,
     MakeTransfer,
     GetDeploy,
@@ -117,6 +118,7 @@ fn cli() -> Command {
             DisplayOrder::SignTransaction as usize,
         ))
         .subcommand(SendDeploy::build(DisplayOrder::SendDeploy as usize))
+        .subcommand(SendTransaction::build(DisplayOrder::SendTransaction as usize))
         .subcommand(Transfer::build(DisplayOrder::Transfer as usize))
         .subcommand(MakeTransfer::build(DisplayOrder::MakeTransfer as usize))
         .subcommand(GetBalance::build(DisplayOrder::GetBalance as usize).hide(true))
@@ -171,6 +173,7 @@ async fn main() {
         SignDeploy::NAME => SignDeploy::run(matches).await,
         SignTransaction::NAME => SignTransaction::run(matches).await,
         SendDeploy::NAME => SendDeploy::run(matches).await,
+        SendTransaction::NAME => SendTransaction::run(matches).await,
         Transfer::NAME => Transfer::run(matches).await,
         MakeTransfer::NAME => MakeTransfer::run(matches).await,
         GetDeploy::NAME => GetDeploy::run(matches).await,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -7,3 +7,4 @@ mod sign;
 pub use make::MakeTransaction;
 pub use put::PutTransaction;
 pub use sign::SignTransaction;
+pub use send::SendTransaction;

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,6 +1,7 @@
 mod creation_common;
 mod make;
 mod put;
+mod send;
 mod sign;
 
 pub use make::MakeTransaction;

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -21,7 +21,8 @@ pub(super) enum DisplayOrder {
     ShowJsonArgExamples,
     NodeAddress,
     SecretKey,
-    Input,
+    SpeculativeExec,
+    TransactionPath,
     Output,
     Force,
     Target,
@@ -533,7 +534,7 @@ pub(super) mod transaction_path {
             .short(ARG_SHORT)
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
-            .display_order(DisplayOrder::Input as usize)
+            .display_order(DisplayOrder::TransactionPath as usize)
     }
 
     pub fn get(matches: &ArgMatches) -> Option<&str> {
@@ -1457,6 +1458,41 @@ pub(super) mod target {
             .get_one::<String>(ARG_NAME)
             .map(String::as_str)
             .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME))
+    }
+}
+
+/// Handles providing the arg for speculative execution.
+pub(super) mod speculative_exec {
+    use super::*;
+
+    const ARG_NAME: &str = "speculative-exec";
+    const ARG_VALUE_NAME: &str = "HEX STRING OR INTEGER";
+    const ARG_HELP: &str =
+        "If the receiving node supports this, execution of the deploy will only be attempted on \
+        that single node. Full validation of the deploy is not performed, and successful execution \
+        at the given global state is no guarantee that the deploy will be able to be successfully \
+        executed if put to the network, nor should execution costs be expected to be identical. \
+        Optionally provide the hex-encoded block hash or height of the block to specify the global \
+        state on which to execute";
+    const DEFAULT_MISSING_VALUE: &str = "";
+
+    pub(in crate::transaction) fn arg() -> Arg {
+        Arg::new(ARG_NAME)
+            .long(ARG_NAME)
+            .required(false)
+            .value_name(ARG_VALUE_NAME)
+            .num_args(0..=1)
+            .default_missing_value(DEFAULT_MISSING_VALUE)
+            .help(ARG_HELP)
+            .display_order(DisplayOrder::SpeculativeExec as usize)
+    }
+
+    // get: The command line posibilities are encoded by a combination of option and &str
+    // None represents no --speculative-exec argument at all
+    // Some("") represents a --speculative-exec with no/empty argument
+    // Some(block_identifier) represents "--speculative-exec block_identifier"
+    pub(in crate::transaction) fn get(matches: &ArgMatches) -> Option<&str> {
+        matches.get_one::<String>(ARG_NAME).map(String::as_str)
     }
 }
 

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -403,6 +403,7 @@ pub(super) fn apply_common_creation_options(
     subcommand: Command,
     require_secret_key: bool,
     include_node_address: bool,
+    include_transaction_args: bool,
 ) -> Command {
     let mut subcommand = subcommand
         .next_line_help(true)
@@ -433,6 +434,12 @@ pub(super) fn apply_common_creation_options(
             signed, for example by running the `sign-transaction` subcommand.",
         )
     };
+
+    if include_transaction_args {
+        subcommand = subcommand
+            .arg(arg_simple::session::arg())
+            .arg(args_json::session::arg())
+    }
 
     subcommand = subcommand
         .arg(secret_key_arg)
@@ -916,9 +923,11 @@ pub(super) mod add_bid {
 
     pub const NAME: &str = "add-bid";
 
+    const ACCEPT_SESSION_ARGS: bool = false;
+
     const ABOUT: &str = "Creates a new add-bid transaction";
     pub fn build() -> Command {
-        apply_common_creation_options(add_args(Command::new(NAME).about(ABOUT)), false, false)
+        apply_common_creation_options(add_args(Command::new(NAME).about(ABOUT)), false, false, ACCEPT_SESSION_ARGS)
     }
 
     pub fn put_transaction_build() -> Command {
@@ -943,7 +952,7 @@ pub(super) mod add_bid {
             amount,
         };
 
-        let transaction_str_params = build_transaction_str_params(matches);
+        let transaction_str_params = build_transaction_str_params(matches, ACCEPT_SESSION_ARGS);
 
         Ok((params, transaction_str_params))
     }
@@ -962,9 +971,11 @@ pub(super) mod withdraw_bid {
 
     pub const NAME: &str = "withdraw-bid";
 
+    const ACCEPT_SESSION_ARGS: bool = false;
+
     const ABOUT: &str = "Creates a new withdraw-bid transaction";
     pub fn build() -> Command {
-        apply_common_creation_options(add_args(Command::new(NAME).about(ABOUT)), false, false)
+        apply_common_creation_options(add_args(Command::new(NAME).about(ABOUT)), false, false, ACCEPT_SESSION_ARGS)
     }
 
     pub fn put_transaction_build() -> Command {
@@ -981,7 +992,7 @@ pub(super) mod withdraw_bid {
         let amount = transaction_amount::parse_transaction_amount(amount_str)?;
 
         let params = TransactionBuilderParams::WithdrawBid { public_key, amount };
-        let transaction_str_params = build_transaction_str_params(matches);
+        let transaction_str_params = build_transaction_str_params(matches, ACCEPT_SESSION_ARGS);
 
         Ok((params, transaction_str_params))
     }
@@ -998,10 +1009,12 @@ pub(super) mod delegate {
 
     pub const NAME: &str = "delegate";
 
+    const ACCEPT_SESSION_ARGS: bool = false;
+
     const ABOUT: &str = "Creates a new delegate transaction";
 
     pub fn build() -> Command {
-        apply_common_creation_options(add_args(Command::new(NAME).about(ABOUT)), false, false)
+        apply_common_creation_options(add_args(Command::new(NAME).about(ABOUT)), false, false, ACCEPT_SESSION_ARGS)
     }
 
     pub fn put_transaction_build() -> Command {
@@ -1025,7 +1038,7 @@ pub(super) mod delegate {
             validator,
             amount,
         };
-        let transaction_str_params = build_transaction_str_params(matches);
+        let transaction_str_params = build_transaction_str_params(matches, ACCEPT_SESSION_ARGS);
 
         Ok((params, transaction_str_params))
     }
@@ -1044,10 +1057,12 @@ pub(super) mod undelegate {
 
     pub const NAME: &str = "undelegate";
 
+    const ACCEPT_SESSION_ARGS: bool = false;
+
     const ABOUT: &str = "Creates a new delegate transaction";
 
     pub fn build() -> Command {
-        apply_common_creation_options(add_args(Command::new(NAME).about(ABOUT)), false, false)
+        apply_common_creation_options(add_args(Command::new(NAME).about(ABOUT)), false, false, ACCEPT_SESSION_ARGS)
     }
 
     pub fn put_transaction_build() -> Command {
@@ -1071,7 +1086,7 @@ pub(super) mod undelegate {
             validator,
             amount,
         };
-        let transaction_str_params = build_transaction_str_params(matches);
+        let transaction_str_params = build_transaction_str_params(matches, ACCEPT_SESSION_ARGS);
         Ok((params, transaction_str_params))
     }
 
@@ -1088,10 +1103,11 @@ pub(super) mod redelegate {
 
     pub const NAME: &str = "redelegate";
 
+    const ACCEPT_SESSION_ARGS: bool = false;
     const ABOUT: &str = "Creates a new delegate transaction";
 
     pub fn build() -> Command {
-        apply_common_creation_options(add_args(Command::new(NAME).about(ABOUT)), false, false)
+        apply_common_creation_options(add_args(Command::new(NAME).about(ABOUT)), false, false, ACCEPT_SESSION_ARGS)
     }
 
     pub fn put_transaction_build() -> Command {
@@ -1119,7 +1135,7 @@ pub(super) mod redelegate {
             new_validator,
             amount,
         };
-        let transaction_str_params = build_transaction_str_params(matches);
+        let transaction_str_params = build_transaction_str_params(matches, ACCEPT_SESSION_ARGS);
         Ok((params, transaction_str_params))
     }
 
@@ -1137,6 +1153,7 @@ pub(super) mod invocable_entity {
     use casper_client::cli::{CliError, TransactionBuilderParams};
 
     pub const NAME: &str = "invocable-entity";
+    const ACCEPT_SESSION_ARGS: bool = true;
 
     const ABOUT: &str = "Creates a new transaction targeting an invocable entity";
 
@@ -1163,7 +1180,7 @@ pub(super) mod invocable_entity {
             entity_addr,
             entry_point,
         };
-        let transaction_str_params = build_transaction_str_params(matches);
+        let transaction_str_params = build_transaction_str_params(matches, ACCEPT_SESSION_ARGS);
         Ok((params, transaction_str_params))
     }
 
@@ -1178,6 +1195,8 @@ pub(super) mod invocable_entity_alias {
     use casper_client::cli::{CliError, TransactionBuilderParams};
 
     pub const NAME: &str = "invocable-entity-alias";
+
+    const ACCEPT_SESSION_ARGS: bool = true;
 
     const ABOUT: &str = "Creates a new transaction targeting an invocable entity via its alias";
 
@@ -1202,7 +1221,7 @@ pub(super) mod invocable_entity_alias {
             entity_alias,
             entry_point,
         };
-        let transaction_str_params = build_transaction_str_params(matches);
+        let transaction_str_params = build_transaction_str_params(matches, ACCEPT_SESSION_ARGS);
         Ok((params, transaction_str_params))
     }
 
@@ -1217,6 +1236,8 @@ pub(super) mod package {
     use casper_client::cli::{CliError, TransactionBuilderParams};
 
     pub const NAME: &str = "package";
+
+    const ACCEPT_SESSION_ARGS: bool = true;
 
     const ABOUT: &str = "Creates a new transaction targeting a package";
 
@@ -1245,7 +1266,7 @@ pub(super) mod package {
             maybe_entity_version,
             entry_point,
         };
-        let transaction_str_params = build_transaction_str_params(matches);
+        let transaction_str_params = build_transaction_str_params(matches, ACCEPT_SESSION_ARGS);
         Ok((params, transaction_str_params))
     }
 
@@ -1261,6 +1282,8 @@ pub(super) mod package_alias {
     use casper_client::cli::{CliError, TransactionBuilderParams};
 
     pub const NAME: &str = "package-alias";
+
+    const ACCEPT_SESSION_ARGS: bool = true;
 
     const ABOUT: &str = "Creates a new transaction targeting package via its alias";
 
@@ -1289,7 +1312,7 @@ pub(super) mod package_alias {
             maybe_entity_version,
             entry_point,
         };
-        let transaction_str_params = build_transaction_str_params(matches);
+        let transaction_str_params = build_transaction_str_params(matches, ACCEPT_SESSION_ARGS);
         Ok((params, transaction_str_params))
     }
 
@@ -1306,6 +1329,8 @@ pub(super) mod session {
     use casper_client::cli::{CliError, TransactionBuilderParams};
 
     pub const NAME: &str = "session";
+
+    const ACCEPT_SESSION_ARGS: bool = true;
 
     const ABOUT: &str = "Creates a new transaction for running session logic";
 
@@ -1341,7 +1366,7 @@ pub(super) mod session {
             transaction_bytes,
             entry_point,
         };
-        let transaction_str_params = build_transaction_str_params(matches);
+        let transaction_str_params = build_transaction_str_params(matches, ACCEPT_SESSION_ARGS);
         Ok((params, transaction_str_params))
     }
 
@@ -1359,10 +1384,12 @@ pub(super) mod transfer {
 
     pub const NAME: &str = "transfer";
 
+    const ACCEPT_SESSION_ARGS: bool = false;
+
     const ABOUT: &str = "Creates a new native transfer transaction";
 
     pub fn build() -> Command {
-        apply_common_creation_options(add_args(Command::new(NAME).about(ABOUT)), false, false)
+        apply_common_creation_options(add_args(Command::new(NAME).about(ABOUT)), false, false, ACCEPT_SESSION_ARGS)
     }
 
     pub fn put_transaction_build() -> Command {
@@ -1396,7 +1423,7 @@ pub(super) mod transfer {
             maybe_to,
             maybe_id,
         };
-        let transaction_str_params = build_transaction_str_params(matches);
+        let transaction_str_params = build_transaction_str_params(matches, ACCEPT_SESSION_ARGS);
 
         Ok((params, transaction_str_params))
     }
@@ -1561,10 +1588,10 @@ pub(super) mod destination_account {
 }
 pub(super) fn apply_common_args(subcommand: Command) -> Command {
     let subcommand = apply_common_args_options(subcommand);
-    apply_common_creation_options(subcommand, false, false)
+    apply_common_creation_options(subcommand, false, false, true)
 }
 
-pub(super) fn build_transaction_str_params(matches: &ArgMatches) -> TransactionStrParams {
+pub(super) fn build_transaction_str_params(matches: &ArgMatches, obtain_session_args: bool) -> TransactionStrParams {
     let secret_key = common::secret_key::get(matches).unwrap_or_default();
     let timestamp = timestamp::get(matches);
     let ttl = ttl::get(matches);
@@ -1572,23 +1599,40 @@ pub(super) fn build_transaction_str_params(matches: &ArgMatches) -> TransactionS
     let maybe_pricing_mode = pricing_mode::get(matches);
     let payment_amount = payment_amount::get(matches);
 
-    let session_args_simple = arg_simple::session::get(matches);
-    let session_args_json = args_json::session::get(matches);
-
     let maybe_output_path = output::get(matches).unwrap_or_default();
     let initiator_addr = initiator_address::get(matches);
-    TransactionStrParams {
-        secret_key,
-        timestamp,
-        ttl,
-        chain_name,
-        initiator_addr,
-        session_args_simple,
-        session_args_json,
-        maybe_pricing_mode,
-        output_path: maybe_output_path,
-        payment_amount,
+
+    if obtain_session_args {
+        let session_args_simple = arg_simple::session::get(matches);
+        let session_args_json = args_json::session::get(matches);
+        TransactionStrParams {
+            secret_key,
+            timestamp,
+            ttl,
+            chain_name,
+            initiator_addr,
+            session_args_simple,
+            session_args_json,
+            maybe_pricing_mode,
+            output_path: maybe_output_path,
+            payment_amount,
+        }
+    } else {
+
+        TransactionStrParams {
+            secret_key,
+            timestamp,
+            ttl,
+            chain_name,
+            initiator_addr,
+            maybe_pricing_mode,
+            output_path: maybe_output_path,
+            payment_amount,
+            ..Default::default()
+        }
     }
+
+
 }
 pub(super) fn add_rpc_args(subcommand: Command) -> Command {
     subcommand

--- a/src/transaction/send.rs
+++ b/src/transaction/send.rs
@@ -1,0 +1,65 @@
+use clap::{ArgMatches, Command};
+
+use async_trait::async_trait;
+
+use casper_client::cli::CliError;
+
+use super::creation_common::{self, DisplayOrder};
+use crate::{command::ClientCommand, common, Success};
+
+pub struct SendDeploy;
+
+#[async_trait]
+impl ClientCommand for SendDeploy {
+    const NAME: &'static str = "send-deploy";
+    const ABOUT: &'static str =
+        "Read a previously-saved deploy from a file and send it to the network for execution";
+
+    fn build(display_order: usize) -> Command {
+        Command::new(Self::NAME)
+            .about(Self::ABOUT)
+            .display_order(display_order)
+            .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
+            .arg(common::node_address::arg(
+                DisplayOrder::NodeAddress as usize,
+            ))
+            .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
+            .arg(creation_common::speculative_exec::arg())
+            .arg(creation_common::transaction_path::arg())
+    }
+
+    async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
+        let maybe_speculative_exec = creation_common::speculative_exec::get(matches);
+        let maybe_rpc_id = common::rpc_id::get(matches);
+        let node_address = common::node_address::get(matches);
+        let verbosity_level = common::verbose::get(matches);
+        let input_path = creation_common::transaction_path::get(matches).unwrap_or_default();
+        if input_path.is_empty() {
+            return Err(CliError::InvalidArgument {
+                context: "send-deploy",
+                error: "Transaction path cannot be empty".to_string(),
+            });
+        }
+
+        if let Some(speculative_exec_height_identifier) = maybe_speculative_exec {
+            casper_client::cli::speculative_send_transaction_file(
+                maybe_rpc_id,
+                node_address,
+                verbosity_level,
+                input_path,
+                speculative_exec_height_identifier,
+            )
+            .await
+            .map(Success::from)
+        } else {
+            casper_client::cli::send_transaction_file(
+                maybe_rpc_id,
+                node_address,
+                verbosity_level,
+                input_path,
+            )
+            .await
+            .map(Success::from)
+        }
+    }
+}

--- a/src/transaction/send.rs
+++ b/src/transaction/send.rs
@@ -7,11 +7,13 @@ use casper_client::cli::CliError;
 use super::creation_common::{self, DisplayOrder};
 use crate::{command::ClientCommand, common, Success};
 
-pub struct SendDeploy;
+pub struct SendTransaction;
+
+const ALIAS: &str = "send-txn";
 
 #[async_trait]
-impl ClientCommand for SendDeploy {
-    const NAME: &'static str = "send-deploy";
+impl ClientCommand for SendTransaction {
+    const NAME: &'static str = "send-transaction";
     const ABOUT: &'static str =
         "Read a previously-saved deploy from a file and send it to the network for execution";
 
@@ -19,6 +21,7 @@ impl ClientCommand for SendDeploy {
         Command::new(Self::NAME)
             .about(Self::ABOUT)
             .display_order(display_order)
+            .alias(ALIAS)
             .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
             .arg(common::node_address::arg(
                 DisplayOrder::NodeAddress as usize,


### PR DESCRIPTION
# Summary of work done:
- Add a `send-transaction` command to enable sending transactions to casper networks via JSON-RPC

# Areas of note for reviewers:
- This PR deals with adding the `send-transaction` command, and fixing a runtime error that resulted from the structuring of clap commands and the generic parsing of arguments that were, in some cases, not bound to the command. This should be fixed and will prevent users from overriding runtime args generated for some transactions by the transaction builder.

### Sample command input/output used when testing after development:


```
casper-client send-txn --transaction-path ~/casper/keys/client-dev/output_transactions/add_bid/add-bid-transaction -n http://localhost:11101/rpc


```

Associated output:

```
{
  "jsonrpc": "2.0",
  "id": -339623264891894255,
  "result": {
    "api_version": "2.0.0",
    "transaction_hash": {
      "Version1": "83efb7a61934987b788626f011e09e0394fe2910cef28b2b85aa7af2edd0fbf5"
    }
  }
}

```

# Associated ticket(s):
- #122 
- [Client send-transaction command and backend fixes](https://app.zenhub.com/workspaces/casperlabs-sdks-64b185bf2cb87924e7759d9d/issues/gh/casper-ecosystem/casper-client-rs/122)