### PR TITLE
Fix transfer parsing

### DIFF
--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -240,7 +240,10 @@ pub fn with_payment_and_session(
     session_params: SessionStrParams,
     allow_unsigned_deploy: bool,
 ) -> Result<Deploy, CliError> {
-    let gas_price: u64 = deploy_params.gas_price_tolerance.parse::<u64>().unwrap_or(DEFAULT_GAS_PRICE);
+    let gas_price: u64 = deploy_params
+        .gas_price_tolerance
+        .parse::<u64>()
+        .unwrap_or(DEFAULT_GAS_PRICE);
     let chain_name = deploy_params.chain_name.to_string();
     let session = parse::session_executable_deploy_item(session_params)?;
     let maybe_secret_key = if allow_unsigned_deploy && deploy_params.secret_key.is_empty() {
@@ -334,7 +337,10 @@ pub fn new_transfer(
     let timestamp = parse::timestamp(deploy_params.timestamp)?;
     let ttl = parse::ttl(deploy_params.ttl)?;
     let maybe_session_account = parse::session_account(deploy_params.session_account)?;
-    let gas_price: u64 = deploy_params.gas_price_tolerance.parse::<u64>().unwrap_or(DEFAULT_GAS_PRICE);
+    let gas_price: u64 = deploy_params
+        .gas_price_tolerance
+        .parse::<u64>()
+        .unwrap_or(DEFAULT_GAS_PRICE);
 
     let mut deploy_builder =
         DeployBuilder::new_transfer(chain_name, amount, source_purse, target, maybe_transfer_id)

--- a/lib/cli/error.rs
+++ b/lib/cli/error.rs
@@ -179,6 +179,10 @@ pub enum CliError {
     /// Failed to parse a package address
     #[error("Failed to parse a package address")]
     FailedToParsePackageAddr,
+
+    ///Failed to parse a transfer target
+    #[error("Failed to parse a transfer target")]
+    FailedToParseTransferTarget,
 }
 
 impl From<CLValueError> for CliError {

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -8,7 +8,7 @@ use rand::Rng;
 use casper_types::{
     account::AccountHash, bytesrepr::Bytes, crypto, AsymmetricType, BlockHash, DeployHash, Digest,
     EntityAddr, ExecutableDeployItem, HashAddr, Key, NamedArg, PricingMode, PublicKey, RuntimeArgs,
-    SecretKey, TimeDiff, Timestamp, UIntParseError, URef, U512,
+    SecretKey, TimeDiff, Timestamp, TransferTarget, UIntParseError, URef, U512,
 };
 
 use super::{simple_args, CliError, PaymentStrParams, SessionStrParams};
@@ -413,6 +413,23 @@ pub fn transaction_module_bytes(session_path: &str) -> Result<Bytes, CliError> {
         error,
     })?;
     Ok(Bytes::from(module_bytes))
+}
+
+/// Parses transfer target from a string for use with the transaction builder
+pub fn transfer_target(target_str: &str) -> Result<TransferTarget, CliError> {
+    if let Ok(public_key) = PublicKey::from_hex(target_str) {
+        return Ok(TransferTarget::PublicKey(public_key));
+    }
+    if let Ok(public_key) = PublicKey::from_file(target_str) {
+        return Ok(TransferTarget::PublicKey(public_key));
+    }
+    if let Ok(account_hash) = AccountHash::from_formatted_str(target_str) {
+        return Ok(TransferTarget::AccountHash(account_hash));
+    }
+    if let Ok(uref) = URef::from_formatted_str(target_str) {
+        return Ok(TransferTarget::URef(uref));
+    }
+    Err(CliError::FailedToParseTransferTarget)
 }
 
 /// Parses a URef from a formatted string for the purposes of creating transactions.

--- a/lib/cli/tests.rs
+++ b/lib/cli/tests.rs
@@ -433,10 +433,7 @@ fn should_fail_to_create_deploy_with_payment_and_session_with_no_secret_key_whil
 mod transaction {
     use super::*;
     use crate::Error::TransactionBuild;
-    use casper_types::{
-        bytesrepr::Bytes, PackageAddr, TransactionEntryPoint, TransactionInvocationTarget,
-        TransactionRuntime, TransactionSessionKind, TransactionTarget, TransactionV1BuilderError,
-    };
+    use casper_types::{bytesrepr::Bytes, PackageAddr, TransactionEntryPoint, TransactionInvocationTarget, TransactionRuntime, TransactionSessionKind, TransactionTarget, TransactionV1BuilderError, TransferTarget};
     const SAMPLE_TRANSACTION: &str = r#"{
   "hash": "f868596bbfd729547ffa25c3421df29d6650cec73e9fe3d0aff633fe2d6ac952",
   "header": {
@@ -1044,6 +1041,8 @@ mod transaction {
         )
         .unwrap();
 
+        let transfer_target = TransferTarget::URef(target_uref);
+
         let maybe_source = Some(source_uref);
 
         let source_uref_cl = &CLValue::from_t(Some(&source_uref)).unwrap();
@@ -1067,7 +1066,7 @@ mod transaction {
 
         let transaction_builder_params = TransactionBuilderParams::Transfer {
             maybe_source,
-            target: target_uref,
+            target: transfer_target,
             amount: Default::default(),
             maybe_id: None,
         };
@@ -1107,7 +1106,7 @@ mod transaction {
         };
         let transaction_builder_params = TransactionBuilderParams::Transfer {
             maybe_source: Default::default(),
-            target: Default::default(),
+            target: TransferTarget::URef(Default::default()),
             amount: Default::default(),
             maybe_id: None,
         };

--- a/lib/cli/transaction_builder_params.rs
+++ b/lib/cli/transaction_builder_params.rs
@@ -1,5 +1,5 @@
 use casper_types::bytesrepr::Bytes;
-use casper_types::{AddressableEntityHash, PackageHash, PublicKey, URef, U512};
+use casper_types::{AddressableEntityHash, PackageHash, PublicKey, TransferTarget, URef, U512};
 
 /// An enum representing the parameters needed to construct a transaction builder
 /// for the commands concerning the creation of a transaction
@@ -87,7 +87,7 @@ pub enum TransactionBuilderParams<'a> {
         /// Source of the transfer transaction
         maybe_source: Option<URef>,
         /// Target of the transfer transaction
-        target: URef,
+        target: TransferTarget,
         /// The amount of motes for the undelegate transaction
         amount: U512,
         /// The optional id for the transfer transaction

--- a/src/deploy/creation_common.rs
+++ b/src/deploy/creation_common.rs
@@ -453,7 +453,6 @@ pub(super) mod gas_price {
     }
 }
 
-
 /// Handles providing the arg for and retrieval of JSON session and payment args.
 pub(super) mod args_json {
     use super::*;

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -1588,7 +1588,7 @@ pub(super) mod source {
     pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
-            .required(true)
+            .required(false)
             .value_name(ARG_VALUE_NAME)
             .help(ARG_HELP)
             .display_order(DisplayOrder::Source as usize)

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -1550,7 +1550,7 @@ pub(super) mod transfer {
         };
 
         let target_str = target::get(matches);
-        let target = parse::uref(target_str)?;
+        let target = parse::transfer_target(target_str)?;
 
         let amount = transfer_amount::get(matches);
         let amount = transaction_amount::parse_transaction_amount(amount)?;


### PR DESCRIPTION
## Description

This PR addresses issues discovered in the parsing functionality for URef strings.
Now the client will accept a `PublicKey` in the form of a file locaiton, or formatted string, an `AccountHash` in the form of a formatted string, or a `URef` in the form of a formatted string as valid parameters for the `--target` argument

## Example
```

/casper-client put-transaction transfer --secret-key /path/to/nctl/secret/key/secret_key.pem --target uref-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20-007 --transfer-amount 10000000000 --payment-amount 1000000 --gas-price-tolerance 5 --chain-name casper-net-1 --pricing-mode fixed -n 'http://localhost:11101/rpc'
```
will show a transaction being sent to a local nctl network


```
{
  "jsonrpc": "2.0",
  "id": 8542344549515375082,
  "result": {
    "api_version": "2.0.0",
    "transaction_hash": {
      "Version1": "a6cf9ed456f72665f31810df44c35f1ac8e3fd436fa0bde1a76feae0dd49ed27"
    }
  }
}

```