### PR TITLE
make gas price flag optional for deploys.

### DIFF
--- a/src/deploy/creation_common.rs
+++ b/src/deploy/creation_common.rs
@@ -439,7 +439,7 @@ pub(super) mod gas_price {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
-            .required(true)
+            .required(false)
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
             .display_order(DisplayOrder::GasPrice as usize)


### PR DESCRIPTION
## Explanation:
This PR allows the gas price argument to be optional for deploys; Defaulting to 1 when the argument is not provided.
The work was done to support this previously but was not reflected as such within clap.

## Example:

### For this command :

```
casper-client make-deploy -o /home/path/to/folder/optional_gas_price.txt --session-path /home/path/to/wasm/contract.wasm --chain-name test --session-account /home/path/to/key/public_key_hex --payment-amount 10
```

### We get this header:

```
"header": {
    "account": "01b65525d3ff42c3ef255f6e09418b14842cf3e266280682285d3c4e50bb1eba14",
    "timestamp": "2024-05-16T17:23:29.750Z",
    "ttl": "30m",
    "gas_price": 1,
    "body_hash": "fae960383d15f04b8cdb44012eb8f72ba627e363aa3decaad58ca820713afcee",
    "dependencies": [],
    "chain_name": "test"
  },
```