### PR TITLE
Address `dev` branch toolchain issues.

### DIFF
--- a/.github/workflows/ci-casper-client-rs.yml
+++ b/.github/workflows/ci-casper-client-rs.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Toolchain - Stable
         run: |
           rustup update --no-self-update ${{ env.RUST_CHANNEL }}
-          rustup component add --toolchain ${{ env.RUST_CHANNEL }} rustfmt rust-src
+          rustup component add --toolchain ${{ env.RUST_CHANNEL }} rustfmt rust-src clippy
           rustup default ${{ env.RUST_CHANNEL }}
 
       - name: Fmt

--- a/.github/workflows/ci-casper-client-rs.yml
+++ b/.github/workflows/ci-casper-client-rs.yml
@@ -25,15 +25,15 @@ jobs:
 
       - name: Get stable from rust-toolchain.toml
         id: stable-toolchain
-        run: echo "::set-output name=version::$(sed -nr 's/channel\s+=\s+\"(.*)\"/\1/p' rust-toolchain.toml)"
+        run: |
+          VER=$(sed -nr 's/channel\s+=\s+\"(.*)\"/\1/p' rust-toolchain.toml)
+          echo "RUST_CHANNEL=$VER" >> $GITHUB_ENV
 
       - name: Install Toolchain - Stable
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #tag v1.0.7
-        with:
-          profile: minimal
-          toolchain: ${{ steps.stable-toolchain.outputs.version }}
-          components: rustfmt, clippy
-          target: wasm32-unknown-unknown
+        run: |
+          rustup update --no-self-update ${{ env.RUST_CHANNEL }}
+          rustup component add --toolchain ${{ env.RUST_CHANNEL }} rustfmt rust-src
+          rustup default ${{ env.RUST_CHANNEL }}
 
       - name: Fmt
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci-casper-client-rs.yml
+++ b/.github/workflows/ci-casper-client-rs.yml
@@ -22,10 +22,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+
+      - name: Get stable from rust-toolchain.toml
+        id: stable-toolchain
+        run: echo "::set-output name=version::$(sed -nr 's/channel\s+=\s+\"(.*)\"/\1/p' rust-toolchain.toml)"
+
+      - name: Install Toolchain - Stable
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #tag v1.0.7
         with:
-          toolchain: stable
           profile: minimal
+          toolchain: ${{ steps.stable-toolchain.outputs.version }}
           components: rustfmt, clippy
           target: wasm32-unknown-unknown
 
@@ -73,4 +79,5 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
+          target: wasm32-unknown-unknown
           args: --lib --target wasm32-unknown-unknown --no-default-features

--- a/.github/workflows/ci-casper-client-rs.yml
+++ b/.github/workflows/ci-casper-client-rs.yml
@@ -34,7 +34,7 @@ jobs:
           rustup update --no-self-update ${{ env.RUST_CHANNEL }}
           rustup component add --toolchain ${{ env.RUST_CHANNEL }} rustfmt rust-src clippy
           rustup default ${{ env.RUST_CHANNEL }}
-
+          rustup target add wasm32-unknown-unknown
       - name: Fmt
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ readme = "README.md"
 homepage = "https://casperlabs.io"
 repository = "https://github.com/casper-ecosystem/casper-client-rs"
 license = "Apache-2.0"
-build = "build.rs"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ async-trait = { version = "0.1.74", optional = true }
 base16 = "0.2.1"
 casper-hashing = "3.0.0"
 casper-types = { version = "4.0.1", features = ["std"] }
-clap = { version = "=4.4.10", optional = true, features = ["cargo", "deprecated", "wrap_help"] }
-clap_complete = { version = "=4.4.4", optional = true }
+clap = { version = "~4.4", optional = true, features = ["cargo", "deprecated", "wrap_help"] }
+clap_complete = { version = "<4.5.0", optional = true }
 hex-buffer-serde = "0.4.0"
 humantime = "2.1.0"
 itertools = "0.12.0"
@@ -49,8 +49,6 @@ uint = "0.9.5"
 
 [dev-dependencies]
 tempfile = "3.8.1"
-
-[build-dependencies]
 
 [patch.crates-io]
 casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "dev" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 homepage = "https://casperlabs.io"
 repository = "https://github.com/casper-ecosystem/casper-client-rs"
 license = "Apache-2.0"
+build = "build.rs"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -30,8 +31,8 @@ async-trait = { version = "0.1.74", optional = true }
 base16 = "0.2.1"
 casper-hashing = "3.0.0"
 casper-types = { version = "4.0.1", features = ["std"] }
-clap = { version = "4.4.10", optional = true, features = ["cargo", "deprecated", "wrap_help"] }
-clap_complete = { version = "4.4.4", optional = true }
+clap = { version = "=4.4.10", optional = true, features = ["cargo", "deprecated", "wrap_help"] }
+clap_complete = { version = "=4.4.4", optional = true }
 hex-buffer-serde = "0.4.0"
 humantime = "2.1.0"
 itertools = "0.12.0"
