### PR TITLE
Fix casper types dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ doc = false
 [dependencies]
 async-trait = "0.1.59"
 base16 = "0.2.1"
-casper-types = { version = "3.0.0", features = ["std"] }
+casper-types = { version = "5.0.0", features = ["std"] }
 clap = { version = "4", features = ["cargo", "deprecated", "wrap_help"] }
 clap_complete = "4"
 hex-buffer-serde = "0.4.0"


### PR DESCRIPTION
The version has been bumped in the node, which leads to build failures, because now casper client ends up trying to get it from crates.io. This aligns the version with current casper-node: https://github.com/casper-network/casper-node/blob/feat-2.0/types/Cargo.toml#L3.