### PR TITLE
Address refactor of Package to SmartContract

### DIFF
--- a/lib/cli/parse.rs
+++ b/lib/cli/parse.rs
@@ -632,7 +632,7 @@ fn contract_hash(value: &str) -> Result<Option<HashAddr>, CliError> {
     match Digest::from_hex(value) {
         Ok(digest) => Ok(Some(digest.value())),
         Err(error) => match Key::from_formatted_str(value) {
-            Ok(Key::Hash(hash)) | Ok(Key::Package(hash)) => Ok(Some(hash)),
+            Ok(Key::Hash(hash)) | Ok(Key::SmartContract(hash)) => Ok(Some(hash)),
             _ => Err(CliError::FailedToParseDigest {
                 context: "contract hash",
                 error,

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -991,7 +991,7 @@ pub(super) mod package_addr {
                         error,
                     })?;
                 match package_addr {
-                    Key::Package(package_addr) => Ok(package_addr),
+                    Key::SmartContract(package_addr) => Ok(package_addr),
                     _ => Err(CliError::Core(Error::InvalidKeyVariant {
                         expected_variant: "Package Address".to_string(),
                         actual: package_addr,


### PR DESCRIPTION
- Address rename of `Key::Package` to `Key::SmartContract`