### PR TITLE
Remove vergen dep on feat-track-2.0 for cargo audit 

### DIFF
--- a/.github/workflows/ci-casper-client-rs.yml
+++ b/.github/workflows/ci-casper-client-rs.yml
@@ -53,12 +53,11 @@ jobs:
           command: clippy
           args: --all-targets
 
-      # // Awaits https://github.com/casper-ecosystem/casper-client-rs/pull/153
-      # - name: Clippy with no features
-      #   uses: actions-rs/cargo@v1
-      #   with:
-      #     command: clippy
-      #     args: --all-targets --no-default-features
+      - name: Clippy with no features
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-targets
 
       - name: Doc
         uses: actions-rs/cargo@v1
@@ -71,16 +70,12 @@ jobs:
         with:
           command: test
 
-      # // Awaits https://github.com/casper-ecosystem/casper-client-rs/pull/153
-      # - name: Test with no features
-      #   uses: actions-rs/cargo@v1
-      #   with:
-      #     command: test
-      #     args: --no-default-features
+      - name: Test with no features
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
 
-      # // Awaits https://github.com/casper-network/casper-node/pull/4714
-      # - name: Build lib for Wasm with no features
-      #   uses: actions-rs/cargo@v1
-      #   with:
-      #     command: build
-      #     args: --lib --target wasm32-unknown-unknown --no-default-features
+      - name: Build lib for Wasm with no features
+        uses: actions-rs/cargo@v1
+        with:
+          command: build

--- a/.github/workflows/ci-casper-client-rs.yml
+++ b/.github/workflows/ci-casper-client-rs.yml
@@ -53,11 +53,11 @@ jobs:
           command: clippy
           args: --all-targets
 
-      - name: Clippy with no features
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets
+      # - name: Clippy with no features
+      #   uses: actions-rs/cargo@v1
+      #   with:
+      #     command: clippy
+      #     args: --all-targets --no-default-features
 
       - name: Doc
         uses: actions-rs/cargo@v1
@@ -70,12 +70,20 @@ jobs:
         with:
           command: test
 
-      - name: Test with no features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+      # - name: Test with no features
+      #   uses: actions-rs/cargo@v1
+      #   with:
+      #     command: test
+      #     args: --no-default-features
 
-      - name: Build lib for Wasm with no features
+      - name: Build
         uses: actions-rs/cargo@v1
         with:
           command: build
+          args: --all-targets
+
+      # - name: Build lib for Wasm with no features
+      #   uses: actions-rs/cargo@v1
+      #   with:
+      #     command: build
+      #     args: --lib --target wasm32-unknown-unknown --no-default-features

--- a/.github/workflows/ci-casper-client-rs.yml
+++ b/.github/workflows/ci-casper-client-rs.yml
@@ -3,12 +3,12 @@ name: ci-casper-client-rs
 
 on:
   push:
-    branches: [main, dev, release-2.0.0]
+    branches: [main, dev, release-2.0.0, feat-track-node-2.0]
     paths-ignore:
       - '**.md'
 
   pull_request:
-    branches: [main, dev, release-2.0.0]
+    branches: [main, dev, release-2.0.0, feat-track-node-2.0]
     paths-ignore:
       - '**.md'
 

--- a/.github/workflows/ci-casper-client-rs.yml
+++ b/.github/workflows/ci-casper-client-rs.yml
@@ -53,11 +53,12 @@ jobs:
           command: clippy
           args: --all-targets
 
-      - name: Clippy with no features
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --no-default-features
+      # // Awaits https://github.com/casper-ecosystem/casper-client-rs/pull/153
+      # - name: Clippy with no features
+      #   uses: actions-rs/cargo@v1
+      #   with:
+      #     command: clippy
+      #     args: --all-targets --no-default-features
 
       - name: Doc
         uses: actions-rs/cargo@v1
@@ -70,11 +71,12 @@ jobs:
         with:
           command: test
 
-      - name: Test with no features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features
+      # // Awaits https://github.com/casper-ecosystem/casper-client-rs/pull/153
+      # - name: Test with no features
+      #   uses: actions-rs/cargo@v1
+      #   with:
+      #     command: test
+      #     args: --no-default-features
 
       # // Awaits https://github.com/casper-network/casper-node/pull/4714
       # - name: Build lib for Wasm with no features

