### PR TITLE
Typo fixes

### DIFF
--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -279,7 +279,7 @@ pub fn sign_deploy_file<P: AsRef<Path>>(
     output.commit()
 }
 
-/// Reads a previously-saved [`TransactionV1`] from a file, cryptographically signs it, and outputs it to a file or stdout.
+/// Reads a previously-saved [`Transaction`] from a file, cryptographically signs it, and outputs it to a file or stdout.
 ///
 /// `output` specifies the output file and corresponding overwrite behaviour, or if OutputKind::Stdout,
 /// causes the `Transaction` to be printed `stdout`.

--- a/src/transaction/make.rs
+++ b/src/transaction/make.rs
@@ -56,7 +56,7 @@ impl ClientCommand for MakeTransaction {
                 undelegate::NAME => undelegate::run(matches)?,
                 redelegate::NAME => redelegate::run(matches)?,
                 change_bid_public_key::NAME => change_bid_public_key::run(matches)?,
-                add_reservations::NAME => cancel_reservations::run(matches)?,
+                add_reservations::NAME => add_reservations::run(matches)?,
                 cancel_reservations::NAME => cancel_reservations::run(matches)?,
                 invocable_entity::NAME => invocable_entity::run(matches)?,
                 invocable_entity_alias::NAME => invocable_entity_alias::run(matches)?,


### PR DESCRIPTION
Fixing typo that wired "add_reservations" command to "cancel_reservations" handling.