### PR TITLE
Add the ability to set the gas price in legacy deploys

### DIFF
--- a/src/deploy/make_transfer.rs
+++ b/src/deploy/make_transfer.rs
@@ -24,6 +24,7 @@ impl ClientCommand for MakeTransfer {
             .arg(transfer::amount::arg())
             .arg(transfer::target_account::arg())
             .arg(transfer::transfer_id::arg())
+            .arg(creation_common::gas_price::arg())
             .arg(common::force::arg(
                 creation_common::DisplayOrder::Force as usize,
                 true,

--- a/src/deploy/transfer.rs
+++ b/src/deploy/transfer.rs
@@ -110,6 +110,7 @@ impl ClientCommand for Transfer {
             .arg(creation_common::speculative_exec::arg())
             .arg(amount::arg())
             .arg(target_account::arg())
+            .arg(creation_common::gas_price::arg())
             .arg(transfer_id::arg());
         let subcommand = creation_common::apply_common_payment_options(
             subcommand,


### PR DESCRIPTION
## Description.
Previously deploy creation supported changing gas price. However, the deploy related commands in the client did not have an argument for gas price. This PR fixes that issue by adding this argument.


## Example
For this make-deploy command:
```
casper-client make-deploy --chain-name casper-net-1 --session-account /home/vimnovice/casper/casper-nctl/assets/net-1/users/user-1/public_key_hex --session-path /path/to/session/code/contract.wasm --payment-amount 100000 --gas-price 10
```

We get this deploy:

```
{
  "hash": "92929f4bc09d4c114b38a9cb0fc34288dfdccbba99225ecb17e2878a6a25f824",
  "header": {
    "account": "016b2de0703d3f5487eac2126e65b8d52251328e65b7c627b832fdf6d05ac0a2b2",
    "timestamp": "2024-05-28T14:39:32.432Z",
    "ttl": "30m",
    "gas_price": 10,
    "body_hash": "54582197a47939d71c36b450e3186caca5cab71c136dba4e4f0fdc5397a803e9",
    "dependencies": [],
    "chain_name": "casper-net-1"
  },
  "payment": {
    "ModuleBytes": {
      "module_bytes": "",
      "args": [
        [
          "amount",
          {
            "cl_type": "U512",
            "bytes": "03a08601",
            "parsed": "100000"
          }
        ]
      ]
    }
  },
  "session": {
    "ModuleBytes": {
      "module_bytes": "Omitted for brevity",
      "args": []
    }
  },
  "approvals": []
}

```