### PR TITLE
Fix `get-node-status` to work with latest node changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.  The format
 
 ### Changed
 * Update to match change to node RPC `info_get_deploy`.
+* Update to match change to node RPC `info_get_status` used in the binary's `get-node-status` subcommand.
 
 ### Removed
 * Remove following public types which are now available in `casper_types`:

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -64,12 +64,12 @@ pub use output_kind::OutputKind;
 use rpcs::{
     common::{BlockIdentifier, GlobalStateIdentifier},
     results::{
-        GetAccountResult, GetAuctionInfoResult, GetBalanceResult, GetBlockResult,
-        GetBlockTransfersResult, GetChainspecResult, GetDeployResult, GetDictionaryItemResult,
-        GetEraInfoResult, GetEraSummaryResult, GetNodeStatusResult, GetPeersResult,
-        GetStateRootHashResult, GetValidatorChangesResult, ListRpcsResult, PutDeployResult,
-        PutTransactionResult, QueryBalanceResult, QueryGlobalStateResult, SpeculativeExecResult,
-        SpeculativeExecTxnResult, GetAddressableEntityResult,
+        GetAccountResult, GetAddressableEntityResult, GetAuctionInfoResult, GetBalanceResult,
+        GetBlockResult, GetBlockTransfersResult, GetChainspecResult, GetDeployResult,
+        GetDictionaryItemResult, GetEraInfoResult, GetEraSummaryResult, GetNodeStatusResult,
+        GetPeersResult, GetStateRootHashResult, GetValidatorChangesResult, ListRpcsResult,
+        PutDeployResult, PutTransactionResult, QueryBalanceResult, QueryGlobalStateResult,
+        SpeculativeExecResult, SpeculativeExecTxnResult,
     },
     v2_0_0::{
         get_account::{AccountIdentifier, GetAccountParams, GET_ACCOUNT_METHOD},

--- a/lib/rpcs/results.rs
+++ b/lib/rpcs/results.rs
@@ -12,8 +12,7 @@ pub use super::v2_0_0::get_entity::GetAddressableEntityResult;
 pub use super::v2_0_0::get_era_info::{EraSummary, GetEraInfoResult};
 pub use super::v2_0_0::get_era_summary::GetEraSummaryResult;
 pub use super::v2_0_0::get_node_status::{
-    ActivationPoint, AvailableBlockRange, BlockSyncStatus, BlockSynchronizerStatus,
-    GetNodeStatusResult, MinimalBlockInfo, NextUpgrade, ReactorState,
+    AvailableBlockRange, GetNodeStatusResult, MinimalBlockInfo, NextUpgrade,
 };
 pub use super::v2_0_0::get_peers::{GetPeersResult, PeerEntry};
 pub use super::v2_0_0::get_state_root_hash::GetStateRootHashResult;

--- a/lib/rpcs/v1_6_0.rs
+++ b/lib/rpcs/v1_6_0.rs
@@ -29,6 +29,7 @@ pub(crate) mod get_era_summary {
 
 pub(crate) mod get_node_status {
     pub(crate) use crate::rpcs::v1_5_0::get_node_status::GET_NODE_STATUS_METHOD;
+    #[allow(unused_imports)]
     pub use crate::rpcs::v1_5_0::get_node_status::{
         ActivationPoint, AvailableBlockRange, BlockSyncStatus, BlockSynchronizerStatus,
         GetNodeStatusResult, MinimalBlockInfo, NextUpgrade, ReactorState,

--- a/lib/rpcs/v2_0_0.rs
+++ b/lib/rpcs/v2_0_0.rs
@@ -3,6 +3,7 @@
 pub(crate) mod get_block;
 pub(crate) mod get_deploy;
 pub(crate) mod get_entity;
+pub(crate) mod get_node_status;
 pub(crate) mod put_transaction;
 pub(crate) mod speculative_exec_transaction;
 
@@ -55,14 +56,6 @@ pub(crate) mod get_era_summary {
     pub use crate::rpcs::v1_6_0::get_era_summary::GetEraSummaryResult;
     pub(crate) use crate::rpcs::v1_6_0::get_era_summary::{
         GetEraSummaryParams, GET_ERA_SUMMARY_METHOD,
-    };
-}
-
-pub(crate) mod get_node_status {
-    pub(crate) use crate::rpcs::v1_6_0::get_node_status::GET_NODE_STATUS_METHOD;
-    pub use crate::rpcs::v1_6_0::get_node_status::{
-        ActivationPoint, AvailableBlockRange, BlockSyncStatus, BlockSynchronizerStatus,
-        GetNodeStatusResult, MinimalBlockInfo, NextUpgrade, ReactorState,
     };
 }
 

--- a/lib/rpcs/v2_0_0/get_node_status.rs
+++ b/lib/rpcs/v2_0_0/get_node_status.rs
@@ -1,0 +1,48 @@
+use serde::{Deserialize, Serialize};
+
+use casper_types::{
+    BlockHash, BlockSynchronizerStatus, Digest, Peers, ProtocolVersion, PublicKey, TimeDiff,
+    Timestamp,
+};
+
+pub(crate) use crate::rpcs::v1_6_0::get_node_status::GET_NODE_STATUS_METHOD;
+
+pub use crate::rpcs::v1_6_0::get_node_status::{
+    AvailableBlockRange, MinimalBlockInfo, NextUpgrade,
+};
+
+/// Result for "info_get_status" RPC response.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct GetNodeStatusResult {
+    /// The RPC API version.
+    pub api_version: ProtocolVersion,
+    /// The node ID and network address of each connected peer.
+    pub peers: Peers,
+    /// The compiled node version.
+    pub build_version: String,
+    /// The chainspec name.
+    pub chainspec_name: String,
+    /// The state root hash of the lowest block in the available block range.
+    pub starting_state_root_hash: Digest,
+    /// The minimal info of the last block from the linear chain.
+    pub last_added_block_info: Option<MinimalBlockInfo>,
+    /// Our public signing key.
+    pub our_public_signing_key: Option<PublicKey>,
+    /// The next round length if this node is a validator.
+    pub round_length: Option<TimeDiff>,
+    /// Information about the next scheduled upgrade.
+    pub next_upgrade: Option<NextUpgrade>,
+    /// Time that passed since the node has started.
+    pub uptime: TimeDiff,
+    /// The name of the current state of node reactor.
+    pub reactor_state: String,
+    /// Timestamp of the last recorded progress in the reactor.
+    pub last_progress: Timestamp,
+    /// The available block range in storage.
+    pub available_block_range: AvailableBlockRange,
+    /// The status of the block synchronizer builders.
+    pub block_sync: BlockSynchronizerStatus,
+    /// The hash of the latest switch block.
+    pub latest_switch_block_hash: Option<BlockHash>,
+}


### PR DESCRIPTION
Align `get-node-status` command with the latest changes in the node.