@@ -39,7 +40,7 @@ jsonrpc-lite = "0.6.0"
 num-traits = "0.2.15"
 once_cell = "1.18.0"
 rand = "0.8.5"
-reqwest = { version = "0.11.22", features = ["json"] }
+reqwest = { version = "0.12.3", features = ["json"] }
 schemars = "=0.8.5"
 serde = { version = "1.0.193", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.108", features = ["preserve_order"] }
@@ -51,7 +52,6 @@ uint = "0.9.5"
 tempfile = "3.8.1"
 
 [build-dependencies]
-vergen = { version = "7", default-features = false, features = ["git"] }
 
 [patch.crates-io]
 casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "dev" }

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,4 @@
 use std::{
-    env::set_var,
     process::Command
 };
 
@@ -18,5 +17,5 @@ fn main() {
     //Remove the newline character from the short git commit hash
     let git_hash = git_hash_raw.trim_end_matches('\n');
 
-    println!("cargo::rustc-env={}={}", GIT_HASH_ENV_VAR, git_hash);
+    println!("cargo:rustc-env={}={}", GIT_HASH_ENV_VAR, git_hash);
 }

--- a/build.rs
+++ b/build.rs
@@ -18,7 +18,5 @@ fn main() {
     //Remove the newline character from the short git commit hash
     let git_hash = git_hash_raw.trim_end_matches('\n');
 
-    println!("test: {}", git_hash);
-
-    set_var(GIT_HASH_ENV_VAR, git_hash);
+    println!("cargo::rustc-env={}={}", GIT_HASH_ENV_VAR, git_hash);
 }

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,24 @@
-use vergen::{Config, ShaKind};
+use std::{
+    env::set_var,
+    process::Command
+};
 
+const GIT_HASH_ENV_VAR: &str = "GIT_SHA_SHORT";
 fn main() {
-    let mut config = Config::default();
-    *config.git_mut().sha_kind_mut() = ShaKind::Short;
-    let _ = vergen::vergen(config);
+    //Build command to retrieve the short git commit hash
+    let git_process_output = Command::new("git")
+        .arg("rev-parse")
+        .arg("--short")
+        .arg("HEAD")
+        .output()
+        .expect("Failed to retrieve short git commit hash");
+
+    //Parse the raw output into a string, we still need to remove the newline character
+    let git_hash_raw = String::from_utf8(git_process_output.stdout).expect("Failed to convert git hash to string");
+    //Remove the newline character from the short git commit hash
+    let git_hash = git_hash_raw.trim_end_matches('\n');
+
+    println!("test: {}", git_hash);
+
+    set_var(GIT_HASH_ENV_VAR, git_hash);
 }

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
 use std::process::Command;
 
 const GIT_HASH_ENV_VAR: &str = "GIT_SHA_SHORT";
+
 fn main() {
     //Build command to retrieve the short git commit hash
     let git_process_output = Command::new("git")

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,4 @@
-use std::{
-    process::Command
-};
+use std::process::Command;
 
 const GIT_HASH_ENV_VAR: &str = "GIT_SHA_SHORT";
 fn main() {
@@ -13,7 +11,8 @@ fn main() {
         .expect("Failed to retrieve short git commit hash");
 
     //Parse the raw output into a string, we still need to remove the newline character
-    let git_hash_raw = String::from_utf8(git_process_output.stdout).expect("Failed to convert git hash to string");
+    let git_hash_raw =
+        String::from_utf8(git_process_output.stdout).expect("Failed to convert git hash to string");
     //Remove the newline character from the short git commit hash
     let git_hash = git_hash_raw.trim_end_matches('\n');
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.73.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ const APP_NAME: &str = "Casper client";
 
 static VERSION: Lazy<String> =
     Lazy::new(
-        || match option_env!("VERGEN_GIT_SHA_SHORT").map(|sha| sha.to_lowercase()) {
+        || match option_env!("GIT_SHA_SHORT").map(|sha| sha.to_lowercase()) {
             None => crate_version!().to_string(),
             Some(git_sha_short) => {
                 if git_sha_short.to_lowercase() == "unknown" {


### PR DESCRIPTION
# Changes in this PR

1. This PR adds a `rust-toolchain.rs` to the repo, pinning the rust toolchain to the same `dev` in casper-node.

   - To achieve this, the PR pins 2 clap dependencies to versions that compile on the previously mentioned rust-toolchain.

2. Additionally, this PR removes a dependency on `vergen` in the `build.rs` build script.
   - This functionality is maintained by replacing `vergen` with standard library functions to ask Cargo to populate an env var during the build lifecycle that the client reads while constructing its version string.