### PR TITLE
Rename transaction-path arg to wasm-path

### DIFF
--- a/lib/json_rpc/call.rs
+++ b/lib/json_rpc/call.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 
 const RPC_API_PATH: &str = "rpc";
 #[cfg(not(target_arch = "wasm32"))]
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Statically declared client used when making HTTP requests
 /// so opened connections are pooled.

--- a/src/deploy/creation_common.rs
+++ b/src/deploy/creation_common.rs
@@ -572,11 +572,9 @@ pub(super) fn apply_common_creation_options(
         );
 
     if include_node_address {
-        subcommand = subcommand.arg(
-            common::node_address::arg(DisplayOrder::NodeAddress as usize)
-                .required_unless_present(show_simple_arg_examples::ARG_NAME)
-                .required_unless_present(show_json_args_examples::ARG_NAME),
-        );
+        subcommand = subcommand.arg(common::node_address::arg(
+            DisplayOrder::NodeAddress as usize,
+        ));
     }
 
     let secret_key_arg = if require_secret_key {

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -817,13 +817,13 @@ pub(super) mod output {
     }
 }
 
-pub(super) mod transaction_path {
+pub(super) mod wasm_path {
     use super::*;
 
-    const ARG_NAME: &str = "transaction-path";
-    const ARG_SHORT: char = 't';
+    const ARG_NAME: &str = "wasm-path";
+    const ARG_SHORT: char = 'w';
     const ARG_VALUE_NAME: &str = common::ARG_PATH;
-    const ARG_HELP: &str = "Path to input transaction file";
+    const ARG_HELP: &str = "Path to compiled Wasm session code";
 
     pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
@@ -2284,17 +2284,16 @@ pub(super) mod session {
         show_simple_arg_examples_and_exit_if_required(matches);
         show_json_args_examples_and_exit_if_required(matches);
 
-        let transaction_path_str = transaction_path::get(matches);
+        let wasm_path_str = wasm_path::get(matches);
 
-        if transaction_path_str.is_none() {
+        if wasm_path_str.is_none() {
             return Err(CliError::InvalidArgument {
-                context: "transaction_path",
-                error: "Transaction path cannot be empty".to_string(),
+                context: "wasm_path",
+                error: "Wasm path cannot be empty".to_string(),
             });
         }
 
-        let transaction_bytes =
-            parse::transaction_module_bytes(transaction_path_str.unwrap_or_default())?;
+        let transaction_bytes = parse::transaction_module_bytes(wasm_path_str.unwrap_or_default())?;
 
         let is_install_upgrade: bool = is_install_upgrade::get(matches);
         let runtime = get_transaction_runtime(matches)?;
@@ -2310,7 +2309,7 @@ pub(super) mod session {
 
     fn add_args(session_subcommand: Command) -> Command {
         session_subcommand
-            .arg(transaction_path::arg())
+            .arg(wasm_path::arg())
             .arg(session_entry_point::arg())
             .arg(is_install_upgrade::arg(
                 DisplayOrder::IsInstallUpgrade as usize,

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -690,11 +690,9 @@ pub(super) fn apply_common_creation_options(
     include_transaction_args: bool,
 ) -> Command {
     if include_node_address {
-        subcommand = subcommand.arg(
-            common::node_address::arg(DisplayOrder::NodeAddress as usize)
-                .required_unless_present(show_simple_arg_examples::ARG_NAME)
-                .required_unless_present(show_json_args_examples::ARG_NAME),
-        );
+        subcommand = subcommand.arg(common::node_address::arg(
+            DisplayOrder::NodeAddress as usize,
+        ));
     }
 
     let secret_key_arg = if require_secret_key {

--- a/src/transaction/send.rs
+++ b/src/transaction/send.rs
@@ -28,7 +28,7 @@ impl ClientCommand for SendTransaction {
             ))
             .arg(common::rpc_id::arg(DisplayOrder::RpcId as usize))
             .arg(creation_common::speculative_exec::arg())
-            .arg(creation_common::transaction_path::arg())
+            .arg(creation_common::wasm_path::arg())
     }
 
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
@@ -36,7 +36,7 @@ impl ClientCommand for SendTransaction {
         let maybe_rpc_id = common::rpc_id::get(matches);
         let node_address = common::node_address::get(matches);
         let verbosity_level = common::verbose::get(matches);
-        let input_path = creation_common::transaction_path::get(matches).unwrap_or_default();
+        let input_path = creation_common::wasm_path::get(matches).unwrap_or_default();
         if input_path.is_empty() {
             return Err(CliError::InvalidArgument {
                 context: "send_deploy",

--- a/src/transaction/sign.rs
+++ b/src/transaction/sign.rs
@@ -23,7 +23,7 @@ impl ClientCommand for SignTransaction {
                 common::secret_key::arg(creation_common::DisplayOrder::SecretKey as usize, "")
                     .required(true),
             )
-            .arg(creation_common::transaction_path::arg())
+            .arg(creation_common::wasm_path::arg())
             .arg(creation_common::output::arg())
             .arg(common::force::arg(
                 creation_common::DisplayOrder::Force as usize,
@@ -32,7 +32,7 @@ impl ClientCommand for SignTransaction {
     }
 
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
-        let input_path = creation_common::transaction_path::get(matches).unwrap_or_default();
+        let input_path = creation_common::wasm_path::get(matches).unwrap_or_default();
         let secret_key = common::secret_key::get(matches).unwrap_or_default();
         let maybe_output_path = creation_common::output::get(matches).unwrap_or_default();
         let force = common::force::get(matches);


### PR DESCRIPTION
Also make sure network-address is always optional and uses a default value when necessary

Resolves https://github.com/casper-network/casper-node/issues/4482 https://github.com/casper-ecosystem/casper-client-rs/issues/230 https://github.com/casper-ecosystem/casper-client-rs/issues/227