### PR TITLE
Fix list-deploys

### DIFF
--- a/src/deploy/list.rs
+++ b/src/deploy/list.rs
@@ -37,9 +37,9 @@ impl From<GetBlockResult> for ListDeploysResult {
                 |block| match &block.block {
                     Block::V1(v1_block) => v1_block.deploy_hashes().to_vec(),
                     Block::V2(v2_block) => v2_block
-                        .standard()
+                        .all_transactions()
                         .filter_map(|txn_hash| match txn_hash {
-                            TransactionHash::Deploy(deploy_hash) => Some(deploy_hash),
+                            TransactionHash::Deploy(deploy_hash) => Some(*deploy_hash),
                             TransactionHash::V1(_) => None,
                         })
                         .collect(),


### PR DESCRIPTION
## Description

This PR fixs the impl of `From<GetBlockResult> for ListDeployResult` after the merge of casper-node #4721 broke it.