### PR TITLE
Export entity or account

### DIFF
--- a/lib/cli/tests.rs
+++ b/lib/cli/tests.rs
@@ -479,6 +479,7 @@ mod transaction {
     ],
     "target": "Native",
     "entry_point": "Transfer",
+    "transaction_kind": 0,
     "scheduling": "Standard"
   },
   "approvals": []

--- a/lib/rpcs.rs
+++ b/lib/rpcs.rs
@@ -13,6 +13,6 @@ pub(crate) mod v2_0_0;
 
 pub use v2_0_0::{
     get_account::AccountIdentifier, get_dictionary_item::DictionaryItemIdentifier,
-    get_entity::EntityIdentifier, query_balance::PurseIdentifier,
+    get_entity::{EntityIdentifier, EntityOrAccount}, query_balance::PurseIdentifier,
     query_global_state::GlobalStateIdentifier,
 };


### PR DESCRIPTION
## Description:
Previously the record type `EntityOrAccount` was not exposed in the RPC library that the client maintains, despite structs that contain it being exposed. This led to an issue where consumers of the library were unable to meaningfully use the types exposed by the client for handling RPC return values, specifically for `state_get_entity`.


This PR also includes a small fix for a test that was failing as a result of changes to transactions that merged into the node recently.