### PR TITLE
Fix info get deploy

### DIFF
--- a/lib/cli/transaction_builder_params.rs
+++ b/lib/cli/transaction_builder_params.rs
@@ -1,7 +1,6 @@
-use casper_types::account::AccountHash;
 use casper_types::bytesrepr::Bytes;
 use casper_types::{
-    AddressableEntityHash, EntityAddr, PackageAddr, PackageHash, PublicKey, URef, U512,
+    AddressableEntityHash, PackageHash, PublicKey, URef, U512,
 };
 
 /// An enum representing the parameters needed to construct a transaction builder

--- a/lib/cli/transaction_builder_params.rs
+++ b/lib/cli/transaction_builder_params.rs
@@ -1,7 +1,5 @@
 use casper_types::bytesrepr::Bytes;
-use casper_types::{
-    AddressableEntityHash, PackageHash, PublicKey, URef, U512,
-};
+use casper_types::{AddressableEntityHash, PackageHash, PublicKey, URef, U512};
 
 /// An enum representing the parameters needed to construct a transaction builder
 /// for the commands concerning the creation of a transaction

--- a/lib/rpcs/results.rs
+++ b/lib/rpcs/results.rs
@@ -6,7 +6,7 @@ pub use super::v2_0_0::get_balance::GetBalanceResult;
 pub use super::v2_0_0::get_block::GetBlockResult;
 pub use super::v2_0_0::get_block_transfers::GetBlockTransfersResult;
 pub use super::v2_0_0::get_chainspec::GetChainspecResult;
-pub use super::v2_0_0::get_deploy::{DeployExecutionInfo, GetDeployResult};
+pub use super::v2_0_0::get_deploy::{ExecutionInfo, GetDeployResult};
 pub use super::v2_0_0::get_dictionary_item::GetDictionaryItemResult;
 pub use super::v2_0_0::get_entity::GetAddressableEntityResult;
 pub use super::v2_0_0::get_era_info::{EraSummary, GetEraInfoResult};

--- a/lib/rpcs/v2_0_0/get_deploy.rs
+++ b/lib/rpcs/v2_0_0/get_deploy.rs
@@ -8,7 +8,7 @@ pub(crate) use crate::rpcs::v1_4_5::get_deploy::{GetDeployParams, GET_DEPLOY_MET
 /// if known.
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
-pub struct DeployExecutionInfo {
+pub struct ExecutionInfo {
     /// Hash of the block that included the deploy.
     pub block_hash: BlockHash,
     /// Height of block that included the deploy.
@@ -27,5 +27,5 @@ pub struct GetDeployResult {
     pub deploy: Deploy,
     /// Execution info, if available.
     #[serde(skip_serializing_if = "Option::is_none", flatten)]
-    pub execution_info: Option<DeployExecutionInfo>,
+    pub execution_info: Option<ExecutionInfo>,
 }

--- a/lib/rpcs/v2_0_0/get_entity.rs
+++ b/lib/rpcs/v2_0_0/get_entity.rs
@@ -1,6 +1,6 @@
 use casper_types::{
     account::{Account, AccountHash},
-    AddressableEntity, AddressableEntityHash, ProtocolVersion, PublicKey,
+    AddressableEntity, EntityAddr, ProtocolVersion, PublicKey,
 };
 use serde::{Deserialize, Serialize};
 
@@ -16,10 +16,8 @@ pub enum EntityIdentifier {
     PublicKey(PublicKey),
     /// The account hash of an account.
     AccountHash(AccountHash),
-    /// The hash of an addressable entity representing an account.
-    EntityHashForAccount(AddressableEntityHash),
-    /// The hash of an addressable entity representing a contract.
-    EntityHashForContract(AddressableEntityHash),
+    /// The address of an addressable entity.
+    EntityAddr(EntityAddr),
 }
 
 /// An addressable entity or a legacy account.

--- a/src/common.rs
+++ b/src/common.rs
@@ -358,7 +358,7 @@ pub(super) mod entity_identifier {
     const ARG_HELP: &str =
         "The identifier for an addressable entity or an account. This can be an entity hash, a public \
         key or an account hash. To provide an entity hash, it must be formatted as \
-        \"contract-addressable-entity-<HEX STRING>\" or \"account-addressable-entity-<HEX STRING>\". \
+        \"entity-contract-<HEX STRING>\" or \"entity-account-<HEX STRING>\". \
         To provide a public key, it must be a properly formatted public key. The public key may be \
         read in from a file, in which case enter the path to the file as the --account-identifier \
         argument. The file should be one of the two public key files generated via the `keygen` \

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -1319,8 +1319,6 @@ pub(super) mod redelegate {
 pub(super) mod invocable_entity {
     use super::*;
     use casper_client::cli::{CliError, TransactionBuilderParams};
-    use casper_types::addressable_entity;
-
     pub const NAME: &str = "invocable-entity";
     const ACCEPT_SESSION_ARGS: bool = true;
 


### PR DESCRIPTION
The `ExecutionInfo` type contained in the client was mistakenly named `DeployExecutionInfo` which prevented `info_get_deploy` RPC responses from being properly deserialized by the client. 

This PR rectifies the issue by giving the type the appropriate name, as well as removes some unused imports.