### PR TITLE
Bump toolchain to 1.85

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.80.0"
+channel = "1.85.0"


### PR DESCRIPTION
Client does not compile anymore with 1.80

```
error: rustc 1.80.0 is not supported by the following packages:
  litemap@0.7.5 requires rustc 1.81
  zerofrom@0.1.6 requires rustc 1.81

