### PR TITLE
Add `CASPER_NODE_ADDRESS` env var.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = { version = "0.1.74", optional = true }
 base16 = "0.2.1"
 casper-hashing = "3.0.0"
 casper-types = { version = "4.0.1", features = ["std"] }
-clap = { version = "~4.4", optional = true, features = ["cargo", "deprecated", "wrap_help"] }
+clap = { version = "~4.4", optional = true, features = ["cargo", "deprecated", "wrap_help", "env"] }
 clap_complete = { version = "<4.5.0", optional = true }
 hex-buffer-serde = "0.4.0"
 humantime = "2.1.0"

--- a/src/common.rs
+++ b/src/common.rs
@@ -47,12 +47,13 @@ pub mod node_address {
     const ARG_VALUE_NAME: &str = "HOST:PORT";
     const ARG_DEFAULT: &str = "http://localhost:7777";
     const ARG_HELP: &str = "Hostname or IP and port of node on which HTTP service is running";
+    const ARG_ENV: &str = "CASPER_NODE_ADDRESS";
 
     pub fn arg(order: usize) -> Arg {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
-            .env("CASPER_NODE_ADDRESS")
+            .env(ARG_ENV)
             .required(false)
             .default_value(ARG_DEFAULT)
             .value_name(ARG_VALUE_NAME)

--- a/src/common.rs
+++ b/src/common.rs
@@ -52,6 +52,7 @@ pub mod node_address {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .short(ARG_SHORT)
+            .env("CASPER_NODE_ADDRESS")
             .required(false)
             .default_value(ARG_DEFAULT)
             .value_name(ARG_VALUE_NAME)


### PR DESCRIPTION
This makes it easier to use multiple commands without remembering to set `--node-address`. With this change, casper-client will try to load its value from env variable `CASPER_NODE_ADDRESS`.