### PR TITLE
Changing TransactionV1 structure follwing https://github.com/casper-network/casper-node/pull/4890

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ std-fs-io = ["casper-types/std-fs-io"]
 [dependencies]
 async-trait = { version = "0.1.74", default-features = false, optional = true }
 base16 = "0.2.1"
+casper-types = { version = "5.0.0", features = ["std", "json-schema"] }
 casper-types = { version = "5.0.0", features = ["std"] }
 clap = { version = "~4.4", features = ["cargo", "deprecated"], optional = true }
 clap_complete = { version = "~4.4", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ uint = "0.9.5"
 tempfile = "3.8.1"
 
 [patch.crates-io]
-casper-types = { version = "5.0.0", path = "../casper-node/types" }
+casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
 
 [package.metadata.deb]
 features = ["vendored-openssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ repository = "https://github.com/casper-ecosystem/casper-client-rs"
 license = "Apache-2.0"
 
 [lib]
+crate-type = ["cdylib", "rlib"]
 name = "casper_client"
 path = "lib/lib.rs"
 
@@ -29,32 +30,32 @@ default = ["async-trait", "clap", "clap_complete", "std-fs-io"]
 std-fs-io = ["casper-types/std-fs-io"]
 
 [dependencies]
-async-trait = { version = "0.1.59", default-features = false, optional = true }
+async-trait = { version = "0.1.74", optional = true }
 base16 = "0.2.1"
 casper-types = { version = "5.0.0", features = ["std"] }
 clap = { version = "~4.4", features = ["cargo", "deprecated"], optional = true }
 clap_complete = { version = "~4.4", default-features = false, optional = true }
 hex-buffer-serde = "0.4.0"
-humantime = "2"
-itertools = "0.11.0"
+humantime = "2.1.0"
+itertools = "0.12.0"
 jsonrpc-lite = "0.6.0"
 num-traits = "0.2.15"
-once_cell = "1"
+once_cell = "1.18.0"
 rand = "0.8.5"
 reqwest = { version = "0.12.5", features = ["json"] }
-schemars = "0.8.13"
+schemars = "0.8.18"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde-map-to-array = "1.1.1"
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "1"
-tokio = { version = "1.38.0", features = ["macros", "rt", "sync", "time"] }
-uint = "0.9.4"
+tokio = { version = "1.39.3", features = ["macros", "rt", "sync", "time"] }
+uint = "0.9.5"
 
 [dev-dependencies]
-tempfile = "3.7.1"
+tempfile = "3.8.1"
 
 [patch.crates-io]
-casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
+casper-types = { version = "5.0.0", path = "../casper-node/types" }
 
 [package.metadata.deb]
 features = ["vendored-openssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ repository = "https://github.com/casper-ecosystem/casper-client-rs"
 license = "Apache-2.0"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
 name = "casper_client"
 path = "lib/lib.rs"
 
@@ -30,7 +29,7 @@ default = ["async-trait", "clap", "clap_complete", "std-fs-io"]
 std-fs-io = ["casper-types/std-fs-io"]
 
 [dependencies]
-async-trait = { version = "0.1.74", optional = true }
+async-trait = { version = "0.1.74", default-features = false, optional = true }
 base16 = "0.2.1"
 casper-types = { version = "5.0.0", features = ["std"] }
 clap = { version = "~4.4", features = ["cargo", "deprecated"], optional = true }

--- a/lib/cli/error.rs
+++ b/lib/cli/error.rs
@@ -184,10 +184,6 @@ pub enum CliError {
     #[error("Failed to parse a transfer target")]
     FailedToParseTransferTarget,
 
-    /// Failed to parse transaction category.
-    #[error("Failed to parse a transaction category")]
-    FailedToParseTransactionCategory,
-
     /// Failed to parse a validator public key.
     #[error("Failed to parse a validator public key")]
     FailedToParseValidatorPublicKey,

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -890,6 +890,8 @@ pub(super) fn pricing_mode(
                     })?;
             Ok(PricingMode::Fixed {
                 gas_price_tolerance,
+                // TODO FIX additional_computation_factor
+                additional_computation_factor: 0,
             })
         }
         "reserved" => {

--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -824,50 +824,51 @@ pub(super) fn public_key(public_key: &str) -> Result<Option<PublicKey>, CliError
 
 pub(super) fn pricing_mode(
     pricing_mode_identifier_str: &str,
-    maybe_payment_amount_str: &str,
-    maybe_gas_price_tolerance_str: &str,
-    maybe_standard_payment_str: &str,
+    payment_amount_str: &str,
+    gas_price_tolerance_str: &str,
+    maybe_additional_computation_factor_str: Option<&str>,
+    standard_payment_str: &str,
     maybe_receipt: Option<Digest>,
 ) -> Result<PricingMode, CliError> {
     match pricing_mode_identifier_str.to_lowercase().as_str() {
         "classic" => {
-            if maybe_gas_price_tolerance_str.is_empty() {
+            if gas_price_tolerance_str.is_empty() {
                 return Err(CliError::InvalidArgument {
                     context: "gas_price_tolerance",
                     error: "Gas price tolerance is required".to_string(),
                 });
             }
-            if maybe_payment_amount_str.is_empty() {
+            if payment_amount_str.is_empty() {
                 return Err(CliError::InvalidArgument {
                     context: "payment_amount",
                     error: "Payment amount is required".to_string(),
                 });
             }
-            if maybe_standard_payment_str.is_empty() {
+            if standard_payment_str.is_empty() {
                 return Err(CliError::InvalidArgument {
                     context: "standard_payment",
                     error: "Standard payment flag is required".to_string(),
                 });
             }
-            let gas_price_tolerance =
-                maybe_gas_price_tolerance_str
-                    .parse::<u8>()
-                    .map_err(|error| CliError::FailedToParseInt {
-                        context: "gas_price_tolerance",
-                        error,
-                    })?;
-            let payment_amount = maybe_payment_amount_str.parse::<u64>().map_err(|error| {
+            let gas_price_tolerance = gas_price_tolerance_str.parse::<u8>().map_err(|error| {
                 CliError::FailedToParseInt {
-                    context: "payment_amount",
+                    context: "gas_price_tolerance",
                     error,
                 }
             })?;
-            let standard_payment = maybe_standard_payment_str
-                .parse::<bool>()
-                .map_err(|error| CliError::FailedToParseBool {
+            let payment_amount =
+                payment_amount_str
+                    .parse::<u64>()
+                    .map_err(|error| CliError::FailedToParseInt {
+                        context: "payment_amount",
+                        error,
+                    })?;
+            let standard_payment = standard_payment_str.parse::<bool>().map_err(|error| {
+                CliError::FailedToParseBool {
                     context: "standard_payment",
                     error,
-                })?;
+                }
+            })?;
             Ok(PricingMode::Classic {
                 payment_amount,
                 gas_price_tolerance,
@@ -875,23 +876,28 @@ pub(super) fn pricing_mode(
             })
         }
         "fixed" => {
-            if maybe_gas_price_tolerance_str.is_empty() {
+            if gas_price_tolerance_str.is_empty() {
                 return Err(CliError::InvalidArgument {
                     context: "gas_price_tolerance",
                     error: "Gas price tolerance is required".to_string(),
                 });
             }
-            let gas_price_tolerance =
-                maybe_gas_price_tolerance_str
-                    .parse::<u8>()
-                    .map_err(|error| CliError::FailedToParseInt {
-                        context: "gas_price_tolerance",
-                        error,
-                    })?;
+            let gas_price_tolerance = gas_price_tolerance_str.parse::<u8>().map_err(|error| {
+                CliError::FailedToParseInt {
+                    context: "gas_price_tolerance",
+                    error,
+                }
+            })?;
+            let additional_computation_factor = maybe_additional_computation_factor_str
+                .unwrap_or_default()
+                .parse::<u8>()
+                .map_err(|error| CliError::FailedToParseInt {
+                    context: "additional_computation_factor",
+                    error,
+                })?;
             Ok(PricingMode::Fixed {
                 gas_price_tolerance,
-                // TODO FIX additional_computation_factor
-                additional_computation_factor: 0,
+                additional_computation_factor,
             })
         }
         "reserved" => {
@@ -1691,11 +1697,13 @@ mod tests {
             let pricing_mode_str = "fixed";
             let payment_amount = "";
             let gas_price_tolerance = "10";
+            let maybe_additional_computation_factor = Some("1");
             let standard_payment = "";
             let parsed = pricing_mode(
                 pricing_mode_str,
                 payment_amount,
                 gas_price_tolerance,
+                maybe_additional_computation_factor,
                 standard_payment,
                 None,
             )
@@ -1703,6 +1711,7 @@ mod tests {
             assert_eq!(
                 parsed,
                 PricingMode::Fixed {
+                    additional_computation_factor: 1,
                     gas_price_tolerance: 10,
                 }
             );
@@ -1712,11 +1721,13 @@ mod tests {
             let pricing_mode_str = "reserved";
             let payment_amount = "";
             let gas_price_tolerance = "";
+            let maybe_additional_computation_factor = None;
             let standard_payment = "";
             let parsed = pricing_mode(
                 pricing_mode_str,
                 payment_amount,
                 gas_price_tolerance,
+                maybe_additional_computation_factor,
                 standard_payment,
                 Some(Digest::from_hex(VALID_HASH).unwrap()),
             )
@@ -1734,10 +1745,12 @@ mod tests {
             let payment_amount = "10";
             let standard_payment = "true";
             let gas_price_tolerance = "10";
+            let maybe_additional_computation_factor = None;
             let parsed = pricing_mode(
                 pricing_mode_str,
                 payment_amount,
                 gas_price_tolerance,
+                maybe_additional_computation_factor,
                 standard_payment,
                 None,
             )
@@ -1758,10 +1771,12 @@ mod tests {
             let payment_amount = "10";
             let standard_payment = "true";
             let gas_price_tolerance = "10";
+            let maybe_additional_computation_factor = Some("true");
             let parsed = pricing_mode(
                 pricing_mode_str,
                 payment_amount,
                 gas_price_tolerance,
+                maybe_additional_computation_factor,
                 standard_payment,
                 None,
             );
@@ -1775,10 +1790,12 @@ mod tests {
             let payment_amount = "";
             let standard_payment = "true";
             let gas_price_tolerance = "10";
+            let maybe_additional_computation_factor = None;
             let parsed = pricing_mode(
                 pricing_mode_str,
                 payment_amount,
                 gas_price_tolerance,
+                maybe_additional_computation_factor,
                 standard_payment,
                 None,
             );

--- a/lib/cli/tests.rs
+++ b/lib/cli/tests.rs
@@ -539,6 +539,7 @@ mod transaction {
             output_path: "",
             payment_amount: "100",
             gas_price_tolerance: "10",
+            additional_computation_factor: None,
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
         };
@@ -601,6 +602,7 @@ mod transaction {
             output_path: "",
             payment_amount: "100",
             gas_price_tolerance: "10",
+            additional_computation_factor: Some("1"),
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
         };
@@ -662,6 +664,7 @@ mod transaction {
             output_path: "",
             payment_amount: "100",
             gas_price_tolerance: "10",
+            additional_computation_factor: Some("0"),
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
         };
@@ -714,6 +717,7 @@ mod transaction {
             output_path: "",
             payment_amount: "100",
             gas_price_tolerance: "10",
+            additional_computation_factor: Some("0"),
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
         };
@@ -781,6 +785,7 @@ mod transaction {
             output_path: "",
             payment_amount: "100",
             gas_price_tolerance: "10",
+            additional_computation_factor: None,
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
         };
@@ -852,6 +857,7 @@ mod transaction {
             output_path: "",
             payment_amount: "100",
             gas_price_tolerance: "10",
+            additional_computation_factor: Some("0"),
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
         };
@@ -894,6 +900,7 @@ mod transaction {
             payment_amount: "100",
             gas_price_tolerance: "10",
             receipt: SAMPLE_DIGEST,
+            additional_computation_factor: None,
             standard_payment: "true",
         };
 
@@ -939,6 +946,7 @@ mod transaction {
             payment_amount: "100",
             gas_price_tolerance: "10",
             receipt: SAMPLE_DIGEST,
+            additional_computation_factor: None,
             standard_payment: "true",
         };
 
@@ -981,6 +989,7 @@ mod transaction {
             output_path: "",
             payment_amount: "100",
             gas_price_tolerance: "10",
+            additional_computation_factor: None,
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
         };
@@ -1003,7 +1012,9 @@ mod transaction {
     #[test]
     fn should_create_session_transaction() {
         let transaction_bytes = Bytes::from(vec![1u8; 32]);
+        let is_install_upgrade = true;
         let target = &TransactionTarget::Session {
+            is_install_upgrade,
             runtime: TransactionRuntime::VmCasperV1,
             module_bytes: transaction_bytes.clone(),
         };
@@ -1019,13 +1030,14 @@ mod transaction {
             output_path: "",
             payment_amount: "100",
             gas_price_tolerance: "10",
+            additional_computation_factor: None,
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
         };
 
         let transaction_builder_params = TransactionBuilderParams::Session {
+            is_install_upgrade,
             transaction_bytes,
-            transaction_category: casper_types::TransactionCategory::Large,
         };
         let transaction =
             create_transaction(transaction_builder_params, transaction_string_params, true);
@@ -1067,6 +1079,7 @@ mod transaction {
             output_path: "",
             payment_amount: "100",
             gas_price_tolerance: "10",
+            additional_computation_factor: None,
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
         };
@@ -1108,6 +1121,7 @@ mod transaction {
             output_path: "",
             payment_amount: "100",
             gas_price_tolerance: "10",
+            additional_computation_factor: None,
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
         };
@@ -1144,6 +1158,7 @@ mod transaction {
             output_path: "",
             payment_amount: "100",
             gas_price_tolerance: "10",
+            additional_computation_factor: None,
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
         };
@@ -1177,6 +1192,7 @@ mod transaction {
             output_path: "",
             payment_amount: "100",
             gas_price_tolerance: "",
+            additional_computation_factor: None,
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
         };

--- a/lib/cli/transaction.rs
+++ b/lib/cli/transaction.rs
@@ -58,6 +58,7 @@ pub fn create_transaction(
             transaction_params.pricing_mode,
             transaction_params.payment_amount,
             transaction_params.gas_price_tolerance,
+            transaction_params.additional_computation_factor,
             transaction_params.standard_payment,
             Some(digest),
         )?
@@ -66,6 +67,7 @@ pub fn create_transaction(
             transaction_params.pricing_mode,
             transaction_params.payment_amount,
             transaction_params.gas_price_tolerance,
+            transaction_params.additional_computation_factor,
             transaction_params.standard_payment,
             None,
         )?
@@ -295,9 +297,12 @@ pub fn make_transaction_builder(
             );
             Ok(transaction_builder)
         }
-        TransactionBuilderParams::Session { transaction_bytes } => {
-            // TODO FIX is_install_upgrade
-            let transaction_builder = TransactionV1Builder::new_session(true, transaction_bytes);
+        TransactionBuilderParams::Session {
+            is_install_upgrade,
+            transaction_bytes,
+        } => {
+            let transaction_builder =
+                TransactionV1Builder::new_session(is_install_upgrade, transaction_bytes);
             Ok(transaction_builder)
         }
         TransactionBuilderParams::Transfer {

--- a/lib/cli/transaction.rs
+++ b/lib/cli/transaction.rs
@@ -295,12 +295,9 @@ pub fn make_transaction_builder(
             );
             Ok(transaction_builder)
         }
-        TransactionBuilderParams::Session {
-            transaction_bytes,
-            transaction_category,
-        } => {
-            let transaction_builder =
-                TransactionV1Builder::new_session(transaction_category, transaction_bytes);
+        TransactionBuilderParams::Session { transaction_bytes } => {
+            // TODO FIX is_install_upgrade
+            let transaction_builder = TransactionV1Builder::new_session(true, transaction_bytes);
             Ok(transaction_builder)
         }
         TransactionBuilderParams::Transfer {

--- a/lib/cli/transaction_builder_params.rs
+++ b/lib/cli/transaction_builder_params.rs
@@ -1,7 +1,5 @@
 use casper_types::bytesrepr::Bytes;
-use casper_types::{
-    AddressableEntityHash, PackageHash, PublicKey, TransactionCategory, TransferTarget, URef, U512,
-};
+use casper_types::{AddressableEntityHash, PackageHash, PublicKey, TransferTarget, URef, U512};
 
 /// An enum representing the parameters needed to construct a transaction builder
 /// for the commands concerning the creation of a transaction
@@ -85,8 +83,6 @@ pub enum TransactionBuilderParams<'a> {
     Session {
         /// The Bytes to be run by the execution engine for the session transaction
         transaction_bytes: Bytes,
-        /// Transaction category
-        transaction_category: TransactionCategory,
     },
     /// Parameters for the transfer variant of the transaction builder
     Transfer {

--- a/lib/cli/transaction_builder_params.rs
+++ b/lib/cli/transaction_builder_params.rs
@@ -81,6 +81,8 @@ pub enum TransactionBuilderParams<'a> {
     },
     /// Parameters for the session variant of the transaction builder
     Session {
+        /// Flag determining if the Wasm is an install/upgrade.
+        is_install_upgrade: bool,
         /// The Bytes to be run by the execution engine for the session transaction
         transaction_bytes: Bytes,
     },

--- a/lib/cli/transaction_str_params.rs
+++ b/lib/cli/transaction_str_params.rs
@@ -56,6 +56,9 @@ pub struct TransactionStrParams<'a> {
     pub session_args_json: &'a str,
     /// The pricing mode to use with the transaction
     pub pricing_mode: &'a str,
+    /// User-specified additional computation factor fro "fixed" pricing_mode(minimum 0)
+    /// Otional, if None or "0" is provided, no additional logic is applied to the computation limit.
+    pub additional_computation_factor: Option<&'a str>,
     /// The optional output path for the transaction, if writing it to a file.
     pub output_path: &'a str,
     /// The payment amount for executing the transaction

--- a/lib/cli/transaction_str_params.rs
+++ b/lib/cli/transaction_str_params.rs
@@ -57,7 +57,7 @@ pub struct TransactionStrParams<'a> {
     /// The pricing mode to use with the transaction
     pub pricing_mode: &'a str,
     /// User-specified additional computation factor fro "fixed" pricing_mode(minimum 0)
-    /// Otional, if None or "0" is provided, no additional logic is applied to the computation limit.
+    /// Otional, if None or Some("0") is provided, no additional logic is applied to the computation limit.
     pub additional_computation_factor: Option<&'a str>,
     /// The optional output path for the transaction, if writing it to a file.
     pub output_path: &'a str,

--- a/lib/cli/transaction_str_params.rs
+++ b/lib/cli/transaction_str_params.rs
@@ -56,9 +56,9 @@ pub struct TransactionStrParams<'a> {
     pub session_args_json: &'a str,
     /// The pricing mode to use with the transaction
     pub pricing_mode: &'a str,
-    /// User-specified additional computation factor fro "fixed" pricing_mode(minimum 0)
-    /// Otional, if None or Some("0") is provided, no additional logic is applied to the computation limit.
-    pub additional_computation_factor: Option<&'a str>,
+    /// User-specified additional computation factor for "fixed" pricing_mode (minimum 0)
+    /// if "0" is provided, no additional logic is applied to the computation limit.
+    pub additional_computation_factor: &'a str,
     /// The optional output path for the transaction, if writing it to a file.
     pub output_path: &'a str,
     /// The payment amount for executing the transaction

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -47,6 +47,7 @@ pub(super) enum DisplayOrder {
     StandardPayment,
     Receipt,
     GasPriceTolerance,
+    AdditionalComputationFactor,
     IsInstallUpgrade,
     TransactionAmount,
     Validator,
@@ -195,6 +196,7 @@ pub(super) mod chain_name {
         Arg::new(ARG_NAME)
             .long(ARG_NAME)
             .value_name(ARG_VALUE_NAME)
+            .required(true)
             .help(ARG_HELP)
             .display_order(DisplayOrder::ChainName as usize)
     }
@@ -506,6 +508,38 @@ pub(super) mod pricing_mode {
     }
 }
 
+pub(super) mod additional_computation_factor {
+    use super::*;
+    pub(in crate::transaction) const ARG_NAME: &str = "additional-computation-factor";
+
+    const ARG_VALUE_NAME: &str = common::ARG_INTEGER;
+
+    const ARG_ALIAS: &str = "additional-computation";
+    const ARG_SHORT: char = 'c';
+    const ARG_HELP: &str =
+        "User-specified additional computation factor for \"fixed\" pricing_mode";
+    const ARG_DEFAULT: &str = "0";
+
+    pub(in crate::transaction) fn arg() -> Arg {
+        Arg::new(ARG_NAME)
+            .long(ARG_NAME)
+            .alias(ARG_ALIAS)
+            .short(ARG_SHORT)
+            .required(false)
+            .default_value(ARG_DEFAULT)
+            .value_name(ARG_VALUE_NAME)
+            .help(ARG_HELP)
+            .display_order(DisplayOrder::AdditionalComputationFactor as usize)
+    }
+
+    pub fn get(matches: &ArgMatches) -> &str {
+        matches
+            .get_one::<String>(ARG_NAME)
+            .map(String::as_str)
+            .unwrap_or_default()
+    }
+}
+
 pub(super) mod initiator_address {
     use super::*;
     pub(in crate::transaction) const ARG_NAME: &str = "initiator-address";
@@ -605,6 +639,7 @@ pub(super) fn apply_common_creation_options(
         .arg(output::arg())
         .arg(payment_amount::arg())
         .arg(pricing_mode::arg())
+        .arg(additional_computation_factor::arg())
         .arg(gas_price_tolerance::arg())
         .arg(receipt::arg())
         .arg(standard_payment::arg())
@@ -671,7 +706,7 @@ pub(super) mod transaction_path {
     use super::*;
 
     const ARG_NAME: &str = "transaction-path";
-    const ARG_SHORT: char = 'i';
+    const ARG_SHORT: char = 't';
     const ARG_VALUE_NAME: &str = common::ARG_PATH;
     const ARG_HELP: &str = "Path to input transaction file";
 
@@ -1847,6 +1882,7 @@ pub(super) fn build_transaction_str_params(
     let chain_name = chain_name::get(matches);
     let maybe_pricing_mode = pricing_mode::get(matches);
     let gas_price_tolerance = gas_price_tolerance::get(matches);
+    let additional_computation_factor = additional_computation_factor::get(matches);
     let payment_amount = payment_amount::get(matches);
     let receipt = receipt::get(matches);
     let standard_payment = standard_payment::get(matches);
@@ -1869,7 +1905,7 @@ pub(super) fn build_transaction_str_params(
             output_path: maybe_output_path,
             payment_amount,
             gas_price_tolerance,
-            additional_computation_factor: None,
+            additional_computation_factor,
             receipt,
             standard_payment,
         }
@@ -1884,6 +1920,7 @@ pub(super) fn build_transaction_str_params(
             output_path: maybe_output_path,
             payment_amount,
             gas_price_tolerance,
+            additional_computation_factor,
             receipt,
             standard_payment,
             ..Default::default()

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -690,82 +690,82 @@ pub(super) mod transaction_path {
     }
 }
 
-pub(super) mod transaction_category {
-    use std::str::FromStr;
+// TODO Fix lane
+// pub(super) mod transaction_category {
+//     use std::str::FromStr;
 
-    use casper_types::TransactionCategory;
-    use clap::{value_parser, ValueEnum};
+//     use clap::{value_parser, ValueEnum};
 
-    use super::*;
+//     use super::*;
 
-    const ARG_NAME: &str = "category";
-    const ARG_SHORT: char = 'c';
-    const ARG_VALUE_NAME: &str = "install-upgrade|large|medium|small";
-    const ARG_HELP: &str = "Transaction category";
+//     const ARG_NAME: &str = "category";
+//     const ARG_SHORT: char = 'c';
+//     const ARG_VALUE_NAME: &str = "install-upgrade|large|medium|small";
+//     const ARG_HELP: &str = "Transaction category";
 
-    #[derive(Debug, Clone, Copy)]
-    pub(super) enum Category {
-        InstallUpgrade,
-        Large,
-        Medium,
-        Small,
-    }
+//     #[derive(Debug, Clone, Copy)]
+//     pub(super) enum Category {
+//         InstallUpgrade,
+//         Large,
+//         Medium,
+//         Small,
+//     }
 
-    impl Category {
-        pub(super) fn into_transaction_v1_category(self) -> TransactionCategory {
-            match self {
-                Self::InstallUpgrade => TransactionCategory::InstallUpgrade,
-                Self::Large => TransactionCategory::Large,
-                Self::Medium => TransactionCategory::Medium,
-                Self::Small => TransactionCategory::Small,
-            }
-        }
-    }
+//     impl Category {
+//         pub(super) fn into_transaction_v1_category(self) -> TransactionCategory {
+//             match self {
+//                 Self::InstallUpgrade => TransactionCategory::InstallUpgrade,
+//                 Self::Large => TransactionCategory::Large,
+//                 Self::Medium => TransactionCategory::Medium,
+//                 Self::Small => TransactionCategory::Small,
+//             }
+//         }
+//     }
 
-    impl ValueEnum for Category {
-        fn value_variants<'a>() -> &'a [Self] {
-            &[Self::InstallUpgrade, Self::Large, Self::Medium, Self::Small]
-        }
+//     impl ValueEnum for Category {
+//         fn value_variants<'a>() -> &'a [Self] {
+//             &[Self::InstallUpgrade, Self::Large, Self::Medium, Self::Small]
+//         }
 
-        fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
-            Some(match self {
-                Self::InstallUpgrade => clap::builder::PossibleValue::new("install-upgrade"),
-                Self::Large => clap::builder::PossibleValue::new("large"),
-                Self::Medium => clap::builder::PossibleValue::new("medium"),
-                Self::Small => clap::builder::PossibleValue::new("small"),
-            })
-        }
-    }
+//         fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
+//             Some(match self {
+//                 Self::InstallUpgrade => clap::builder::PossibleValue::new("install-upgrade"),
+//                 Self::Large => clap::builder::PossibleValue::new("large"),
+//                 Self::Medium => clap::builder::PossibleValue::new("medium"),
+//                 Self::Small => clap::builder::PossibleValue::new("small"),
+//             })
+//         }
+//     }
 
-    impl FromStr for Category {
-        type Err = String;
+//     impl FromStr for Category {
+//         type Err = String;
 
-        fn from_str(s: &str) -> Result<Self, Self::Err> {
-            match s.to_lowercase().as_str() {
-                "install-upgrade" => Ok(Category::InstallUpgrade),
-                "large" => Ok(Category::Large),
-                "medium" => Ok(Category::Medium),
-                "small" => Ok(Category::Small),
-                _ => Err(format!("'{}' is not a valid size option", s)),
-            }
-        }
-    }
+//         fn from_str(s: &str) -> Result<Self, Self::Err> {
+//             match s.to_lowercase().as_str() {
+//                 "install-upgrade" => Ok(Category::InstallUpgrade),
+//                 "large" => Ok(Category::Large),
+//                 "medium" => Ok(Category::Medium),
+//                 "small" => Ok(Category::Small),
+//                 _ => Err(format!("'{}' is not a valid size option", s)),
+//             }
+//         }
+//     }
 
-    pub fn arg() -> Arg {
-        Arg::new(ARG_NAME)
-            .required(true)
-            .long(ARG_NAME)
-            .short(ARG_SHORT)
-            .value_name(ARG_VALUE_NAME)
-            .help(ARG_HELP)
-            .display_order(DisplayOrder::TransactionCategory as usize)
-            .value_parser(value_parser!(Category))
-    }
+//     pub fn arg() -> Arg {
+//         Arg::new(ARG_NAME)
+//             .required(true)
+//             .long(ARG_NAME)
+//             .short(ARG_SHORT)
+//             .value_name(ARG_VALUE_NAME)
+//             .help(ARG_HELP)
+//             .display_order(DisplayOrder::TransactionCategory as usize)
+//             .value_parser(value_parser!(Category))
+//     }
 
-    pub(super) fn get(matches: &ArgMatches) -> Option<&Category> {
-        matches.get_one(ARG_NAME)
-    }
-}
+//     pub(super) fn get(matches: &ArgMatches) -> Option<&Category> {
+//         matches.get_one(ARG_NAME)
+//     }
+// }
 
 pub(super) mod public_key {
     use super::*;
@@ -1710,13 +1710,12 @@ pub(super) mod session {
         let transaction_bytes =
             parse::transaction_module_bytes(transaction_path_str.unwrap_or_default())?;
 
-        let transaction_category = *transaction_category::get(matches)
-            .ok_or(CliError::FailedToParseTransactionCategory)?;
+        // TODO Fix lane
+        // let transaction_category = *transaction_category::get(matches)
+        //     .ok_or(CliError::FailedToParseTransactionCategory)?;
 
-        let params = TransactionBuilderParams::Session {
-            transaction_bytes,
-            transaction_category: transaction_category.into_transaction_v1_category(),
-        };
+        // TODO fix session lane
+        let params = TransactionBuilderParams::Session { transaction_bytes };
         let transaction_str_params = build_transaction_str_params(matches, ACCEPT_SESSION_ARGS);
         Ok((params, transaction_str_params))
     }
@@ -1725,7 +1724,8 @@ pub(super) mod session {
         add_bid_subcommand
             .arg(transaction_path::arg())
             .arg(session_entry_point::arg())
-            .arg(transaction_category::arg())
+        // TODO fix session lane
+        // .arg(transaction_category::arg())
     }
 }
 


### PR DESCRIPTION
Porting the changes required to compile the client and run tests with changes of 

Changing TransactionV1 structure follwing [#4890](https://github.com/casper-network/casper-node/pull/4890/commits)

- Adding  `additional_computation_factor` in `TransactionStrParams` for "Fixed" Pricing mode
- Replace Transaction Category by `is_install_upgrade` in `session::run` and `TransactionBuilderParams::Session` following `TransactionTarget::Session` 

- Change tests / Add some tests for `additional_computation_factor` 

> Please note new format of a generated transaction

```
{
  "hash": "864b384f3c5e45070d0f9aa66b6ccb41406521b81346ada017b3900eb404d75c",
  "payload": {
    "initiator_addr": {
      "PublicKey": "01722e1b3d31bef0ba832121bd2941aae6a246d0d05ac95aa16dd587cc5469871d"
    },
    "timestamp": "2024-10-07T16:59:42.023Z",
    "ttl": "30m",
    "chain_name": "test",
    "pricing_mode": {
      "Fixed": {
        "additional_computation_factor": 0,
        "gas_price_tolerance": 10
      }
    },
    "fields": {
      "0": "020000000600000074617267657421000000722e1b3d31bef0ba832121bd2941aae6a246d0d05ac95aa16dd587cc5469871d010c06000000616d6f756e7402000000010a08",
      "1": "010000000000000000000100000000",
      "2": "010000000000000000000100000002",
      "3": "010000000000000000000100000000"
    }
  },
  "approvals": []
}
```