--- a/.github/workflows/ci-casper-client-rs.yml
+++ b/.github/workflows/ci-casper-client-rs.yml
@@ -22,11 +22,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          components: rustfmt, clippy
+
+      - name: Get stable from rust-toolchain.toml
+        id: stable-toolchain
+        run: |
+          VER=$(sed -nr 's/channel\s+=\s+\"(.*)\"/\1/p' rust-toolchain.toml)
+          echo "RUST_CHANNEL=$VER" >> $GITHUB_ENV
+
+      - name: Install Toolchain - Stable
+        run: |
+          rustup update --no-self-update ${{ env.RUST_CHANNEL }}
+          rustup component add --toolchain ${{ env.RUST_CHANNEL }} rustfmt rust-src clippy
+          rustup default ${{ env.RUST_CHANNEL }}
+          rustup target add wasm32-unknown-unknown
 
       - name: Fmt
         uses: actions-rs/cargo@v1
@@ -45,6 +53,12 @@ jobs:
           command: clippy
           args: --all-targets
 
+      - name: Clippy with no features
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-targets --no-default-features
+
       - name: Doc
         uses: actions-rs/cargo@v1
         with:
@@ -55,3 +69,16 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+
+      - name: Test with no features
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features
+
+      # // Awaits https://github.com/casper-network/casper-node/pull/4714
+      # - name: Build lib for Wasm with no features
+      #   uses: actions-rs/cargo@v1
+      #   with:
+      #     command: build
+      #     args: --lib --target wasm32-unknown-unknown --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "casper-client"
 version = "2.0.0" # when updating, also update 'html_root_url' in lib.rs
-authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>", "Zachary Showalter <zach@casperlabs.io>"]
+authors = [
+    "Marc Brinkmann <marc@casperlabs.io>",
+    "Fraser Hutchison <fraser@casperlabs.io>",
+    "Zachary Showalter <zach@casperlabs.io>",
+]
 edition = "2021"
 description = "A client library and binary for interacting with the Casper network"
 documentation = "https://docs.rs/casper-client"
@@ -18,21 +22,18 @@ path = "lib/lib.rs"
 name = "casper-client"
 path = "src/main.rs"
 doc = false
+required-features = ["async-trait", "clap", "clap_complete", "std-fs-io"]
 
 [features]
-default = ["async-trait", "clap", "clap_complete", "tokio", "std-fs-io"]
+default = ["async-trait", "clap", "clap_complete", "std-fs-io"]
 std-fs-io = ["casper-types/std-fs-io"]
 
 [dependencies]
 async-trait = { version = "0.1.59", default-features = false, optional = true }
 base16 = "0.2.1"
 casper-types = { version = "5.0.0", features = ["std"] }
-clap = { version = "4", features = [
-  "cargo",
-  "deprecated",
-  "wrap_help",
-], optional = true }
-clap_complete = { version = "4", default-features = false, optional = true }
+clap = { version = "~4.4", features = ["cargo", "deprecated"], optional = true }
+clap_complete = { version = "~4.4", default-features = false, optional = true }
 hex-buffer-serde = "0.4.0"
 humantime = "2"
 itertools = "0.11.0"
@@ -40,26 +41,17 @@ jsonrpc-lite = "0.6.0"
 num-traits = "0.2.15"
 once_cell = "1"
 rand = "0.8.5"
-reqwest = { version = "0.11.13", features = ["json"] }
+reqwest = { version = "0.12.5", features = ["json"] }
 schemars = "0.8.13"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde-map-to-array = "1.1.1"
 serde_json = { version = "1", features = ["preserve_order"] }
-thiserror = "1.0.34"
-tokio = { version = "1.23.0", features = [
-  "macros",
-  "net",
-  "rt-multi-thread",
-  "sync",
-  "time",
-], optional = true }
+thiserror = "1"
+tokio = { version = "1.38.0", features = ["macros", "rt", "sync", "time"] }
 uint = "0.9.4"
 
 [dev-dependencies]
 tempfile = "3.7.1"
-
-[build-dependencies]
-vergen = { version = "7", default-features = false, features = ["git"] }
 
 [patch.crates-io]
 casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
