### PR TITLE
Pub DeployBuilder

### DIFF
--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -74,7 +74,7 @@ pub use deploy::{
     make_deploy, make_transfer, put_deploy, send_deploy_file, sign_deploy_file,
     speculative_put_deploy, speculative_send_deploy_file, speculative_transfer, transfer,
 };
-pub(crate) use deploy_builder::{DeployBuilder, DeployBuilderError};
+pub use deploy_builder::{DeployBuilder, DeployBuilderError};
 pub use deploy_str_params::DeployStrParams;
 pub use dictionary_item_str_params::DictionaryItemStrParams;
 pub use error::{CliError, FromDecStrErr};


### PR DESCRIPTION
This helper was public in casper node and consumed by crates that can build deploy easily. Would you please consider making it public ? Related to https://github.com/casper-ecosystem/casper-client-rs/pull/212

 