### PR TITLE
Fix for remove of `as_entity_addr`

### DIFF
--- a/lib/cli/dictionary_item_str_params.rs
+++ b/lib/cli/dictionary_item_str_params.rs
@@ -112,10 +112,15 @@ impl<'a> TryFrom<DictionaryItemStrParams<'a>> for DictionaryItemIdentifier {
                         error,
                     }
                 })?;
-                let entity_addr = key.as_entity_addr().ok_or(CliError::InvalidArgument {
-                    context: "dictionary item entity named key",
-                    error: "not a entity-addr".to_string(),
-                })?;
+
+                let entity_addr = if let Key::AddressableEntity(addr) = key {
+                    addr
+                }  else {
+                    return Err(CliError::InvalidArgument {
+                        context: "dictionary item entity named key",
+                        error: "not a entity-addr".to_string(),
+                    })
+                };
                 Ok(DictionaryItemIdentifier::new_from_entity_info(
                     entity_addr,
                     dictionary_name.to_string(),

--- a/lib/cli/dictionary_item_str_params.rs
+++ b/lib/cli/dictionary_item_str_params.rs
@@ -115,11 +115,11 @@ impl<'a> TryFrom<DictionaryItemStrParams<'a>> for DictionaryItemIdentifier {
 
                 let entity_addr = if let Key::AddressableEntity(addr) = key {
                     addr
-                }  else {
+                } else {
                     return Err(CliError::InvalidArgument {
                         context: "dictionary item entity named key",
                         error: "not a entity-addr".to_string(),
-                    })
+                    });
                 };
                 Ok(DictionaryItemIdentifier::new_from_entity_info(
                     entity_addr,


### PR DESCRIPTION
When this PR[https://github.com/casper-network/casper-node/pull/4897] closed, it took away a public function expressed in types that was never release, `as_entity_addr` which broke the client. This PR is meant to fix that, allow the client to build again