### PR TITLE
Point back at casper-node feat-2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ tempfile = "3.7.1"
 vergen = { version = "7", default-features = false, features = ["git"] }
 
 [patch.crates-io]
-casper-types = { git = "https://github.com/darthsiroftardis/casper-node.git", branch = "block-restructure" }
+casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
 
 [package.metadata.deb]
 features = ["vendored-openssl"]


### PR DESCRIPTION
There's a compilation error when building against the fork, we should point back at feat-2.0 (which now contains block restructure anyway)