### PR TITLE
Use EntityAddr instead of AddressableEntityHash

### DIFF
--- a/lib/cli/transaction_builder_params.rs
+++ b/lib/cli/transaction_builder_params.rs
@@ -1,8 +1,5 @@
-use casper_types::account::AccountHash;
 use casper_types::bytesrepr::Bytes;
-use casper_types::{
-    AddressableEntityHash, EntityAddr, PackageAddr, PackageHash, PublicKey, URef, U512,
-};
+use casper_types::{AddressableEntityHash, PackageHash, PublicKey, URef, U512};
 
 /// An enum representing the parameters needed to construct a transaction builder
 /// for the commands concerning the creation of a transaction

--- a/lib/rpcs/v2_0_0/get_entity.rs
+++ b/lib/rpcs/v2_0_0/get_entity.rs
@@ -1,6 +1,6 @@
 use casper_types::{
     account::{Account, AccountHash},
-    AddressableEntity, AddressableEntityHash, ProtocolVersion, PublicKey,
+    AddressableEntity, EntityAddr, ProtocolVersion, PublicKey,
 };
 use serde::{Deserialize, Serialize};
 
@@ -16,10 +16,8 @@ pub enum EntityIdentifier {
     PublicKey(PublicKey),
     /// The account hash of an account.
     AccountHash(AccountHash),
-    /// The hash of an addressable entity representing an account.
-    EntityHashForAccount(AddressableEntityHash),
-    /// The hash of an addressable entity representing a contract.
-    EntityHashForContract(AddressableEntityHash),
+    /// The address of an addressable entity.
+    EntityAddr(EntityAddr),
 }
 
 /// An addressable entity or a legacy account.

--- a/src/common.rs
+++ b/src/common.rs
@@ -358,7 +358,7 @@ pub(super) mod entity_identifier {
     const ARG_HELP: &str =
         "The identifier for an addressable entity or an account. This can be an entity hash, a public \
         key or an account hash. To provide an entity hash, it must be formatted as \
-        \"contract-addressable-entity-<HEX STRING>\" or \"account-addressable-entity-<HEX STRING>\". \
+        \"entity-contract-<HEX STRING>\" or \"entity-account-<HEX STRING>\". \
         To provide a public key, it must be a properly formatted public key. The public key may be \
         read in from a file, in which case enter the path to the file as the --account-identifier \
         argument. The file should be one of the two public key files generated via the `keygen` \


### PR DESCRIPTION
The initial code was written before `EntityAddr` was introduced, so we didn't use it, but now that `EntityAddr` exists, it should be used here instead for consistency with other code (like for example `GetDictionaryItem`).

Depends on https://github.com/casper-network/casper-sidecar/pull/275 and https://github.com/casper-network/casper-node/pull/4653.