### PR TITLE
Remove skip_serializing_if attribute to align with the RPC

### DIFF
--- a/lib/rpcs/v2_0_0/get_deploy.rs
+++ b/lib/rpcs/v2_0_0/get_deploy.rs
@@ -26,6 +26,5 @@ pub struct GetDeployResult {
     /// The deploy.
     pub deploy: Deploy,
     /// Execution info, if available.
-    #[serde(skip_serializing_if = "Option::is_none", flatten)]
     pub execution_info: Option<DeployExecutionInfo>,
 }


### PR DESCRIPTION
The attribute was deleted in the RPC recently, and now the client unexpectedly gets a null for a field it expects to be omitted