### PR TITLE
Remove --gas-limit parameter

### DIFF
--- a/lib/cli/tests.rs
+++ b/lib/cli/tests.rs
@@ -534,7 +534,6 @@ mod transaction {
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
             transferred_value: "0",
-            gas_limit: "",
             session_entry_point: None,
             chunked_args: None,
         };
@@ -615,7 +614,6 @@ mod transaction {
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
             transferred_value: "0",
-            gas_limit: "",
             session_entry_point: None,
             chunked_args: None,
         };
@@ -695,7 +693,6 @@ mod transaction {
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
             transferred_value: "0",
-            gas_limit: "",
             session_entry_point: None,
             chunked_args: None,
         };
@@ -764,7 +761,6 @@ mod transaction {
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
             transferred_value: "0",
-            gas_limit: "",
             session_entry_point: None,
             chunked_args: None,
         };
@@ -850,7 +846,6 @@ mod transaction {
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
             transferred_value: "0",
-            gas_limit: "",
             session_entry_point: None,
             chunked_args: None,
         };
@@ -944,7 +939,6 @@ mod transaction {
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
             transferred_value: "0",
-            gas_limit: "",
             session_entry_point: None,
             chunked_args: None,
         };
@@ -1004,7 +998,6 @@ mod transaction {
             additional_computation_factor: "",
             standard_payment: "true",
             transferred_value: "0",
-            gas_limit: "",
             session_entry_point: None,
             chunked_args: None,
         };
@@ -1068,7 +1061,6 @@ mod transaction {
             additional_computation_factor: "",
             standard_payment: "true",
             transferred_value: "0",
-            gas_limit: "",
             session_entry_point: None,
             chunked_args: None,
         };
@@ -1130,7 +1122,6 @@ mod transaction {
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
             transferred_value: "0",
-            gas_limit: "",
             session_entry_point: None,
             chunked_args: None,
         };
@@ -1190,7 +1181,6 @@ mod transaction {
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
             transferred_value: "0",
-            gas_limit: "",
             session_entry_point: None,
             chunked_args: None,
         };
@@ -1257,7 +1247,6 @@ mod transaction {
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
             transferred_value: "0",
-            gas_limit: "",
             session_entry_point: None,
             chunked_args: None,
         };
@@ -1323,7 +1312,6 @@ mod transaction {
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
             transferred_value: "0",
-            gas_limit: "",
             session_entry_point: None,
             chunked_args: None,
         };
@@ -1366,7 +1354,6 @@ mod transaction {
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
             transferred_value: "0",
-            gas_limit: "",
             session_entry_point: None,
             chunked_args: None,
         };
@@ -1404,7 +1391,6 @@ mod transaction {
             receipt: SAMPLE_DIGEST,
             standard_payment: "true",
             transferred_value: "0",
-            gas_limit: "",
             session_entry_point: None,
             chunked_args: None,
         };

--- a/lib/cli/transaction_str_params.rs
+++ b/lib/cli/transaction_str_params.rs
@@ -69,8 +69,6 @@ pub struct TransactionStrParams<'a> {
     pub receipt: &'a str,
     /// Standard payment.
     pub standard_payment: &'a str,
-    /// Gas limit for the transaction.
-    pub gas_limit: &'a str,
     /// Transaferred value.
     pub transferred_value: &'a str,
     /// The entry point for the session.

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -441,35 +441,6 @@ pub(super) mod gas_price_tolerance {
     }
 }
 
-pub(super) mod gas_limit {
-    use super::*;
-    pub(in crate::transaction) const ARG_NAME: &str = "gas-limit";
-
-    const ARG_VALUE_NAME: &str = common::ARG_INTEGER;
-
-    const ARG_ALIAS: &str = "gas-limit";
-    const ARG_SHORT: char = 'l';
-    const ARG_HELP: &str =
-        "The maximum amount of gas the user is willing to pay for the transaction";
-
-    pub(in crate::transaction) fn arg() -> Arg {
-        Arg::new(ARG_NAME)
-            .long(ARG_NAME)
-            .alias(ARG_ALIAS)
-            .short(ARG_SHORT)
-            .required(true)
-            .value_name(ARG_VALUE_NAME)
-            .help(ARG_HELP)
-            .display_order(DisplayOrder::GasPriceTolerance as usize)
-    }
-
-    pub fn get(matches: &ArgMatches) -> &str {
-        matches
-            .get_one::<String>(ARG_NAME)
-            .map(String::as_str)
-            .unwrap_or_default()
-    }
-}
 pub(super) mod transfer_amount {
     use super::*;
     pub(in crate::transaction) const ARG_NAME: &str = "transfer-amount";
@@ -1659,7 +1630,6 @@ pub(super) mod invocable_entity {
             .arg(entity_addr::arg())
             .arg(session_entry_point::arg())
             .arg(transaction_runtime::arg())
-            .arg(gas_limit::arg())
             .arg(transferred_value::arg())
             .arg(chunked_args::arg())
     }
@@ -1911,7 +1881,6 @@ pub(super) mod session {
                 DisplayOrder::IsInstallUpgrade as usize,
             ))
             .arg(transaction_runtime::arg())
-            .arg(gas_limit::arg())
             .arg(transferred_value::arg())
             .arg(chunked_args::arg())
     }
@@ -2095,7 +2064,6 @@ pub(super) fn build_transaction_str_params(
     let payment_amount = payment_amount::get(matches);
     let receipt = receipt::get(matches);
     let standard_payment = standard_payment::get(matches);
-    let gas_limit = gas_limit::get(matches);
 
     let maybe_output_path = output::get(matches).unwrap_or_default();
     let initiator_addr = initiator_address::get(matches);
@@ -2123,7 +2091,6 @@ pub(super) fn build_transaction_str_params(
             transferred_value: transferred_value::get(matches)
                 .map(|tv| tv.as_str())
                 .unwrap_or_default(),
-            gas_limit,
             session_entry_point,
             chunked_args,
         }


### PR DESCRIPTION
This is a leftover command line switch from the early implementation of new VM integration work and is no longer necessary.