### PR TITLE
Allow users to set the gas price when building deploys

### DIFF
--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -7,6 +7,8 @@ use super::{parse, CliError, DeployStrParams, PaymentStrParams, SessionStrParams
 use crate::rpcs::results::{PutDeployResult, SpeculativeExecResult};
 use crate::{SuccessResponse, MAX_SERIALIZED_SIZE_OF_DEPLOY};
 
+const DEFAULT_GAS_PRICE: u64 = 1;
+
 /// Creates a [`Deploy`] and sends it to the network for execution.
 ///
 /// For details of the parameters, see [the module docs](crate::cli#common-parameters) or the docs
@@ -238,6 +240,7 @@ pub fn with_payment_and_session(
     session_params: SessionStrParams,
     allow_unsigned_deploy: bool,
 ) -> Result<Deploy, CliError> {
+    let gas_price: u64 = deploy_params.gas_price_tolerance.parse::<u64>().unwrap_or(DEFAULT_GAS_PRICE);
     let chain_name = deploy_params.chain_name.to_string();
     let session = parse::session_executable_deploy_item(session_params)?;
     let maybe_secret_key = if allow_unsigned_deploy && deploy_params.secret_key.is_empty() {
@@ -261,6 +264,7 @@ pub fn with_payment_and_session(
     let mut deploy_builder = DeployBuilder::new(chain_name, session)
         .with_payment(payment)
         .with_timestamp(timestamp)
+        .with_gas_price(gas_price)
         .with_ttl(ttl);
 
     if let Some(secret_key) = &maybe_secret_key {
@@ -330,11 +334,13 @@ pub fn new_transfer(
     let timestamp = parse::timestamp(deploy_params.timestamp)?;
     let ttl = parse::ttl(deploy_params.ttl)?;
     let maybe_session_account = parse::session_account(deploy_params.session_account)?;
+    let gas_price: u64 = deploy_params.gas_price_tolerance.parse::<u64>().unwrap_or(DEFAULT_GAS_PRICE);
 
     let mut deploy_builder =
         DeployBuilder::new_transfer(chain_name, amount, source_purse, target, maybe_transfer_id)
             .with_payment(payment)
             .with_timestamp(timestamp)
+            .with_gas_price(gas_price)
             .with_ttl(ttl);
     if let Some(secret_key) = &maybe_secret_key {
         deploy_builder = deploy_builder.with_secret_key(secret_key);

--- a/lib/cli/deploy_str_params.rs
+++ b/lib/cli/deploy_str_params.rs
@@ -29,4 +29,6 @@ pub struct DeployStrParams<'a> {
     /// If `session_account` is empty, the account's public key will be derived from the provided
     /// `secret_key`.  It is an error for both fields to be empty.
     pub session_account: &'a str,
+    /// Gas price for the deploy.
+    pub gas_price_tolerance: &'a str,
 }

--- a/src/deploy/creation_common.rs
+++ b/src/deploy/creation_common.rs
@@ -23,6 +23,7 @@ pub(super) enum DisplayOrder {
     Input,
     Output,
     Force,
+    GasPriceTolerance,
     TransferAmount,
     TransferTargetAccount,
     TransferId,
@@ -423,6 +424,37 @@ pub(super) mod arg_simple {
             .display_order(order)
     }
 }
+
+pub(super) mod gas_price_tolerance {
+    use super::*;
+    pub(crate) const ARG_NAME: &str = "gas-price-tolerance";
+
+    const ARG_VALUE_NAME: &str = common::ARG_INTEGER;
+
+    const ARG_ALIAS: &str = "gas-price";
+    const ARG_SHORT: char = 'g';
+    const ARG_HELP: &str =
+        "The maximum gas price that the user is willing to pay for the transaction";
+
+    pub(crate) fn arg() -> Arg {
+        Arg::new(ARG_NAME)
+            .long(ARG_NAME)
+            .alias(ARG_ALIAS)
+            .short(ARG_SHORT)
+            .required(true)
+            .value_name(ARG_VALUE_NAME)
+            .help(ARG_HELP)
+            .display_order(DisplayOrder::GasPriceTolerance as usize)
+    }
+
+    pub fn get(matches: &ArgMatches) -> &str {
+        matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_default()
+    }
+}
+
 
 /// Handles providing the arg for and retrieval of JSON session and payment args.
 pub(super) mod args_json {

--- a/src/deploy/creation_common.rs
+++ b/src/deploy/creation_common.rs
@@ -23,7 +23,7 @@ pub(super) enum DisplayOrder {
     Input,
     Output,
     Force,
-    GasPriceTolerance,
+    GasPrice,
     TransferAmount,
     TransferTargetAccount,
     TransferId,
@@ -425,13 +425,12 @@ pub(super) mod arg_simple {
     }
 }
 
-pub(super) mod gas_price_tolerance {
+pub(super) mod gas_price {
     use super::*;
-    pub(crate) const ARG_NAME: &str = "gas-price-tolerance";
+    pub(crate) const ARG_NAME: &str = "gas-price";
 
     const ARG_VALUE_NAME: &str = common::ARG_INTEGER;
 
-    const ARG_ALIAS: &str = "gas-price";
     const ARG_SHORT: char = 'g';
     const ARG_HELP: &str =
         "The maximum gas price that the user is willing to pay for the transaction";
@@ -439,12 +438,11 @@ pub(super) mod gas_price_tolerance {
     pub(crate) fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
-            .alias(ARG_ALIAS)
             .short(ARG_SHORT)
             .required(true)
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
-            .display_order(DisplayOrder::GasPriceTolerance as usize)
+            .display_order(DisplayOrder::GasPrice as usize)
     }
 
     pub fn get(matches: &ArgMatches) -> &str {

--- a/src/deploy/make.rs
+++ b/src/deploy/make.rs
@@ -24,6 +24,7 @@ impl ClientCommand for MakeDeploy {
                 creation_common::DisplayOrder::Force as usize,
                 true,
             ))
+            .arg(creation_common::gas_price_tolerance::arg())
             .display_order(display_order);
         let subcommand = creation_common::apply_common_session_options(subcommand);
         let subcommand = creation_common::apply_common_payment_options(subcommand, None);
@@ -33,6 +34,7 @@ impl ClientCommand for MakeDeploy {
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
         creation_common::show_simple_arg_examples_and_exit_if_required(matches);
         creation_common::show_json_args_examples_and_exit_if_required(matches);
+        let gas_price = creation_common::gas_price_tolerance::get(matches);
 
         let secret_key = common::secret_key::get(matches).unwrap_or_default();
         let timestamp = creation_common::timestamp::get(matches);
@@ -55,6 +57,7 @@ impl ClientCommand for MakeDeploy {
                 ttl,
                 chain_name,
                 session_account: &session_account,
+                gas_price_tolerance: gas_price,
             },
             session_str_params,
             payment_str_params,

--- a/src/deploy/make.rs
+++ b/src/deploy/make.rs
@@ -24,7 +24,7 @@ impl ClientCommand for MakeDeploy {
                 creation_common::DisplayOrder::Force as usize,
                 true,
             ))
-            .arg(creation_common::gas_price_tolerance::arg())
+            .arg(creation_common::gas_price::arg())
             .display_order(display_order);
         let subcommand = creation_common::apply_common_session_options(subcommand);
         let subcommand = creation_common::apply_common_payment_options(subcommand, None);
@@ -34,7 +34,7 @@ impl ClientCommand for MakeDeploy {
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
         creation_common::show_simple_arg_examples_and_exit_if_required(matches);
         creation_common::show_json_args_examples_and_exit_if_required(matches);
-        let gas_price = creation_common::gas_price_tolerance::get(matches);
+        let gas_price = creation_common::gas_price::get(matches);
 
         let secret_key = common::secret_key::get(matches).unwrap_or_default();
         let timestamp = creation_common::timestamp::get(matches);

--- a/src/deploy/make_transfer.rs
+++ b/src/deploy/make_transfer.rs
@@ -39,7 +39,7 @@ impl ClientCommand for MakeTransfer {
         creation_common::show_simple_arg_examples_and_exit_if_required(matches);
         creation_common::show_json_args_examples_and_exit_if_required(matches);
 
-        let gas_price = creation_common::gas_price_tolerance::get(matches);
+        let gas_price = creation_common::gas_price::get(matches);
 
         let amount = transfer::amount::get(matches);
         let target_account = transfer::target_account::get(matches);

--- a/src/deploy/make_transfer.rs
+++ b/src/deploy/make_transfer.rs
@@ -39,6 +39,8 @@ impl ClientCommand for MakeTransfer {
         creation_common::show_simple_arg_examples_and_exit_if_required(matches);
         creation_common::show_json_args_examples_and_exit_if_required(matches);
 
+        let gas_price = creation_common::gas_price_tolerance::get(matches);
+
         let amount = transfer::amount::get(matches);
         let target_account = transfer::target_account::get(matches);
         let transfer_id = transfer::transfer_id::get(matches);
@@ -65,6 +67,7 @@ impl ClientCommand for MakeTransfer {
                 ttl,
                 chain_name,
                 session_account: &session_account,
+                gas_price_tolerance: gas_price,
             },
             payment_str_params,
             force,

--- a/src/deploy/put.rs
+++ b/src/deploy/put.rs
@@ -20,7 +20,7 @@ impl ClientCommand for PutDeploy {
             .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
             .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
             .arg(creation_common::speculative_exec::arg())
-            .arg(creation_common::gas_price_tolerance::arg());
+            .arg(creation_common::gas_price::arg());
         let subcommand = creation_common::apply_common_session_options(subcommand);
         let subcommand = creation_common::apply_common_payment_options(subcommand, None);
         creation_common::apply_common_creation_options(subcommand, true, true)
@@ -40,7 +40,7 @@ impl ClientCommand for PutDeploy {
         let ttl = creation_common::ttl::get(matches);
         let chain_name = creation_common::chain_name::get(matches);
         let session_account = creation_common::session_account::get(matches)?;
-        let gas_price = creation_common::gas_price_tolerance::get(matches);
+        let gas_price = creation_common::gas_price::get(matches);
         let session_str_params = creation_common::session_str_params(matches);
         let payment_str_params = creation_common::payment_str_params(matches);
 

--- a/src/deploy/put.rs
+++ b/src/deploy/put.rs
@@ -19,7 +19,8 @@ impl ClientCommand for PutDeploy {
             .display_order(display_order)
             .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
             .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
-            .arg(creation_common::speculative_exec::arg());
+            .arg(creation_common::speculative_exec::arg())
+            .arg(creation_common::gas_price_tolerance::arg());
         let subcommand = creation_common::apply_common_session_options(subcommand);
         let subcommand = creation_common::apply_common_payment_options(subcommand, None);
         creation_common::apply_common_creation_options(subcommand, true, true)
@@ -39,7 +40,7 @@ impl ClientCommand for PutDeploy {
         let ttl = creation_common::ttl::get(matches);
         let chain_name = creation_common::chain_name::get(matches);
         let session_account = creation_common::session_account::get(matches)?;
-
+        let gas_price = creation_common::gas_price_tolerance::get(matches);
         let session_str_params = creation_common::session_str_params(matches);
         let payment_str_params = creation_common::payment_str_params(matches);
 
@@ -55,6 +56,7 @@ impl ClientCommand for PutDeploy {
                     ttl,
                     chain_name,
                     session_account: &session_account,
+                    gas_price_tolerance: gas_price,
                 },
                 session_str_params,
                 payment_str_params,
@@ -72,6 +74,7 @@ impl ClientCommand for PutDeploy {
                     ttl,
                     chain_name,
                     session_account: &session_account,
+                    gas_price_tolerance: gas_price,
                 },
                 session_str_params,
                 payment_str_params,

--- a/src/deploy/transfer.rs
+++ b/src/deploy/transfer.rs
@@ -122,6 +122,8 @@ impl ClientCommand for Transfer {
         creation_common::show_simple_arg_examples_and_exit_if_required(matches);
         creation_common::show_json_args_examples_and_exit_if_required(matches);
 
+        let gas_price = creation_common::gas_price_tolerance::get(matches);
+
         let amount = amount::get(matches);
         let target_account = target_account::get(matches);
         let transfer_id = transfer_id::get(matches);
@@ -154,6 +156,7 @@ impl ClientCommand for Transfer {
                     ttl,
                     chain_name,
                     session_account: &session_account,
+                    gas_price_tolerance: gas_price,
                 },
                 payment_str_params,
             )
@@ -173,6 +176,7 @@ impl ClientCommand for Transfer {
                     ttl,
                     chain_name,
                     session_account: &session_account,
+                    gas_price_tolerance: gas_price,
                 },
                 payment_str_params,
             )

--- a/src/deploy/transfer.rs
+++ b/src/deploy/transfer.rs
@@ -122,7 +122,7 @@ impl ClientCommand for Transfer {
         creation_common::show_simple_arg_examples_and_exit_if_required(matches);
         creation_common::show_json_args_examples_and_exit_if_required(matches);
 
-        let gas_price = creation_common::gas_price_tolerance::get(matches);
+        let gas_price = creation_common::gas_price::get(matches);
 
         let amount = amount::get(matches);
         let target_account = target_account::get(matches);


### PR DESCRIPTION
This PR adds an additional argument to the client that allows users to set the gas price (tolerance) when creating deploys.