### PR TITLE
Fix transaction builder errors

### DIFF
--- a/lib/cli/tests.rs
+++ b/lib/cli/tests.rs
@@ -479,6 +479,7 @@ mod transaction {
     ],
     "target": "Native",
     "entry_point": "Transfer",
+    "transaction_kind": 0,
     "scheduling": "Standard"
   },
   "approvals": []
@@ -1018,7 +1019,6 @@ mod transaction {
 
         let transaction_builder_params = TransactionBuilderParams::Session {
             transaction_bytes,
-            entry_point: "entry-point-session",
         };
         let transaction =
             create_transaction(transaction_builder_params, transaction_string_params, true);
@@ -1026,7 +1026,7 @@ mod transaction {
         assert_eq!(transaction.as_ref().unwrap().chain_name(), "session");
         assert_eq!(
             transaction.as_ref().unwrap().body().entry_point(),
-            &TransactionEntryPoint::Custom("entry-point-session".to_string())
+            &TransactionEntryPoint::Call
         );
         assert_eq!(transaction.as_ref().unwrap().body().target(), target);
     }

--- a/lib/cli/transaction.rs
+++ b/lib/cli/transaction.rs
@@ -302,12 +302,10 @@ pub fn make_transaction_builder(
         }
         TransactionBuilderParams::Session {
             transaction_bytes,
-            entry_point,
         } => {
             let transaction_builder = TransactionV1Builder::new_session(
                 TransactionSessionKind::Standard,
                 transaction_bytes,
-                entry_point,
             );
             Ok(transaction_builder)
         }

--- a/lib/cli/transaction_builder_params.rs
+++ b/lib/cli/transaction_builder_params.rs
@@ -79,8 +79,6 @@ pub enum TransactionBuilderParams<'a> {
     Session {
         /// The Bytes to be run by the execution engine for the session transaction
         transaction_bytes: Bytes,
-        /// The entry point for the session transaction
-        entry_point: &'a str,
     },
     /// Parameters for the transfer variant of the transaction builder
     Transfer {

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -1498,11 +1498,9 @@ pub(super) mod session {
         let transaction_bytes =
             parse::transaction_module_bytes(transaction_path_str.unwrap_or_default())?;
 
-        let entry_point = session_entry_point::get(matches);
 
         let params = TransactionBuilderParams::Session {
             transaction_bytes,
-            entry_point,
         };
         let transaction_str_params = build_transaction_str_params(matches, ACCEPT_SESSION_ARGS);
         Ok((params, transaction_str_params))


### PR DESCRIPTION
This PR fixes a compilation issue with the client as a result of recent merges in the node by removing references to entry point for new session transactions.