### PR TITLE
Making transferred-value optional in the CLI. Also, if VM1 is the sel…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ uint = "0.9.5"
 tempfile = "3.8.1"
 
 [patch.crates-io]
-casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
+casper-types = { git = "https://github.com/casper-network/casper-node.git", tag = "v2.0.0-rc5" }
 
 [package.metadata.deb]
 features = ["vendored-openssl"]

--- a/lib/cli/tests.rs
+++ b/lib/cli/tests.rs
@@ -454,7 +454,7 @@ mod transaction {
     use once_cell::sync::Lazy;
     use serde_json::json;
     static SAMPLE_TRANSACTION: Lazy<serde_json::Value> = Lazy::new(|| {
-        json!({
+        json!({"Version1": {
             "hash": "57144349509f7cb9374e0f38b4e4910526b397a38f0dc21eaae1df916df66aae",
             "payload": {
                 "initiator_addr": {
@@ -470,14 +470,28 @@ mod transaction {
                 }
                 },
                 "fields": {
-                    "0": "020000000600000074617267657421000000722e1b3d31bef0ba832121bd2941aae6a246d0d05ac95aa16dd587cc5469871d010c06000000616d6f756e7402000000010a08",
-                    "1": "010000000000000000000100000000",
-                    "2": "010000000000000000000100000002",
-                    "3": "010000000000000000000100000000",
+                  "args": {
+                    "Named": [
+                      [
+                        "xyz",
+                        {
+                          "bytes": "0d0000001af81d860f238f832b8f8e648c",
+                          "cl_type": {
+                            "List": "U8"
+                          }
+                        }
+                      ]
+                    ]
+                  },
+                  "entry_point": "AddBid",
+                  "scheduling": {
+                    "FutureEra": 195120
+                  },
+                  "target": "Native"
                 }
             },
             "approvals": [],
-        })
+        }})
     });
     const SAMPLE_DIGEST: &str =
         "01722e1b3d31bef0ba832121bd2941aae6a246d0d05ac95aa16dd587cc5469871d";
@@ -550,11 +564,10 @@ mod transaction {
             create_transaction(transaction_builder_params, transaction_string_params, true);
 
         assert!(transaction.is_ok(), "{:?}", transaction);
-        assert_eq!(transaction.as_ref().unwrap().chain_name(), "add-bid-test");
+        let transaction_v1 = unwrap_transaction(transaction);
+        assert_eq!(transaction_v1.chain_name(), "add-bid-test");
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionArgs>(ARGS_MAP_KEY)
                 .unwrap()
                 .into_named()
@@ -563,9 +576,7 @@ mod transaction {
                 .unwrap(),
             public_key_cl
         );
-        assert!(transaction
-            .as_ref()
-            .unwrap()
+        assert!(transaction_v1
             .deserialize_field::<TransactionArgs>(ARGS_MAP_KEY)
             .unwrap()
             .into_named()
@@ -573,9 +584,7 @@ mod transaction {
             .get("delegation_rate")
             .is_some());
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionArgs>(ARGS_MAP_KEY)
                 .unwrap()
                 .into_named()
@@ -628,11 +637,10 @@ mod transaction {
             create_transaction(transaction_builder_params, transaction_string_params, true);
 
         assert!(transaction.is_ok(), "{:?}", transaction);
-        assert_eq!(transaction.as_ref().unwrap().chain_name(), "delegate");
+        let transaction_v1 = unwrap_transaction(transaction);
+        assert_eq!(transaction_v1.chain_name(), "delegate");
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionArgs>(ARGS_MAP_KEY)
                 .unwrap()
                 .into_named()
@@ -642,9 +650,7 @@ mod transaction {
             amount_cl
         );
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionArgs>(ARGS_MAP_KEY)
                 .unwrap()
                 .into_named()
@@ -654,9 +660,7 @@ mod transaction {
             delegator_public_key_cl
         );
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionArgs>(ARGS_MAP_KEY)
                 .unwrap()
                 .into_named()
@@ -705,11 +709,10 @@ mod transaction {
             create_transaction(transaction_builder_params, transaction_string_params, true);
 
         assert!(transaction.is_ok(), "{:?}", transaction);
-        assert_eq!(transaction.as_ref().unwrap().chain_name(), "withdraw-bid");
+        let transaction_v1 = unwrap_transaction(transaction);
+        assert_eq!(transaction_v1.chain_name(), "withdraw-bid");
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionArgs>(ARGS_MAP_KEY)
                 .unwrap()
                 .into_named()
@@ -719,9 +722,7 @@ mod transaction {
             amount_cl
         );
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionArgs>(ARGS_MAP_KEY)
                 .unwrap()
                 .into_named()
@@ -775,11 +776,10 @@ mod transaction {
             create_transaction(transaction_builder_params, transaction_string_params, true);
 
         assert!(transaction.is_ok(), "{:?}", transaction);
-        assert_eq!(transaction.as_ref().unwrap().chain_name(), "undelegate");
+        let transaction_v1 = unwrap_transaction(transaction);
+        assert_eq!(transaction_v1.chain_name(), "undelegate");
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionArgs>(ARGS_MAP_KEY)
                 .unwrap()
                 .into_named()
@@ -789,9 +789,7 @@ mod transaction {
             amount_cl
         );
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionArgs>(ARGS_MAP_KEY)
                 .unwrap()
                 .into_named()
@@ -801,9 +799,7 @@ mod transaction {
             delegator_public_key_cl
         );
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionArgs>(ARGS_MAP_KEY)
                 .unwrap()
                 .into_named()
@@ -859,11 +855,10 @@ mod transaction {
         let transaction =
             create_transaction(transaction_builder_params, transaction_string_params, true);
         assert!(transaction.is_ok(), "{:?}", transaction);
-        assert_eq!(transaction.as_ref().unwrap().chain_name(), "redelegate");
+        let transaction_v1 = unwrap_transaction(transaction);
+        assert_eq!(transaction_v1.chain_name(), "redelegate");
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionArgs>(ARGS_MAP_KEY)
                 .unwrap()
                 .into_named()
@@ -873,9 +868,7 @@ mod transaction {
             amount_cl
         );
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionArgs>(ARGS_MAP_KEY)
                 .unwrap()
                 .into_named()
@@ -885,9 +878,7 @@ mod transaction {
             delegator_public_key_cl
         );
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionArgs>(ARGS_MAP_KEY)
                 .unwrap()
                 .into_named()
@@ -897,9 +888,7 @@ mod transaction {
             validator_public_key_cl
         );
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionArgs>(ARGS_MAP_KEY)
                 .unwrap()
                 .into_named()
@@ -953,22 +942,16 @@ mod transaction {
             create_transaction(transaction_builder_params, transaction_string_params, true);
 
         assert!(transaction.is_ok(), "{:?}", transaction);
+        let transaction_v1 = unwrap_transaction(transaction);
+        assert_eq!(transaction_v1.chain_name(), "invocable-entity");
         assert_eq!(
-            transaction.as_ref().unwrap().chain_name(),
-            "invocable-entity"
-        );
-        assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionEntryPoint>(ENTRY_POINT_MAP_KEY)
                 .unwrap(),
             *entry_point_ref
         );
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionTarget>(TARGET_MAP_KEY)
                 .unwrap(),
             *target
@@ -1011,27 +994,22 @@ mod transaction {
         let transaction =
             create_transaction(transaction_builder_params, transaction_string_params, true);
         assert!(transaction.is_ok(), "{:?}", transaction);
+        let transaction_v1 = unwrap_transaction(transaction);
+        assert_eq!(transaction_v1.chain_name(), "invocable-entity-alias");
         assert_eq!(
-            transaction.as_ref().unwrap().chain_name(),
-            "invocable-entity-alias"
-        );
-        assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionEntryPoint>(ENTRY_POINT_MAP_KEY)
                 .unwrap(),
             TransactionEntryPoint::Custom("entry-point-alias".to_string())
         );
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionTarget>(TARGET_MAP_KEY)
                 .unwrap(),
             *target
         );
     }
+
     #[test]
     fn should_create_package_transaction() {
         let package_addr: PackageAddr = vec![0u8; 32].as_slice().try_into().unwrap();
@@ -1075,24 +1053,22 @@ mod transaction {
         let transaction =
             create_transaction(transaction_builder_params, transaction_string_params, true);
         assert!(transaction.is_ok(), "{:?}", transaction);
-        assert_eq!(transaction.as_ref().unwrap().chain_name(), "package");
+        let transaction_v1 = unwrap_transaction(transaction);
+        assert_eq!(transaction_v1.chain_name(), "package");
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionEntryPoint>(ENTRY_POINT_MAP_KEY)
                 .unwrap(),
             TransactionEntryPoint::Custom("test-entry-point-package".to_string())
         );
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionTarget>(TARGET_MAP_KEY)
                 .unwrap(),
             *target
         );
     }
+
     #[test]
     fn should_create_package_alias_transaction() {
         let package_name = String::from("package-name");
@@ -1136,19 +1112,16 @@ mod transaction {
         let transaction =
             create_transaction(transaction_builder_params, transaction_string_params, true);
         assert!(transaction.is_ok(), "{:?}", transaction);
-        assert_eq!(transaction.as_ref().unwrap().chain_name(), "package");
+        let transaction_v1 = unwrap_transaction(transaction);
+        assert_eq!(transaction_v1.chain_name(), "package");
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionEntryPoint>(ENTRY_POINT_MAP_KEY)
                 .unwrap(),
             TransactionEntryPoint::Custom("test-entry-point-package".to_string())
         );
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionTarget>(TARGET_MAP_KEY)
                 .unwrap(),
             *target
@@ -1195,24 +1168,22 @@ mod transaction {
         let transaction =
             create_transaction(transaction_builder_params, transaction_string_params, true);
         assert!(transaction.is_ok(), "{:?}", transaction);
-        assert_eq!(transaction.as_ref().unwrap().chain_name(), "session");
+        let transaction_v1 = unwrap_transaction(transaction);
+        assert_eq!(transaction_v1.chain_name(), "session");
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionEntryPoint>(ENTRY_POINT_MAP_KEY)
                 .unwrap(),
             TransactionEntryPoint::Call
         );
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionTarget>(TARGET_MAP_KEY)
                 .unwrap(),
             *target
         );
     }
+
     #[test]
     fn should_create_transfer_transaction() {
         let source_uref = URef::from_formatted_str(
@@ -1260,19 +1231,16 @@ mod transaction {
         let transaction =
             create_transaction(transaction_builder_params, transaction_string_params, true);
         assert!(transaction.is_ok(), "{:?}", transaction);
-        assert_eq!(transaction.as_ref().unwrap().chain_name(), "transfer");
+        let transaction_v1 = unwrap_transaction(transaction);
+        assert_eq!(transaction_v1.chain_name(), "transfer");
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionEntryPoint>(ENTRY_POINT_MAP_KEY)
                 .unwrap(),
             TransactionEntryPoint::Transfer
         );
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionArgs>(ARGS_MAP_KEY)
                 .unwrap()
                 .into_named()
@@ -1282,9 +1250,7 @@ mod transaction {
             source_uref_cl
         );
         assert_eq!(
-            transaction
-                .as_ref()
-                .unwrap()
+            transaction_v1
                 .deserialize_field::<TransactionArgs>(ARGS_MAP_KEY)
                 .unwrap()
                 .into_named()
@@ -1293,6 +1259,17 @@ mod transaction {
                 .unwrap(),
             target_uref_cl
         );
+    }
+
+    fn unwrap_transaction(
+        transaction: Result<casper_types::Transaction, CliError>,
+    ) -> casper_types::TransactionV1 {
+        match transaction.unwrap() {
+            casper_types::Transaction::Deploy(_) => {
+                unreachable!("Expected transaction, got deploy")
+            }
+            casper_types::Transaction::V1(transaction_v1) => transaction_v1,
+        }
     }
     #[test]
     fn should_fail_to_create_transaction_with_no_secret_or_public_key() {

--- a/lib/cli/transaction.rs
+++ b/lib/cli/transaction.rs
@@ -12,14 +12,14 @@ use crate::{
 };
 use casper_types::{
     Digest, InitiatorAddr, SecretKey, Transaction, TransactionArgs, TransactionEntryPoint,
-    TransactionRuntime, TransactionV1, TransactionV1Builder,
+    TransactionRuntime, TransactionV1Builder,
 };
 
 pub fn create_transaction(
     builder_params: TransactionBuilderParams,
     transaction_params: TransactionStrParams,
     allow_unsigned_transaction: bool,
-) -> Result<TransactionV1, CliError> {
+) -> Result<Transaction, CliError> {
     let chain_name = transaction_params.chain_name.to_string();
 
     let maybe_secret_key = get_maybe_secret_key(
@@ -111,8 +111,7 @@ pub fn create_transaction(
     }
 
     let txn = transaction_builder.build().map_err(crate::Error::from)?;
-    // dbg!(&txn);
-    Ok(txn)
+    Ok(Transaction::V1(txn))
 }
 
 /// Creates a [`Transaction`] and outputs it to a file or stdout if the `std-fs-io` feature is enabled.
@@ -129,7 +128,7 @@ pub fn make_transaction(
     builder_params: TransactionBuilderParams,
     transaction_params: TransactionStrParams<'_>,
     #[allow(unused_variables)] force: bool,
-) -> Result<TransactionV1, CliError> {
+) -> Result<Transaction, CliError> {
     let transaction = create_transaction(builder_params, transaction_params.clone(), true)?;
     #[cfg(feature = "std-fs-io")]
     {
@@ -154,14 +153,9 @@ pub async fn put_transaction(
     let rpc_id = parse::rpc_id(rpc_id_str);
     let verbosity_level = parse::verbosity(verbosity_level);
     let transaction = create_transaction(builder_params, transaction_params, false)?;
-    put_transaction_rpc_handler(
-        rpc_id,
-        node_address,
-        verbosity_level,
-        Transaction::V1(transaction),
-    )
-    .await
-    .map_err(CliError::from)
+    put_transaction_rpc_handler(rpc_id, node_address, verbosity_level, transaction)
+        .await
+        .map_err(CliError::from)
 }
 ///
 /// Reads a previously-saved [`TransactionV1`] from a file and sends it to the network for execution.
@@ -179,14 +173,9 @@ pub async fn send_transaction_file(
     let rpc_id = parse::rpc_id(rpc_id_str);
     let verbosity_level = parse::verbosity(verbosity_level);
     let transaction = read_transaction_file(input_path)?;
-    put_transaction_rpc_handler(
-        rpc_id,
-        node_address,
-        verbosity_level,
-        Transaction::V1(transaction),
-    )
-    .await
-    .map_err(CliError::from)
+    put_transaction_rpc_handler(rpc_id, node_address, verbosity_level, transaction)
+        .await
+        .map_err(CliError::from)
 }
 
 ///
@@ -205,14 +194,9 @@ pub async fn speculative_send_transaction_file(
     let rpc_id = parse::rpc_id(rpc_id_str);
     let verbosity_level = parse::verbosity(verbosity_level);
     let transaction = read_transaction_file(input_path).unwrap();
-    speculative_exec_txn(
-        rpc_id,
-        node_address,
-        verbosity_level,
-        Transaction::V1(transaction),
-    )
-    .await
-    .map_err(CliError::from)
+    speculative_exec_txn(rpc_id, node_address, verbosity_level, transaction)
+        .await
+        .map_err(CliError::from)
 }
 
 /// Reads a previously-saved [`TransactionV1`] from a file, cryptographically signs it, and outputs it to a

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -60,13 +60,13 @@ use std::{
 #[cfg(feature = "std-fs-io")]
 use serde::Serialize;
 
+#[cfg(any(feature = "std-fs-io", test))]
+use casper_types::SecretKey;
 #[cfg(doc)]
 use casper_types::{account::Account, Block, StoredValue, Transfer};
 use casper_types::{
     Deploy, DeployHash, Digest, Key, PublicKey, Transaction, TransactionHash, URef,
 };
-#[cfg(any(feature = "std-fs-io", test))]
-use casper_types::{SecretKey, TransactionV1};
 
 #[cfg(any(feature = "std-fs-io", test))]
 use base64::{engine::general_purpose::STANDARD, Engine};
@@ -223,7 +223,7 @@ pub fn output_deploy(output: OutputKind, deploy: &Deploy) -> Result<(), Error> {
 /// `output` specifies the output file and corresponding overwrite behaviour, or if
 /// `OutputKind::Stdout`, causes the `Transaction` to be printed `stdout`.
 #[cfg(any(feature = "std-fs-io", test))]
-pub fn output_transaction(output: OutputKind, transaction: &TransactionV1) -> Result<(), Error> {
+pub fn output_transaction(output: OutputKind, transaction: &Transaction) -> Result<(), Error> {
     write_transaction(transaction, output.get()?)?;
     output.commit()
 }
@@ -243,7 +243,7 @@ pub fn read_deploy_file<P: AsRef<Path>>(deploy_path: P) -> Result<Deploy, Error>
 
 /// Reads a previously-saved [`Transaction`] from a file.
 #[cfg(any(feature = "std-fs-io", test))]
-pub fn read_transaction_file<P: AsRef<Path>>(transaction_path: P) -> Result<TransactionV1, Error> {
+pub fn read_transaction_file<P: AsRef<Path>>(transaction_path: P) -> Result<Transaction, Error> {
     let input = fs::read(transaction_path.as_ref()).map_err(|error| Error::IoError {
         context: format!(
             "unable to read transaction file at '{}'",
@@ -701,7 +701,7 @@ fn write_deploy<W: Write>(deploy: &Deploy, mut output: W) -> Result<(), Error> {
 }
 
 #[cfg(any(feature = "std-fs-io", test))]
-fn write_transaction<W: Write>(transaction: &TransactionV1, mut output: W) -> Result<(), Error> {
+fn write_transaction<W: Write>(transaction: &Transaction, mut output: W) -> Result<(), Error> {
     let content =
         serde_json::to_string_pretty(transaction).map_err(|error| Error::FailedToEncodeToJson {
             context: "writing transaction",
@@ -727,8 +727,8 @@ fn read_deploy<R: Read>(input: R) -> Result<Deploy, Error> {
 }
 
 #[cfg(any(feature = "std-fs-io", test))]
-fn read_transaction<R: Read>(input: R) -> Result<TransactionV1, Error> {
-    let transaction: TransactionV1 =
+fn read_transaction<R: Read>(input: R) -> Result<Transaction, Error> {
+    let transaction: Transaction =
         serde_json::from_reader(input).map_err(|error| Error::FailedToDecodeFromJson {
             context: "reading transaction",
             error,

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -8,6 +8,7 @@ use clap::{Arg, ArgAction, ArgGroup, ArgMatches, Command};
 use casper_client::cli::{
     json_args_help, simple_args_help, CliError, TransactionBuilderParams, TransactionStrParams,
 };
+use casper_types::TransactionRuntime;
 
 use crate::common;
 
@@ -583,7 +584,7 @@ pub(super) mod transaction_runtime {
 
     const ARG_VALUE_NAME: &str = "vm-casper-v1|vm-casper-v2";
     const ARG_HELP: &str = "Transaction runtime";
-    const ARG_DEFAULT: &str = TransactionRuntime::VM_CASPER_V2;
+    const ARG_DEFAULT: &str = TransactionRuntime::VM_CASPER_V1;
 
     pub(in crate::transaction) fn arg() -> Arg {
         Arg::new(ARG_NAME)
@@ -862,7 +863,7 @@ pub(super) mod transferred_value {
 
     pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
-            .required(true)
+            .required(false)
             .long(ARG_NAME)
             .short(ARG_SHORT)
             .value_name(ARG_VALUE_NAME)
@@ -1611,14 +1612,15 @@ pub(super) mod invocable_entity {
         let runtime = transaction_runtime::get(matches);
 
         let entry_point = session_entry_point::get(matches).unwrap_or_default();
-        let transferred_value = transferred_value::get(matches)
-            .map(|value| value.parse::<u64>().unwrap())
-            .unwrap_or_default();
+        let maybe_transferred_value =
+            transferred_value::get(matches).map(|value| value.parse::<u64>().unwrap());
 
+        let runtime = runtime.cloned().unwrap_or_default().into();
+        let transferred_value = map_maybe_transferred(maybe_transferred_value, &runtime)?;
         let params = TransactionBuilderParams::InvocableEntity {
             entity_hash: entity_addr.into(), // TODO: Skip `entity_addr` and match directly for hash?
             entry_point,
-            runtime: runtime.cloned().unwrap_or_default().into(),
+            runtime,
             transferred_value,
         };
         let transaction_str_params = build_transaction_str_params(matches, ACCEPT_SESSION_ARGS);
@@ -1669,10 +1671,9 @@ pub(super) mod invocable_entity_alias {
             .cloned()
             .unwrap_or_default()
             .into();
-        let transferred_value = transferred_value::get(matches)
-            .map(|value| value.parse::<u64>().unwrap())
-            .unwrap_or_default();
-
+        let maybe_transferred_value =
+            transferred_value::get(matches).map(|value| value.parse::<u64>().unwrap());
+        let transferred_value = map_maybe_transferred(maybe_transferred_value, &runtime)?;
         let params = TransactionBuilderParams::InvocableEntityAlias {
             entity_alias,
             entry_point,
@@ -1727,9 +1728,9 @@ pub(super) mod package {
             .into();
 
         let entry_point = session_entry_point::get(matches).unwrap_or_default();
-        let transferred_value = transferred_value::get(matches)
-            .map(|value| value.parse::<u64>().unwrap())
-            .unwrap_or_default();
+        let maybe_transferred_value =
+            transferred_value::get(matches).map(|value| value.parse::<u64>().unwrap());
+        let transferred_value = map_maybe_transferred(maybe_transferred_value, &runtime)?;
         let params = TransactionBuilderParams::Package {
             package_hash: package_addr.into(), // TODO: Skip `package_addr` and match directly for hash?
             maybe_entity_version,
@@ -1786,9 +1787,9 @@ pub(super) mod package_alias {
             .cloned()
             .unwrap_or_default()
             .into();
-        let transferred_value = transferred_value::get(matches)
-            .map(|value| value.parse::<u64>().unwrap())
-            .unwrap_or_default();
+        let maybe_transferred_value =
+            transferred_value::get(matches).map(|value| value.parse::<u64>().unwrap());
+        let transferred_value = map_maybe_transferred(maybe_transferred_value, &runtime)?;
 
         let params = TransactionBuilderParams::PackageAlias {
             package_alias,
@@ -1851,15 +1852,14 @@ pub(super) mod session {
             parse::transaction_module_bytes(transaction_path_str.unwrap_or_default())?;
 
         let is_install_upgrade: bool = is_install_upgrade::get(matches);
-
         let runtime = transaction_runtime::get(matches)
             .cloned()
             .unwrap_or_default()
             .into();
 
-        let transferred_value = transferred_value::get(matches)
-            .map(|value| value.parse::<u64>().unwrap())
-            .unwrap_or_default();
+        let maybe_transferred_value =
+            transferred_value::get(matches).map(|value| value.parse::<u64>().unwrap());
+        let transferred_value = map_maybe_transferred(maybe_transferred_value, &runtime)?;
         let seed = None; // TODO: support seeds
 
         let params = TransactionBuilderParams::Session {
@@ -2148,6 +2148,34 @@ pub(super) fn parse_rpc_args_and_run(
         rpc_id,
         verbosity_level,
     ))
+}
+
+fn map_maybe_transferred(
+    maybe_transferred_value: Option<u64>,
+    runtime: &TransactionRuntime,
+) -> Result<u64, CliError> {
+    match runtime {
+        TransactionRuntime::VmCasperV1 => {
+            if maybe_transferred_value.is_some() {
+                Err(CliError::InvalidArgument {
+                    context: "transferred_value",
+                    error: "Argument `transferred-value` has no usage in V1 execution engine VM (if you provided no execution engine vm parameter, V1 is the default)".to_string(),
+                })
+            } else {
+                Ok(0)
+            }
+        }
+        TransactionRuntime::VmCasperV2 => {
+            if let Some(transferred_value) = maybe_transferred_value {
+                Ok(transferred_value)
+            } else {
+                Err(CliError::InvalidArgument {
+                    context: "transferred_value",
+                    error: "VmCasperV2 requires `transferred-value` argument".to_string(),
+                })
+            }
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
…ected (or defaulted) runtime, `--transferred-value` argument is not allowed. This doesn't 100% reflect the API, since the API actually allows to provide a value for that field in case of VM1, but to limit confusion we reject it in the CLI since it has no meaning for VM1