### PR TITLE
Add json-schema to casper types import

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ std-fs-io = ["casper-types/std-fs-io"]
 [dependencies]
 async-trait = { version = "0.1.59", default-features = false, optional = true }
 base16 = "0.2.1"
-casper-types = { version = "5.0.0", features = ["std"] }
+casper-types = { version = "5.0.0", features = ["std", "json-schema"] }
 clap = { version = "~4.4", features = ["cargo", "deprecated"], optional = true }
 clap_complete = { version = "~4.4", default-features = false, optional = true }
 hex-buffer-serde = "0.4.0"


### PR DESCRIPTION
Probably fix CI for this error

```#22 988.9    Compiling casper-client v2.0.0 (/app/casper-client-rs)
#22 989.2    Compiling casper-types v5.0.0 (https://github.com/casper-network/casper-node.git?branch=feat-2.0#0ca0d95f)
#22 999.4    Compiling reqwest v0.12.8
#22 1020.4    Compiling clap_complete v4.4.10
#22 1024.9    Compiling hex-buffer-serde v0.4.0
#22 1025.0    Compiling itertools v0.11.0
#22 1026.6    Compiling jsonrpc-lite v0.6.0
#22 1029.9    Compiling async-trait v0.1.83
#22 1031.8 error[E0425]: cannot find function `json_pretty_print` in crate `casper_types`
#22 1031.8    --> lib/lib.rs:657:44
#22 1031.8     |
#22 1031.8 657 |         Verbosity::Medium => casper_types::json_pretty_print(value),
#22 1031.8     |                                            ^^^^^^^^^^^^^^^^^ not found in `casper_types`
#22 1031.8     |
#22 1031.8 note: found an item that was configured out
#22 1031.8    --> /root/.cargo/git/checkouts/casper-node-dd1233ff78032163/0ca0d95/types/src/lib.rs:168:30