### PR TITLE
Update dictionary item request with entity variant

### DIFF
--- a/lib/cli/dictionary_item_str_params.rs
+++ b/lib/cli/dictionary_item_str_params.rs
@@ -29,6 +29,16 @@ pub enum DictionaryItemStrParams<'a> {
         /// The key within the dictionary under which the item is held.
         dictionary_item_key: &'a str,
     },
+    /// A dictionary item identified via a [`AddressableEntity`]'s named keys.
+    EntityNamedKey {
+        /// The [`HashAddr`] as a formatted string, identifying the entity whose named keys
+        /// contains `dictionary_name`.
+        entity_addr: &'a str,
+        /// The named key under which the dictionary seed `URef` is stored.
+        dictionary_name: &'a str,
+        /// The key within the dictionary under which the item is held.
+        dictionary_item_key: &'a str,
+    },
     /// A dictionary item identified via its seed [`URef`].
     URef {
         /// The dictionary's seed `URef` as a formatted string.
@@ -87,6 +97,27 @@ impl<'a> TryFrom<DictionaryItemStrParams<'a>> for DictionaryItemIdentifier {
                 })?;
                 Ok(DictionaryItemIdentifier::new_from_contract_info(
                     hash_addr,
+                    dictionary_name.to_string(),
+                    dictionary_item_key.to_string(),
+                ))
+            }
+            DictionaryItemStrParams::EntityNamedKey {
+                entity_addr,
+                dictionary_name,
+                dictionary_item_key,
+            } => {
+                let key = Key::from_formatted_str(entity_addr).map_err(|error| {
+                    CliError::FailedToParseKey {
+                        context: "dictionary item entity named key",
+                        error,
+                    }
+                })?;
+                let entity_addr = key.as_entity_addr().ok_or(CliError::InvalidArgument {
+                    context: "dictionary item entity named key",
+                    error: "not a entity hash-addr".to_string(),
+                })?;
+                Ok(DictionaryItemIdentifier::new_from_entity_info(
+                    entity_addr,
                     dictionary_name.to_string(),
                     dictionary_item_key.to_string(),
                 ))

--- a/lib/cli/dictionary_item_str_params.rs
+++ b/lib/cli/dictionary_item_str_params.rs
@@ -114,7 +114,7 @@ impl<'a> TryFrom<DictionaryItemStrParams<'a>> for DictionaryItemIdentifier {
                 })?;
                 let entity_addr = key.as_entity_addr().ok_or(CliError::InvalidArgument {
                     context: "dictionary item entity named key",
-                    error: "not a entity hash-addr".to_string(),
+                    error: "not a entity-addr".to_string(),
                 })?;
                 Ok(DictionaryItemIdentifier::new_from_entity_info(
                     entity_addr,

--- a/lib/cli/dictionary_item_str_params.rs
+++ b/lib/cli/dictionary_item_str_params.rs
@@ -31,7 +31,7 @@ pub enum DictionaryItemStrParams<'a> {
     },
     /// A dictionary item identified via a [`AddressableEntity`]'s named keys.
     EntityNamedKey {
-        /// The [`HashAddr`] as a formatted string, identifying the entity whose named keys
+        /// The [`EntityAddr`] as a formatted string, identifying the entity whose named keys
         /// contains `dictionary_name`.
         entity_addr: &'a str,
         /// The named key under which the dictionary seed `URef` is stored.

--- a/lib/rpcs/v1_4_5/get_dictionary_item.rs
+++ b/lib/rpcs/v1_4_5/get_dictionary_item.rs
@@ -2,11 +2,7 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(doc)]
 use casper_types::{account::Account, Contract};
-use casper_types::{
-    account::AccountHash, Digest, HashAddr, Key, ProtocolVersion, StoredValue, URef,
-};
-
-use crate::Error;
+use casper_types::{Digest, ProtocolVersion, StoredValue, URef};
 
 pub(crate) const GET_DICTIONARY_ITEM_METHOD: &str = "state_get_dictionary_item";
 
@@ -47,73 +43,11 @@ pub enum DictionaryItemIdentifier {
     Dictionary(String),
 }
 
-impl DictionaryItemIdentifier {
-    /// Returns a new `DictionaryItemIdentifier::AccountNamedKey` variant.
-    pub fn new_from_account_info(
-        account_hash: AccountHash,
-        dictionary_name: String,
-        dictionary_item_key: String,
-    ) -> Self {
-        DictionaryItemIdentifier::AccountNamedKey {
-            key: Key::Account(account_hash).to_formatted_string(),
-            dictionary_name,
-            dictionary_item_key,
-        }
-    }
-
-    /// Returns a new `DictionaryItemIdentifier::ContractNamedKey` variant.
-    pub fn new_from_contract_info(
-        contract_addr: HashAddr,
-        dictionary_name: String,
-        dictionary_item_key: String,
-    ) -> Self {
-        DictionaryItemIdentifier::ContractNamedKey {
-            key: Key::Hash(contract_addr).to_formatted_string(),
-            dictionary_name,
-            dictionary_item_key,
-        }
-    }
-
-    /// Returns a new `DictionaryItemIdentifier::URef` variant.
-    pub fn new_from_seed_uref(seed_uref: URef, dictionary_item_key: String) -> Self {
-        DictionaryItemIdentifier::URef {
-            seed_uref,
-            dictionary_item_key,
-        }
-    }
-
-    /// Returns a new `DictionaryItemIdentifier::Dictionary` variant.
-    pub fn new_from_item_key(item_key: Key) -> Result<Self, Error> {
-        if item_key.as_dictionary().is_some() {
-            Ok(DictionaryItemIdentifier::Dictionary(
-                item_key.to_formatted_string(),
-            ))
-        } else {
-            Err(Error::InvalidKeyVariant {
-                expected_variant: "Key::Dictionary".to_string(),
-                actual: item_key,
-            })
-        }
-    }
-}
-
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct GetDictionaryItemParams {
     state_root_hash: Digest,
     dictionary_identifier: DictionaryItemIdentifier,
-}
-
-impl GetDictionaryItemParams {
-    pub(crate) fn new(
-        state_root_hash: Digest,
-        dictionary_identifier: DictionaryItemIdentifier,
-    ) -> Self {
-        GetDictionaryItemParams {
-            state_root_hash,
-            dictionary_identifier,
-        }
-    }
 }
 
 /// The `result` field of a successful JSON-RPC response to a `state_get_dictionary_item` request.

--- a/lib/rpcs/v1_5_0.rs
+++ b/lib/rpcs/v1_5_0.rs
@@ -45,12 +45,8 @@ pub(crate) mod get_block_transfers {
 }
 
 pub(crate) mod get_dictionary_item {
-    pub use crate::rpcs::v1_4_5::get_dictionary_item::{
-        DictionaryItemIdentifier, GetDictionaryItemResult,
-    };
-    pub(crate) use crate::rpcs::v1_4_5::get_dictionary_item::{
-        GetDictionaryItemParams, GET_DICTIONARY_ITEM_METHOD,
-    };
+    pub use crate::rpcs::v1_4_5::get_dictionary_item::GetDictionaryItemResult;
+    pub(crate) use crate::rpcs::v1_4_5::get_dictionary_item::GET_DICTIONARY_ITEM_METHOD;
 }
 
 pub(crate) mod get_era_info {

--- a/lib/rpcs/v1_6_0.rs
+++ b/lib/rpcs/v1_6_0.rs
@@ -76,12 +76,8 @@ pub(crate) mod get_block_transfers {
 }
 
 pub(crate) mod get_dictionary_item {
-    pub use crate::rpcs::v1_5_0::get_dictionary_item::{
-        DictionaryItemIdentifier, GetDictionaryItemResult,
-    };
-    pub(crate) use crate::rpcs::v1_5_0::get_dictionary_item::{
-        GetDictionaryItemParams, GET_DICTIONARY_ITEM_METHOD,
-    };
+    pub use crate::rpcs::v1_5_0::get_dictionary_item::GetDictionaryItemResult;
+    pub(crate) use crate::rpcs::v1_5_0::get_dictionary_item::GET_DICTIONARY_ITEM_METHOD;
 }
 
 pub(crate) mod get_era_info {

--- a/lib/rpcs/v2_0_0.rs
+++ b/lib/rpcs/v2_0_0.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod get_block;
 pub(crate) mod get_deploy;
+pub(crate) mod get_dictionary_item;
 pub(crate) mod get_entity;
 pub(crate) mod get_node_status;
 pub(crate) mod put_transaction;
@@ -36,15 +37,6 @@ pub(crate) mod get_block_transfers {
 pub(crate) mod get_chainspec {
     pub use crate::rpcs::v1_6_0::get_chainspec::GetChainspecResult;
     pub(crate) use crate::rpcs::v1_6_0::get_chainspec::GET_CHAINSPEC_METHOD;
-}
-
-pub(crate) mod get_dictionary_item {
-    pub use crate::rpcs::v1_6_0::get_dictionary_item::{
-        DictionaryItemIdentifier, GetDictionaryItemResult,
-    };
-    pub(crate) use crate::rpcs::v1_6_0::get_dictionary_item::{
-        GetDictionaryItemParams, GET_DICTIONARY_ITEM_METHOD,
-    };
 }
 
 pub(crate) mod get_era_info {

--- a/lib/rpcs/v2_0_0/get_dictionary_item.rs
+++ b/lib/rpcs/v2_0_0/get_dictionary_item.rs
@@ -1,0 +1,136 @@
+use serde::{Deserialize, Serialize};
+
+use casper_types::{account::AccountHash, Digest, EntityAddr, HashAddr, Key, URef};
+
+pub use crate::rpcs::v1_6_0::get_dictionary_item::GetDictionaryItemResult;
+pub(crate) use crate::rpcs::v1_6_0::get_dictionary_item::GET_DICTIONARY_ITEM_METHOD;
+use crate::Error;
+
+/// The identifier for a dictionary item.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub enum DictionaryItemIdentifier {
+    /// A dictionary item identified via an [`Account`]'s named keys.
+    AccountNamedKey {
+        /// The [`Key::Account`] as a formatted string, identifying the account whose named keys
+        /// contains `dictionary_name`.
+        key: String,
+        /// The named key under which the dictionary seed `URef` is stored.
+        dictionary_name: String,
+        /// The key within the dictionary under which the item is held.
+        dictionary_item_key: String,
+    },
+    /// A dictionary item identified via a [`Contract`]'s named keys.
+    ContractNamedKey {
+        /// The [`Key::Hash`] as a formatted string, identifying the contract whose named keys
+        /// contains `dictionary_name`.
+        key: String,
+        /// The named key under which the dictionary seed `URef` is stored.
+        dictionary_name: String,
+        /// The key within the dictionary under which the item is held.
+        dictionary_item_key: String,
+    },
+    /// A dictionary item identified via a [`AddressableEntity`]'s named keys.
+    EntityNamedKey {
+        /// The [`Key::Hash`] as a formatted string, identifying the entity whose named keys
+        /// contains `dictionary_name`.
+        key: String,
+        /// The named key under which the dictionary seed `URef` is stored.
+        dictionary_name: String,
+        /// The key within the dictionary under which the item is held.
+        dictionary_item_key: String,
+    },
+    /// A dictionary item identified via its seed [`URef`].
+    URef {
+        /// The dictionary's seed `URef`.
+        seed_uref: URef,
+        /// The key within the dictionary under which the item is held.
+        dictionary_item_key: String,
+    },
+    /// A dictionary item identified via its unique address derived from the dictionary's seed
+    /// `URef` and the item's key within the dictionary.  The key must be a `Key::Dictionary`
+    /// variant, as a formatted string.
+    Dictionary(String),
+}
+
+impl DictionaryItemIdentifier {
+    /// Returns a new `DictionaryItemIdentifier::AccountNamedKey` variant.
+    pub fn new_from_account_info(
+        account_hash: AccountHash,
+        dictionary_name: String,
+        dictionary_item_key: String,
+    ) -> Self {
+        DictionaryItemIdentifier::AccountNamedKey {
+            key: Key::Account(account_hash).to_formatted_string(),
+            dictionary_name,
+            dictionary_item_key,
+        }
+    }
+
+    /// Returns a new `DictionaryItemIdentifier::ContractNamedKey` variant.
+    pub fn new_from_contract_info(
+        contract_addr: HashAddr,
+        dictionary_name: String,
+        dictionary_item_key: String,
+    ) -> Self {
+        DictionaryItemIdentifier::ContractNamedKey {
+            key: Key::Hash(contract_addr).to_formatted_string(),
+            dictionary_name,
+            dictionary_item_key,
+        }
+    }
+
+    /// Returns a new `DictionaryItemIdentifier::EntityNamedKey` variant.
+    pub fn new_from_entity_info(
+        entity_addr: EntityAddr,
+        dictionary_name: String,
+        dictionary_item_key: String,
+    ) -> Self {
+        DictionaryItemIdentifier::EntityNamedKey {
+            key: Key::AddressableEntity(entity_addr).to_formatted_string(),
+            dictionary_name,
+            dictionary_item_key,
+        }
+    }
+
+    /// Returns a new `DictionaryItemIdentifier::URef` variant.
+    pub fn new_from_seed_uref(seed_uref: URef, dictionary_item_key: String) -> Self {
+        DictionaryItemIdentifier::URef {
+            seed_uref,
+            dictionary_item_key,
+        }
+    }
+
+    /// Returns a new `DictionaryItemIdentifier::Dictionary` variant.
+    pub fn new_from_item_key(item_key: Key) -> Result<Self, Error> {
+        if item_key.as_dictionary().is_some() {
+            Ok(DictionaryItemIdentifier::Dictionary(
+                item_key.to_formatted_string(),
+            ))
+        } else {
+            Err(Error::InvalidKeyVariant {
+                expected_variant: "Key::Dictionary".to_string(),
+                actual: item_key,
+            })
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct GetDictionaryItemParams {
+    state_root_hash: Digest,
+    dictionary_identifier: DictionaryItemIdentifier,
+}
+
+impl GetDictionaryItemParams {
+    pub(crate) fn new(
+        state_root_hash: Digest,
+        dictionary_identifier: DictionaryItemIdentifier,
+    ) -> Self {
+        GetDictionaryItemParams {
+            state_root_hash,
+            dictionary_identifier,
+        }
+    }
+}

--- a/lib/rpcs/v2_0_0/get_dictionary_item.rs
+++ b/lib/rpcs/v2_0_0/get_dictionary_item.rs
@@ -32,8 +32,8 @@ pub enum DictionaryItemIdentifier {
     },
     /// A dictionary item identified via a [`AddressableEntity`]'s named keys.
     EntityNamedKey {
-        /// The [`Key::Hash`] as a formatted string, identifying the entity whose named keys
-        /// contains `dictionary_name`.
+        /// The [`Key::AddressableEntity`] as a formatted string, identifying the entity whose
+        /// named keys contain `dictionary_name`.
         key: String,
         /// The named key under which the dictionary seed `URef` is stored.
         dictionary_name: String,

--- a/src/get_dictionary_item.rs
+++ b/src/get_dictionary_item.rs
@@ -111,9 +111,9 @@ mod entity_addr {
     use super::*;
 
     pub(crate) const ARG_NAME: &str = "entity-addr";
-    const ARG_HELP: &str =
-        "This must be a properly formatted entity address. The format for contract address is \
-        \"addressable-entity-contract-<HEX STRING>\".";
+    const ARG_HELP: &str = "This must be a properly formatted entity address. The format is \
+        \"entity-contract-<HEX STRING>\" for contracts and \"entity-account-<HEX STRING>\" for \
+        accounts.";
 
     pub(super) fn arg() -> Arg {
         key::arg(ARG_NAME, ARG_HELP, DisplayOrder::EntityAddr as usize)

--- a/src/get_dictionary_item.rs
+++ b/src/get_dictionary_item.rs
@@ -18,6 +18,7 @@ enum DisplayOrder {
     StateRootHash,
     AccountHash,
     ContractHash,
+    EntityAddr,
     DictionaryName,
     DictionaryItemKey,
     DictionarySeedURef,
@@ -99,6 +100,23 @@ mod contract_hash {
 
     pub(super) fn arg() -> Arg {
         key::arg(ARG_NAME, ARG_HELP, DisplayOrder::ContractHash as usize)
+    }
+
+    pub(super) fn get(matches: &ArgMatches) -> Result<String, CliError> {
+        key::get(ARG_NAME, matches)
+    }
+}
+
+mod entity_addr {
+    use super::*;
+
+    pub(crate) const ARG_NAME: &str = "entity-addr";
+    const ARG_HELP: &str =
+        "This must be a properly formatted entity address. The format for contract address is \
+        \"addressable-entity-contract-<HEX STRING>\".";
+
+    pub(super) fn arg() -> Arg {
+        key::arg(ARG_NAME, ARG_HELP, DisplayOrder::EntityAddr as usize)
     }
 
     pub(super) fn get(matches: &ArgMatches) -> Result<String, CliError> {
@@ -227,6 +245,7 @@ impl ClientCommand for GetDictionaryItem {
             ))
             .arg(account_hash::arg())
             .arg(contract_hash::arg())
+            .arg(entity_addr::arg())
             .arg(seed_uref::arg())
             .arg(dictionary_address::arg())
             .arg(dictionary_name::arg())
@@ -235,6 +254,7 @@ impl ClientCommand for GetDictionaryItem {
                 ArgGroup::new("dictionary-identifier")
                     .arg(account_hash::ARG_NAME)
                     .arg(contract_hash::ARG_NAME)
+                    .arg(entity_addr::ARG_NAME)
                     .arg(seed_uref::ARG_NAME)
                     .arg(dictionary_address::ARG_NAME)
                     .required(true),
@@ -250,6 +270,7 @@ impl ClientCommand for GetDictionaryItem {
 
         let account_hash = account_hash::get(matches)?;
         let contract_hash = contract_hash::get(matches)?;
+        let entity_addr = entity_addr::get(matches)?;
         let dictionary_name = dictionary_name::get(matches);
         let seed_uref = seed_uref::get(matches);
         let dictionary_key = dictionary_address::get(matches);
@@ -265,6 +286,12 @@ impl ClientCommand for GetDictionaryItem {
         } else if !contract_hash.is_empty() && !dictionary_name.is_empty() {
             DictionaryItemStrParams::ContractNamedKey {
                 hash_addr: &contract_hash,
+                dictionary_name,
+                dictionary_item_key,
+            }
+        } else if !entity_addr.is_empty() && !dictionary_name.is_empty() {
+            DictionaryItemStrParams::EntityNamedKey {
+                entity_addr: &entity_addr,
                 dictionary_name,
                 dictionary_item_key,
             }


### PR DESCRIPTION
Adds a new version of the dictionary item request with a new variant for entities to match parity with what we already support for legacy accounts/contracts.

Depends on:
- https://github.com/casper-network/casper-node/pull/4628
- https://github.com/casper-network/casper-sidecar/pull/267