@@ -67,7 +59,7 @@ casper-types = { git = "https://github.com/casper-network/casper-node.git", bran
 [package.metadata.deb]
 features = ["vendored-openssl"]
 revision = "0"
-assets = [["./target/release/casper-client", "/usr/bin/casper-client", "755"], ]
+assets = [["./target/release/casper-client", "/usr/bin/casper-client", "755"]]
 extended-description = """
 Package for Casper Client to connect to Casper Node.
 

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,35 @@
-use vergen::{Config, ShaKind};
+use std::io;
+use std::process::Command;
+
+const GIT_HASH_ENV_VAR: &str = "GIT_SHA_SHORT";
 
 fn main() {
-    let mut config = Config::default();
-    *config.git_mut().sha_kind_mut() = ShaKind::Short;
-    let _ = vergen::vergen(config);
+    match get_git_commit_hash() {
+        // If the git commit hash is retrieved successfully, set the environment variable
+        Ok(git_hash) => {
+            println!("cargo:rustc-env={GIT_HASH_ENV_VAR}={git_hash}");
+        }
+        // If there's an error retrieving the git commit hash, print a note and set the environment variable to "unknown"
+        Err(e) => {
+            println!("cargo:warning=Note: Failed to get git commit hash: {}", e);
+            println!("cargo:rustc-env={GIT_HASH_ENV_VAR}=unknown");
+        }
+    }
+}
+
+fn get_git_commit_hash() -> Result<String, io::Error> {
+    // Build the command to retrieve the short git commit hash
+    let output = Command::new("git")
+        .arg("rev-parse")
+        .arg("--short")
+        .arg("HEAD")
+        .output()?;
+
+    if output.status.success() {
+        // Parse the raw output into a string and trim the newline character
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        // Return an error if the command failed
+        Err(io::Error::new(io::ErrorKind::Other, "Git command failed"))
+    }
 }

--- a/lib/cli/tests.rs
+++ b/lib/cli/tests.rs
@@ -585,8 +585,8 @@ mod transaction {
         let validator_public_key = PublicKey::from(&validator_secret_key);
         let amount = U512::from(2000);
 
-        let delegator_public_key_cl = &CLValue::from_t(&delegator_public_key).unwrap();
-        let validator_public_key_cl = &CLValue::from_t(&validator_public_key).unwrap();
+        let delegator_public_key_cl = &CLValue::from_t(delegator_public_key).unwrap();
+        let validator_public_key_cl = &CLValue::from_t(validator_public_key).unwrap();
         let amount_cl = &CLValue::from_t(amount).unwrap();
 
         let transaction_string_params = TransactionStrParams {
@@ -699,8 +699,8 @@ mod transaction {
         let validator_public_key = PublicKey::from(&validator_secret_key);
 
         let amount_cl = &CLValue::from_t(amount).unwrap();
-        let delegator_public_key_cl = &CLValue::from_t(&delegator_public_key).unwrap();
-        let validator_public_key_cl = &CLValue::from_t(&validator_public_key).unwrap();
+        let delegator_public_key_cl = &CLValue::from_t(delegator_public_key).unwrap();
+        let validator_public_key_cl = &CLValue::from_t(validator_public_key).unwrap();
 
         let transaction_string_params = TransactionStrParams {
             secret_key: "",
@@ -764,9 +764,9 @@ mod transaction {
         let new_validator_public_key = PublicKey::from(&new_validator_secret_key);
         let amount = U512::from(5000);
 
-        let delegator_public_key_cl = &CLValue::from_t(&delegator_public_key).unwrap();
-        let validator_public_key_cl = &CLValue::from_t(&validator_public_key).unwrap();
-        let new_validator_public_key_cl = &CLValue::from_t(&new_validator_public_key).unwrap();
+        let delegator_public_key_cl = &CLValue::from_t(delegator_public_key).unwrap();
+        let validator_public_key_cl = &CLValue::from_t(validator_public_key).unwrap();
+        let new_validator_public_key_cl = &CLValue::from_t(new_validator_public_key).unwrap();
         let amount_cl = &CLValue::from_t(amount).unwrap();
 
         let transaction_string_params = TransactionStrParams {
@@ -1053,7 +1053,7 @@ mod transaction {
         let maybe_source = Some(source_uref);
 
         let source_uref_cl = &CLValue::from_t(Some(&source_uref)).unwrap();
-        let target_uref_cl = &CLValue::from_t(&target_uref).unwrap();
+        let target_uref_cl = &CLValue::from_t(target_uref).unwrap();
 
         let transaction_string_params = TransactionStrParams {
             secret_key: "",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.73.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ const APP_NAME: &str = "Casper client";
 
 static VERSION: Lazy<String> =
     Lazy::new(
-        || match option_env!("VERGEN_GIT_SHA_SHORT").map(|sha| sha.to_lowercase()) {
+        || match option_env!("GIT_SHA_SHORT").map(|sha| sha.to_lowercase()) {
             None => crate_version!().to_string(),
             Some(git_sha_short) => {
                 if git_sha_short.to_lowercase() == "unknown" {
@@ -175,7 +175,7 @@ fn cli() -> Command {
         ))
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     let arg_matches = cli().get_matches();
     let (subcommand_name, matches) = arg_matches.subcommand().unwrap_or_else(|| {


### PR DESCRIPTION
We need to have Ci/CD and cargo audit passing on feat-track-2.0. I suggest we cherry-pick some changes from dev to remove vergen, prepare code verification changes and for now still bypass "std-fs-io" feature

- Port from dev to feat-track-2.0 of #149 #175 and partially #144 to remove vergen and set tokio as dep
- clippy/test/build with no default features not yet working until #153 and https://github.com/casper-network/casper-node/pull/4714 are merged
