### PR TITLE
Add new subcommand `withdraw-bid-all`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "toml",
  "uint",
 ]
 
@@ -1944,6 +1945,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,6 +2249,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+dependencies = [
+ "indexmap 2.7.1",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tower"
@@ -2600,6 +2651,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn",
 ]
 
 [[package]]
@@ -252,8 +252,8 @@ dependencies = [
 
 [[package]]
 name = "casper-types"
-version = "5.0.0"
-source = "git+https://github.com/casper-network/casper-node.git?branch=dev#1e2c84ad674f3862fe71f7f6c8f6d429567f777a"
+version = "5.0.1"
+source = "git+https://github.com/casper-network/casper-node.git?branch=dev#1c3b8ad90bf0d83e73c73a6e6ddfc09f148b88b1"
 dependencies = [
  "base16",
  "base64 0.13.1",
@@ -345,10 +345,10 @@ version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn",
 ]
 
 [[package]]
@@ -471,7 +471,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn",
 ]
 
 [[package]]
@@ -494,7 +494,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.99",
+ "syn",
 ]
 
 [[package]]
@@ -535,7 +535,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn",
 ]
 
 [[package]]
@@ -627,7 +627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -832,6 +832,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -1097,7 +1103,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn",
 ]
 
 [[package]]
@@ -1342,7 +1348,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn",
 ]
 
 [[package]]
@@ -1430,7 +1436,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn",
 ]
 
 [[package]]
@@ -1542,7 +1548,7 @@ checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn",
 ]
 
 [[package]]
@@ -1739,7 +1745,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1836,7 +1842,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.99",
+ "syn",
 ]
 
 [[package]]
@@ -1917,7 +1923,7 @@ checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn",
 ]
 
 [[package]]
@@ -1928,7 +1934,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn",
 ]
 
 [[package]]
@@ -2047,24 +2053,24 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.24.3"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -2072,17 +2078,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -2112,7 +2107,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn",
 ]
 
 [[package]]
@@ -2157,7 +2152,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2177,7 +2172,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn",
 ]
 
 [[package]]
@@ -2214,7 +2209,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn",
 ]
 
 [[package]]
@@ -2481,7 +2476,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2516,7 +2511,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2702,7 +2697,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn",
  "synstructure",
 ]
 
@@ -2724,7 +2719,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn",
 ]
 
 [[package]]
@@ -2744,7 +2739,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn",
  "synstructure",
 ]
 
@@ -2773,5 +2768,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ async-trait = { version = "0.1.74", default-features = false, optional = true }
 base16 = "0.2.1"
 base64 = { version = "0.22.1", default-features = false }
 bytes = { version = "1.6.0", default-features = false }
-casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "dev" , features = ["std", "json-schema"] }
+casper-types = { version = "5.0.1", git = "https://github.com/casper-network/casper-node.git", branch = "dev" , features = ["std", "json-schema"] }
 clap = { version = "~4.4", features = ["cargo", "deprecated"], optional = true }
 clap_complete = { version = "~4.4", default-features = false, optional = true }
 flate2 = "1.0.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ tar = { version = "0.4.41", default-features = false }
 thiserror = "1"
 tokio = { version = "1.39.3", features = ["macros", "rt", "sync", "time"] }
 uint = "0.9.5"
+toml = "0.8.22"
 
 [dev-dependencies]
 tempfile = "3.8.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ async-trait = { version = "0.1.74", default-features = false, optional = true }
 base16 = "0.2.1"
 base64 = { version = "0.22.1", default-features = false }
 bytes = { version = "1.6.0", default-features = false }
-casper-types = { version = "5.0.0", features = ["std", "json-schema"] }
+casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "dev" , features = ["std", "json-schema"] }
 clap = { version = "~4.4", features = ["cargo", "deprecated"], optional = true }
 clap_complete = { version = "~4.4", default-features = false, optional = true }
 flate2 = "1.0.30"
@@ -57,7 +57,7 @@ uint = "0.9.5"
 
 [dev-dependencies]
 tempfile = "3.8.1"
-casper-types = { version = "5.0.0", features = ["std", "json-schema", "testing"] }
+casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "dev", features = ["std", "json-schema", "testing"] }
 
 [patch.crates-io]
 casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "dev" }

--- a/lib/cli.rs
+++ b/lib/cli.rs
@@ -92,7 +92,7 @@ pub use transaction::{
 };
 pub use transaction_builder_params::TransactionBuilderParams;
 pub use transaction_str_params::TransactionStrParams;
-pub(crate) use transaction_v1_builder::{TransactionV1Builder, TransactionV1BuilderError};
+pub use transaction_v1_builder::{TransactionV1Builder, TransactionV1BuilderError};
 
 /// Retrieves a [`casper_types::Deploy`] from the network.
 ///

--- a/lib/cli/error.rs
+++ b/lib/cli/error.rs
@@ -203,7 +203,11 @@ pub enum CliError {
 
     /// Attempting to withdraw bid will reduce stake below the minimum amount.
     #[error("Attempting to withdraw bid will reduce stake below the minimum amount.")]
-    ReducedStakeBelowMinAmount
+    ReducedStakeBelowMinAmount,
+
+    /// Failed to parse the chainspec as raw bytes.
+    #[error("Failed to parse the chainspec as raw bytes")]
+    FailedToParseChainspecBytes
 }
 
 impl From<CLValueError> for CliError {

--- a/lib/cli/error.rs
+++ b/lib/cli/error.rs
@@ -207,7 +207,7 @@ pub enum CliError {
 
     /// Failed to parse the chainspec as raw bytes.
     #[error("Failed to parse the chainspec as raw bytes")]
-    FailedToParseChainspecBytes
+    FailedToParseChainspecBytes,
 }
 
 impl From<CLValueError> for CliError {

--- a/lib/cli/error.rs
+++ b/lib/cli/error.rs
@@ -196,6 +196,14 @@ pub enum CliError {
     /// Unexpected transaction args variant.
     #[error("Unexpected transaction args variant")]
     UnexpectedTransactionArgsVariant,
+
+    /// Failed to get auction info to determine validator stake.
+    #[error("Failed to get auction state")]
+    FailedToGetAuctionState,
+
+    /// Attempting to withdraw bid will reduce stake below the minimum amount.
+    #[error("Attempting to withdraw bid will reduce stake below the minimum amount.")]
+    ReducedStakeBelowMinAmount
 }
 
 impl From<CLValueError> for CliError {

--- a/lib/cli/error.rs
+++ b/lib/cli/error.rs
@@ -208,6 +208,10 @@ pub enum CliError {
     /// Failed to parse the chainspec as raw bytes.
     #[error("Failed to parse the chainspec as raw bytes")]
     FailedToParseChainspecBytes,
+
+    /// Missing major version.
+    #[error("Major version is missing when specifying entity version")]
+    MissingMajorVersion,
 }
 
 impl From<CLValueError> for CliError {

--- a/lib/cli/tests.rs
+++ b/lib/cli/tests.rs
@@ -489,9 +489,7 @@ mod transaction {
                     ]
                   },
                   "entry_point": "AddBid",
-                  "scheduling": {
-                    "FutureEra": 195120
-                  },
+                  "scheduling": "Standard",
                   "target": "Native"
                 }
             },
@@ -759,7 +757,7 @@ mod transaction {
         let transaction_string_params = transaction_str_params;
 
         let transaction_builder_params =
-            TransactionBuilderParams::WithdrawBid { public_key, amount };
+            TransactionBuilderParams::WithdrawBid { public_key, amount, min_bid_override: true };
 
         let transaction =
             create_transaction(transaction_builder_params, transaction_string_params, true);
@@ -1270,12 +1268,13 @@ mod transaction {
     fn should_create_package_transaction() {
         let package_addr: PackageAddr = vec![0u8; 32].as_slice().try_into().unwrap();
         let entry_point = "test-entry-point-package";
-        let maybe_entity_version = Some(23);
+        let maybe_entity_version = None;
         let params = TransactionRuntimeParams::VmCasperV1;
         let target = &TransactionTarget::Stored {
             id: TransactionInvocationTarget::ByPackageHash {
                 addr: package_addr,
                 version: maybe_entity_version,
+                version_key: None,
             },
             runtime: params,
         };
@@ -1334,6 +1333,7 @@ mod transaction {
             id: TransactionInvocationTarget::ByPackageName {
                 name: package_name.clone(),
                 version: maybe_entity_version,
+                version_key: None,
             },
             runtime: params,
         };

--- a/lib/cli/tests.rs
+++ b/lib/cli/tests.rs
@@ -756,8 +756,11 @@ mod transaction {
         };
         let transaction_string_params = transaction_str_params;
 
-        let transaction_builder_params =
-            TransactionBuilderParams::WithdrawBid { public_key, amount, min_bid_override: true };
+        let transaction_builder_params = TransactionBuilderParams::WithdrawBid {
+            public_key,
+            amount,
+            min_bid_override: true,
+        };
 
         let transaction =
             create_transaction(transaction_builder_params, transaction_string_params, true);

--- a/lib/cli/transaction.rs
+++ b/lib/cli/transaction.rs
@@ -343,7 +343,7 @@ pub fn make_transaction_builder(
 
             Ok(transaction_builder)
         }
-        TransactionBuilderParams::WithdrawBid { public_key, amount } => {
+        TransactionBuilderParams::WithdrawBid { public_key, amount , .. } => {
             let transaction_builder = TransactionV1Builder::new_withdraw_bid(public_key, amount)?;
             Ok(transaction_builder)
         }

--- a/lib/cli/transaction.rs
+++ b/lib/cli/transaction.rs
@@ -307,6 +307,20 @@ pub fn make_transaction_builder(
             );
             Ok(transaction_builder)
         }
+        TransactionBuilderParams::PackageWithVersionKey {
+            package_hash,
+            maybe_entity_version_key,
+            entry_point,
+            runtime,
+        } => {
+            let transaction_builder = TransactionV1Builder::new_targeting_package_with_version_key(
+                package_hash,
+                maybe_entity_version_key,
+                entry_point,
+                runtime,
+            );
+            Ok(transaction_builder)
+        }
         TransactionBuilderParams::PackageAlias {
             package_alias,
             maybe_entity_version,
@@ -317,6 +331,22 @@ pub fn make_transaction_builder(
                 TransactionV1Builder::new_targeting_package_via_alias(
                     package_alias,
                     maybe_entity_version,
+                    entry_point,
+                    runtime,
+                );
+            let transaction_builder = new_targeting_package_via_alias;
+            Ok(transaction_builder)
+        }
+        TransactionBuilderParams::PackageAliasWithVersionKey {
+            package_alias,
+            maybe_entity_version_key,
+            entry_point,
+            runtime,
+        } => {
+            let new_targeting_package_via_alias =
+                TransactionV1Builder::new_targeting_package_via_alias_with_version_key(
+                    package_alias,
+                    maybe_entity_version_key,
                     entry_point,
                     runtime,
                 );

--- a/lib/cli/transaction.rs
+++ b/lib/cli/transaction.rs
@@ -343,7 +343,9 @@ pub fn make_transaction_builder(
 
             Ok(transaction_builder)
         }
-        TransactionBuilderParams::WithdrawBid { public_key, amount , .. } => {
+        TransactionBuilderParams::WithdrawBid {
+            public_key, amount, ..
+        } => {
             let transaction_builder = TransactionV1Builder::new_withdraw_bid(public_key, amount)?;
             Ok(transaction_builder)
         }

--- a/lib/cli/transaction_builder_params.rs
+++ b/lib/cli/transaction_builder_params.rs
@@ -1,4 +1,9 @@
-use casper_types::{bytesrepr::Bytes, system::auction::{DelegatorKind, Reservation}, AddressableEntityHash, PackageHash, PublicKey, TransactionRuntimeParams, TransferTarget, URef, U512, EntityVersionKey};
+use casper_types::{
+    bytesrepr::Bytes,
+    system::auction::{DelegatorKind, Reservation},
+    AddressableEntityHash, EntityVersionKey, PackageHash, PublicKey, TransactionRuntimeParams,
+    TransferTarget, URef, U512,
+};
 
 /// An enum representing the parameters needed to construct a transaction builder
 /// for the commands concerning the creation of a transaction

--- a/lib/cli/transaction_builder_params.rs
+++ b/lib/cli/transaction_builder_params.rs
@@ -139,6 +139,8 @@ pub enum TransactionBuilderParams<'a> {
         public_key: PublicKey,
         /// The amount to be withdrawn in the withdraw bid transaction
         amount: U512,
+        /// Override the min bid amount check
+        min_bid_override: bool,
     },
     /// Parameters for the activate bid variant of the transaction builder
     ActivateBid {

--- a/lib/cli/transaction_builder_params.rs
+++ b/lib/cli/transaction_builder_params.rs
@@ -1,9 +1,4 @@
-use casper_types::{
-    bytesrepr::Bytes,
-    system::auction::{DelegatorKind, Reservation},
-    AddressableEntityHash, PackageHash, PublicKey, TransactionRuntimeParams, TransferTarget, URef,
-    U512,
-};
+use casper_types::{bytesrepr::Bytes, system::auction::{DelegatorKind, Reservation}, AddressableEntityHash, PackageHash, PublicKey, TransactionRuntimeParams, TransferTarget, URef, U512, EntityVersionKey};
 
 /// An enum representing the parameters needed to construct a transaction builder
 /// for the commands concerning the creation of a transaction
@@ -102,12 +97,34 @@ pub enum TransactionBuilderParams<'a> {
         /// Transaction Runtime.
         runtime: TransactionRuntimeParams,
     },
+    /// Parameters for the package variant of the transaction builder
+    PackageWithVersionKey {
+        /// The package hash for the package transaction
+        package_hash: PackageHash,
+        /// The optional entity version for the package transaction
+        maybe_entity_version_key: Option<EntityVersionKey>,
+        /// The entry_point for the package transaction
+        entry_point: &'a str,
+        /// Transaction Runtime.
+        runtime: TransactionRuntimeParams,
+    },
     /// Parameters for the package alias variant of the transaction builder
     PackageAlias {
         /// The package alias for the package alias transaction
         package_alias: &'a str,
         /// The optional entity version for the package alias transaction
         maybe_entity_version: Option<u32>,
+        /// The entry point for the package alias transaction
+        entry_point: &'a str,
+        /// Transaction Runtime params.
+        runtime: TransactionRuntimeParams,
+    },
+    /// Parameters for the package alias variant of the transaction builder
+    PackageAliasWithVersionKey {
+        /// The package alias for the package alias transaction
+        package_alias: &'a str,
+        /// The optional entity version for the package alias transaction
+        maybe_entity_version_key: Option<EntityVersionKey>,
         /// The entry point for the package alias transaction
         entry_point: &'a str,
         /// Transaction Runtime params.

--- a/lib/cli/transaction_v1_builder.rs
+++ b/lib/cli/transaction_v1_builder.rs
@@ -7,15 +7,7 @@ use crate::{
 use alloc::collections::BTreeMap;
 use alloc::collections::BTreeSet;
 use alloc::vec::Vec;
-use casper_types::{
-    bytesrepr::{Bytes, ToBytes},
-    system::auction::{DelegatorKind, Reservation},
-    AddressableEntityHash, CLValueError, Digest, EntityVersion, InitiatorAddr, PackageHash,
-    PricingMode, PublicKey, RuntimeArgs, SecretKey, TimeDiff, Timestamp, TransactionArgs,
-    TransactionEntryPoint, TransactionInvocationTarget, TransactionRuntimeParams,
-    TransactionScheduling, TransactionTarget, TransactionV1, TransactionV1Payload, TransferTarget,
-    URef, U512,
-};
+use casper_types::{bytesrepr::{Bytes, ToBytes}, system::auction::{DelegatorKind, Reservation}, AddressableEntityHash, CLValueError, Digest, EntityVersion, InitiatorAddr, PackageHash, PricingMode, PublicKey, RuntimeArgs, SecretKey, TimeDiff, Timestamp, TransactionArgs, TransactionEntryPoint, TransactionInvocationTarget, TransactionRuntimeParams, TransactionScheduling, TransactionTarget, TransactionV1, TransactionV1Payload, TransferTarget, URef, U512, EntityVersionKey};
 use core::marker::PhantomData;
 pub use error::TransactionV1BuilderError;
 
@@ -364,6 +356,18 @@ impl<'a> TransactionV1Builder<'a> {
     }
 
     /// Returns a new `TransactionV1Builder` suitable for building a transaction targeting a
+    /// package.
+    pub fn new_targeting_package_with_version_key<E: Into<String>>(
+        hash: PackageHash,
+        version: Option<EntityVersionKey>,
+        entry_point: E,
+        runtime: TransactionRuntimeParams,
+    ) -> Self {
+        let id = TransactionInvocationTarget::new_package_with_key(hash, version);
+        Self::new_targeting_stored(id, entry_point, runtime)
+    }
+
+    /// Returns a new `TransactionV1Builder` suitable for building a transaction targeting a
     /// package via its alias.
     pub fn new_targeting_package_via_alias<A: Into<String>, E: Into<String>>(
         alias: A,
@@ -373,6 +377,18 @@ impl<'a> TransactionV1Builder<'a> {
     ) -> Self {
         #[allow(deprecated)]
         let id = TransactionInvocationTarget::new_package_alias(alias.into(), version);
+        Self::new_targeting_stored(id, entry_point, runtime)
+    }
+
+    /// Returns a new `TransactionV1Builder` suitable for building a transaction targeting a
+    /// package via its alias.
+    pub fn new_targeting_package_via_alias_with_version_key<A: Into<String>, E: Into<String>>(
+        alias: A,
+        version: Option<EntityVersionKey>,
+        entry_point: E,
+        runtime: TransactionRuntimeParams,
+    ) -> Self {
+        let id = TransactionInvocationTarget::new_package_alias_with_key(alias.into(), version);
         Self::new_targeting_stored(id, entry_point, runtime)
     }
 

--- a/lib/cli/transaction_v1_builder.rs
+++ b/lib/cli/transaction_v1_builder.rs
@@ -7,7 +7,15 @@ use crate::{
 use alloc::collections::BTreeMap;
 use alloc::collections::BTreeSet;
 use alloc::vec::Vec;
-use casper_types::{bytesrepr::{Bytes, ToBytes}, system::auction::{DelegatorKind, Reservation}, AddressableEntityHash, CLValueError, Digest, EntityVersion, InitiatorAddr, PackageHash, PricingMode, PublicKey, RuntimeArgs, SecretKey, TimeDiff, Timestamp, TransactionArgs, TransactionEntryPoint, TransactionInvocationTarget, TransactionRuntimeParams, TransactionScheduling, TransactionTarget, TransactionV1, TransactionV1Payload, TransferTarget, URef, U512, EntityVersionKey};
+use casper_types::{
+    bytesrepr::{Bytes, ToBytes},
+    system::auction::{DelegatorKind, Reservation},
+    AddressableEntityHash, CLValueError, Digest, EntityVersion, EntityVersionKey, InitiatorAddr,
+    PackageHash, PricingMode, PublicKey, RuntimeArgs, SecretKey, TimeDiff, Timestamp,
+    TransactionArgs, TransactionEntryPoint, TransactionInvocationTarget, TransactionRuntimeParams,
+    TransactionScheduling, TransactionTarget, TransactionV1, TransactionV1Payload, TransferTarget,
+    URef, U512,
+};
 use core::marker::PhantomData;
 pub use error::TransactionV1BuilderError;
 

--- a/lib/cli/transaction_v1_builder.rs
+++ b/lib/cli/transaction_v1_builder.rs
@@ -358,6 +358,7 @@ impl<'a> TransactionV1Builder<'a> {
         entry_point: E,
         runtime: TransactionRuntimeParams,
     ) -> Self {
+        #[allow(deprecated)]
         let id = TransactionInvocationTarget::new_package(hash, version);
         Self::new_targeting_stored(id, entry_point, runtime)
     }
@@ -370,6 +371,7 @@ impl<'a> TransactionV1Builder<'a> {
         entry_point: E,
         runtime: TransactionRuntimeParams,
     ) -> Self {
+        #[allow(deprecated)]
         let id = TransactionInvocationTarget::new_package_alias(alias.into(), version);
         Self::new_targeting_stored(id, entry_point, runtime)
     }

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -1220,11 +1220,8 @@ pub(super) mod major_version {
             .display_order(DisplayOrder::MajorVersion as usize)
     }
 
-    pub fn get(matches: &ArgMatches) -> u32 {
-        matches
-            .get_one::<u32>(ARG_NAME)
-            .map(get_deref_helper)
-            .unwrap_or_default()
+    pub fn get(matches: &ArgMatches) -> Option<u32> {
+        matches.get_one::<u32>(ARG_NAME).map(get_deref_helper)
     }
 
     fn get_deref_helper(get_result: &u32) -> u32 {
@@ -2285,8 +2282,10 @@ pub(super) mod package {
         let runtime = get_transaction_runtime(matches)?;
 
         let maybe_entity_version_key = if let Some(entity_version) = maybe_entity_version {
-            let major = major_version::get(matches);
-            Some(EntityVersionKey::new(major, entity_version))
+            match major_version::get(matches) {
+                Some(major) => Some(EntityVersionKey::new(major, entity_version)),
+                None => return Err(CliError::MissingMajorVersion),
+            }
         } else {
             None
         };
@@ -2347,8 +2346,10 @@ pub(super) mod package_alias {
         let maybe_entity_version = session_version::get(matches);
 
         let maybe_entity_version_key = if let Some(entity_version) = maybe_entity_version {
-            let major = major_version::get(matches);
-            Some(EntityVersionKey::new(major, entity_version))
+            match major_version::get(matches) {
+                Some(major) => Some(EntityVersionKey::new(major, entity_version)),
+                None => return Err(CliError::MissingMajorVersion),
+            }
         } else {
             None
         };

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -63,6 +63,7 @@ pub(super) enum DisplayOrder {
     EntityAddr,
     ContractHash,
     MinBidOverride,
+    MajorVersion,
     RpcId,
     Verbose,
 }
@@ -1201,6 +1202,33 @@ pub(super) mod session_version {
         *get_result
     }
 }
+
+pub(super) mod major_version {
+    use super::*;
+
+    pub const ARG_NAME: &str = "major-version";
+    const ARG_VALUE_NAME: &str = common::ARG_INTEGER;
+    const ARG_HELP: &str = "The major version of the called session contract. Required if specifying a version";
+
+    pub fn arg() -> Arg {
+        Arg::new(ARG_NAME)
+            .long(ARG_NAME)
+            .value_name(ARG_VALUE_NAME)
+            .help(ARG_HELP)
+            .required(false)
+            .display_order(DisplayOrder::MajorVersion as usize)
+    }
+
+    pub fn get(matches: &ArgMatches) -> u32 {
+        matches.get_one::<u32>(ARG_NAME).map(get_deref_helper).unwrap_or_default()
+    }
+
+    fn get_deref_helper(get_result: &u32) -> u32 {
+        *get_result
+    }
+}
+
+
 mod package_name_arg {
     use super::*;
 
@@ -2212,6 +2240,7 @@ pub(super) mod invocable_entity_alias {
 }
 
 pub(super) mod package {
+    use casper_types::EntityVersionKey;
     use super::*;
     use casper_client::cli::{CliError, TransactionBuilderParams};
 
@@ -2252,10 +2281,17 @@ pub(super) mod package {
         let maybe_entity_version = session_version::get(matches);
         let runtime = get_transaction_runtime(matches)?;
 
+        let maybe_entity_version_key = if let Some(entity_version) = maybe_entity_version {
+            let major = major_version::get(matches);
+            Some(EntityVersionKey::new(major, entity_version))
+        } else {
+            None
+        };
+
         let entry_point = session_entry_point::get(matches).unwrap_or_default();
-        let params = TransactionBuilderParams::Package {
+        let params = TransactionBuilderParams::PackageWithVersionKey {
             package_hash: package_addr.into(), // TODO: Skip `package_addr` and match directly for hash?
-            maybe_entity_version,
+            maybe_entity_version_key,
             entry_point,
             runtime,
         };
@@ -2268,11 +2304,13 @@ pub(super) mod package {
             .arg(package_addr::arg().required_unless_present(contract_package_hash::ARG_NAME))
             .arg(contract_package_hash::arg())
             .arg(session_version::arg())
+            .arg(major_version::arg())
             .arg(session_entry_point::arg())
     }
 }
 
 pub(super) mod package_alias {
+    use casper_types::EntityVersionKey;
     use super::*;
     use casper_client::cli::{CliError, TransactionBuilderParams};
 
@@ -2305,12 +2343,19 @@ pub(super) mod package_alias {
 
         let maybe_entity_version = session_version::get(matches);
 
+        let maybe_entity_version_key = if let Some(entity_version) = maybe_entity_version {
+            let major = major_version::get(matches);
+            Some(EntityVersionKey::new(major, entity_version))
+        } else {
+            None
+        };
+
         let entry_point = session_entry_point::get(matches).unwrap_or_default();
         let runtime = get_transaction_runtime(matches)?;
 
-        let params = TransactionBuilderParams::PackageAlias {
+        let params = TransactionBuilderParams::PackageAliasWithVersionKey {
             package_alias,
-            maybe_entity_version,
+            maybe_entity_version_key,
             entry_point,
             runtime,
         };
@@ -2322,6 +2367,7 @@ pub(super) mod package_alias {
         package_alias_subcommand
             .arg(package_name_arg::arg())
             .arg(session_version::arg())
+            .arg(major_version::arg())
             .arg(session_entry_point::arg())
     }
 }

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -6,7 +6,7 @@ use std::process;
 use clap::{Arg, ArgAction, ArgGroup, ArgMatches, Command};
 
 use casper_client::cli::{
-    json_args_help, simple_args_help, CliError, TransactionBuilderParams, TransactionStrParams,
+    json_args_help, simple_args_help, CliError, TransactionStrParams,
 };
 use casper_types::TransactionRuntimeParams;
 use transaction_runtime::TransactionRuntime;

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -1208,7 +1208,8 @@ pub(super) mod major_version {
 
     pub const ARG_NAME: &str = "major-version";
     const ARG_VALUE_NAME: &str = common::ARG_INTEGER;
-    const ARG_HELP: &str = "The major version of the called session contract. Required if specifying a version";
+    const ARG_HELP: &str =
+        "The major version of the called session contract. Required if specifying a version";
 
     pub fn arg() -> Arg {
         Arg::new(ARG_NAME)
@@ -1220,14 +1221,16 @@ pub(super) mod major_version {
     }
 
     pub fn get(matches: &ArgMatches) -> u32 {
-        matches.get_one::<u32>(ARG_NAME).map(get_deref_helper).unwrap_or_default()
+        matches
+            .get_one::<u32>(ARG_NAME)
+            .map(get_deref_helper)
+            .unwrap_or_default()
     }
 
     fn get_deref_helper(get_result: &u32) -> u32 {
         *get_result
     }
 }
-
 
 mod package_name_arg {
     use super::*;
@@ -2240,9 +2243,9 @@ pub(super) mod invocable_entity_alias {
 }
 
 pub(super) mod package {
-    use casper_types::EntityVersionKey;
     use super::*;
     use casper_client::cli::{CliError, TransactionBuilderParams};
+    use casper_types::EntityVersionKey;
 
     pub const NAME: &str = "package";
 
@@ -2310,9 +2313,9 @@ pub(super) mod package {
 }
 
 pub(super) mod package_alias {
-    use casper_types::EntityVersionKey;
     use super::*;
     use casper_client::cli::{CliError, TransactionBuilderParams};
+    use casper_types::EntityVersionKey;
 
     pub const NAME: &str = "package-name";
 

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -64,6 +64,7 @@ pub(super) enum DisplayOrder {
     Delegator,
     EntityAddr,
     ContractHash,
+    MinBidOverride,
     RpcId,
     Verbose,
 }
@@ -926,7 +927,7 @@ pub(super) mod public_key {
         common::public_key::try_read_from_file(value)
     }
 
-    pub(super) fn parse_public_key(value: &str) -> Result<PublicKey, CliError> {
+    pub(crate) fn parse_public_key(value: &str) -> Result<PublicKey, CliError> {
         let public_key =
             PublicKey::from_hex(value).map_err(|error| casper_client::Error::CryptoError {
                 context: "session account",
@@ -974,6 +975,28 @@ pub(super) mod new_public_key {
             })?;
         Ok(public_key)
     }
+}
+
+pub(super) mod min_bid_override {
+    use super::*;
+
+    const ARG_NAME: &str = "min-bid-override";
+
+    const ARG_HELP: &str = "Flag to override the min bid staking amount check";
+
+    pub fn arg() -> Arg {
+        Arg::new(ARG_NAME)
+            .long(ARG_NAME)
+            .required(false)
+            .action(ArgAction::SetTrue)
+            .help(ARG_HELP)
+            .display_order(DisplayOrder::MinBidOverride as usize)
+    }
+
+    pub fn get(matches: &ArgMatches) -> bool {
+        matches.get_flag(ARG_NAME)
+    }
+
 }
 
 pub(super) mod entity_addr {
@@ -1689,6 +1712,49 @@ pub(super) mod activate_bid {
     }
 }
 
+pub(super) mod withdraw_bid_all {
+    use casper_types::U512;
+    use super::*;
+    use crate::cli::TransactionBuilderParams;
+    use casper_client::cli::CliError;
+
+    pub const NAME: &str = "withdraw-bid-all";
+
+    const ACCEPT_SESSION_ARGS: bool = false;
+
+    const ABOUT: &str = "Creates a new withdraw-bid transaction which completely unbonds the validator";
+    pub fn build() -> Command {
+        apply_common_creation_options(
+            add_args(Command::new(NAME).about(ABOUT)),
+            false,
+            false,
+            ACCEPT_SESSION_ARGS,
+        )
+    }
+
+    pub fn put_transaction_build() -> Command {
+        add_rpc_args(build())
+    }
+
+    pub fn run(
+        matches: &ArgMatches,
+        amount: U512,
+    ) -> Result<(TransactionBuilderParams, TransactionStrParams), CliError> {
+        let public_key_str = public_key::get(matches)?;
+        let public_key = public_key::parse_public_key(&public_key_str)?;
+
+        let params = TransactionBuilderParams::WithdrawBid { public_key, amount , min_bid_override: true };
+        let transaction_str_params = build_transaction_str_params(matches, ACCEPT_SESSION_ARGS);
+
+        Ok((params, transaction_str_params))
+    }
+
+    fn add_args(withdraw_bid_subcommand: Command) -> Command {
+        withdraw_bid_subcommand
+            .arg(public_key::arg(DisplayOrder::PublicKey as usize))
+    }
+}
+
 pub(super) mod withdraw_bid {
     use super::*;
     use crate::cli::TransactionBuilderParams;
@@ -1721,7 +1787,9 @@ pub(super) mod withdraw_bid {
         let amount_str = transaction_amount::get(matches);
         let amount = transaction_amount::parse_transaction_amount(amount_str)?;
 
-        let params = TransactionBuilderParams::WithdrawBid { public_key, amount };
+        let min_bid_override = min_bid_override::get(matches);
+
+        let params = TransactionBuilderParams::WithdrawBid { public_key, amount, min_bid_override};
         let transaction_str_params = build_transaction_str_params(matches, ACCEPT_SESSION_ARGS);
 
         Ok((params, transaction_str_params))
@@ -1730,6 +1798,7 @@ pub(super) mod withdraw_bid {
     fn add_args(withdraw_bid_subcommand: Command) -> Command {
         withdraw_bid_subcommand
             .arg(public_key::arg(DisplayOrder::PublicKey as usize))
+            .arg(min_bid_override::arg())
             .arg(transaction_amount::arg())
     }
 }
@@ -2553,34 +2622,7 @@ pub(super) fn add_rpc_args(subcommand: Command) -> Command {
         .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
 }
 
-pub(super) fn parse_rpc_args_and_run(
-    matches: &ArgMatches,
-    subcommand_run: fn(
-        &ArgMatches,
-    ) -> Result<(TransactionBuilderParams, TransactionStrParams), CliError>,
-) -> Result<
-    (
-        TransactionBuilderParams,
-        TransactionStrParams,
-        &str,
-        &str,
-        u64,
-    ),
-    CliError,
-> {
-    let node_address = common::node_address::get(matches);
-    let rpc_id = common::rpc_id::get(matches);
-    let verbosity_level = common::verbose::get(matches);
 
-    let (transaction_builder_params, transaction_str_params) = subcommand_run(matches)?;
-    Ok((
-        transaction_builder_params,
-        transaction_str_params,
-        node_address,
-        rpc_id,
-        verbosity_level,
-    ))
-}
 
 fn get_transaction_runtime(matches: &ArgMatches) -> Result<TransactionRuntimeParams, CliError> {
     let runtime_tag = transaction_runtime::get(matches)

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -2,6 +2,7 @@
 //! creating transactions.
 
 use std::process;
+use std::str::FromStr;
 
 use clap::{Arg, ArgAction, ArgGroup, ArgMatches, Command};
 
@@ -64,6 +65,7 @@ pub(super) enum DisplayOrder {
     ContractHash,
     MinBidOverride,
     MajorVersion,
+    TransactionRuntime,
     RpcId,
     Verbose,
 }
@@ -600,7 +602,7 @@ pub(super) mod transaction_runtime {
             .value_name(ARG_VALUE_NAME)
             .default_value(ARG_DEFAULT)
             .help(ARG_HELP)
-            .display_order(DisplayOrder::PricingMode as usize)
+            .display_order(DisplayOrder::TransactionRuntime as usize)
             .value_parser(value_parser!(TransactionRuntime))
     }
 
@@ -1178,6 +1180,17 @@ pub(super) mod session_entry_point {
     }
 }
 
+fn parse_arg_to_int<T: FromStr<Err = std::num::ParseIntError>>(value: &str, context: &'static str) -> Result<T, CliError>
+{
+    value
+        .parse()
+        .map_err(move |err| CliError::FailedToParseInt {
+            context,
+            error: err,
+        })
+}
+
+
 pub(super) mod session_version {
     use super::*;
 
@@ -1195,7 +1208,10 @@ pub(super) mod session_version {
     }
 
     pub fn get(matches: &ArgMatches) -> Option<u32> {
-        matches.get_one::<u32>(ARG_NAME).map(get_deref_helper)
+        match matches.get_one::<String>(ARG_NAME) {
+            Some(arg) => parse_arg_to_int(arg, "session-version").ok(),
+            None => None,
+        }
     }
 
     fn get_deref_helper(get_result: &u32) -> u32 {
@@ -1221,7 +1237,10 @@ pub(super) mod major_version {
     }
 
     pub fn get(matches: &ArgMatches) -> Option<u32> {
-        matches.get_one::<u32>(ARG_NAME).map(get_deref_helper)
+        match matches.get_one::<String>(ARG_NAME) {
+            Some(arg) => parse_arg_to_int(arg, "major-version").ok(),
+            None => None,
+        }
     }
 
     fn get_deref_helper(get_result: &u32) -> u32 {
@@ -2306,6 +2325,9 @@ pub(super) mod package {
             .arg(package_addr::arg().required_unless_present(contract_package_hash::ARG_NAME))
             .arg(contract_package_hash::arg())
             .arg(session_version::arg())
+            .arg(transaction_runtime::arg())
+            .arg(transferred_value::arg())
+            .arg(chunked_args::arg())
             .arg(major_version::arg())
             .arg(session_entry_point::arg())
     }
@@ -2371,6 +2393,9 @@ pub(super) mod package_alias {
         package_alias_subcommand
             .arg(package_name_arg::arg())
             .arg(session_version::arg())
+            .arg(transaction_runtime::arg())
+            .arg(transferred_value::arg())
+            .arg(chunked_args::arg())
             .arg(major_version::arg())
             .arg(session_entry_point::arg())
     }

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -1180,8 +1180,10 @@ pub(super) mod session_entry_point {
     }
 }
 
-fn parse_arg_to_int<T: FromStr<Err = std::num::ParseIntError>>(value: &str, context: &'static str) -> Result<T, CliError>
-{
+fn parse_arg_to_int<T: FromStr<Err = std::num::ParseIntError>>(
+    value: &str,
+    context: &'static str,
+) -> Result<T, CliError> {
     value
         .parse()
         .map_err(move |err| CliError::FailedToParseInt {
@@ -1189,7 +1191,6 @@ fn parse_arg_to_int<T: FromStr<Err = std::num::ParseIntError>>(value: &str, cont
             error: err,
         })
 }
-
 
 pub(super) mod session_version {
     use super::*;

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -5,9 +5,7 @@ use std::process;
 
 use clap::{Arg, ArgAction, ArgGroup, ArgMatches, Command};
 
-use casper_client::cli::{
-    json_args_help, simple_args_help, CliError, TransactionStrParams,
-};
+use casper_client::cli::{json_args_help, simple_args_help, CliError, TransactionStrParams};
 use casper_types::TransactionRuntimeParams;
 use transaction_runtime::TransactionRuntime;
 
@@ -996,7 +994,6 @@ pub(super) mod min_bid_override {
     pub fn get(matches: &ArgMatches) -> bool {
         matches.get_flag(ARG_NAME)
     }
-
 }
 
 pub(super) mod entity_addr {
@@ -1713,16 +1710,17 @@ pub(super) mod activate_bid {
 }
 
 pub(super) mod withdraw_bid_all {
-    use casper_types::U512;
     use super::*;
     use crate::cli::TransactionBuilderParams;
     use casper_client::cli::CliError;
+    use casper_types::U512;
 
     pub const NAME: &str = "withdraw-bid-all";
 
     const ACCEPT_SESSION_ARGS: bool = false;
 
-    const ABOUT: &str = "Creates a new withdraw-bid transaction which completely unbonds the validator";
+    const ABOUT: &str =
+        "Creates a new withdraw-bid transaction which completely unbonds the validator";
     pub fn build() -> Command {
         apply_common_creation_options(
             add_args(Command::new(NAME).about(ABOUT)),
@@ -1743,15 +1741,18 @@ pub(super) mod withdraw_bid_all {
         let public_key_str = public_key::get(matches)?;
         let public_key = public_key::parse_public_key(&public_key_str)?;
 
-        let params = TransactionBuilderParams::WithdrawBid { public_key, amount , min_bid_override: true };
+        let params = TransactionBuilderParams::WithdrawBid {
+            public_key,
+            amount,
+            min_bid_override: true,
+        };
         let transaction_str_params = build_transaction_str_params(matches, ACCEPT_SESSION_ARGS);
 
         Ok((params, transaction_str_params))
     }
 
     fn add_args(withdraw_bid_subcommand: Command) -> Command {
-        withdraw_bid_subcommand
-            .arg(public_key::arg(DisplayOrder::PublicKey as usize))
+        withdraw_bid_subcommand.arg(public_key::arg(DisplayOrder::PublicKey as usize))
     }
 }
 
@@ -1789,7 +1790,11 @@ pub(super) mod withdraw_bid {
 
         let min_bid_override = min_bid_override::get(matches);
 
-        let params = TransactionBuilderParams::WithdrawBid { public_key, amount, min_bid_override};
+        let params = TransactionBuilderParams::WithdrawBid {
+            public_key,
+            amount,
+            min_bid_override,
+        };
         let transaction_str_params = build_transaction_str_params(matches, ACCEPT_SESSION_ARGS);
 
         Ok((params, transaction_str_params))
@@ -2621,8 +2626,6 @@ pub(super) fn add_rpc_args(subcommand: Command) -> Command {
         ))
         .arg(common::verbose::arg(DisplayOrder::Verbose as usize))
 }
-
-
 
 fn get_transaction_runtime(matches: &ArgMatches) -> Result<TransactionRuntimeParams, CliError> {
     let runtime_tag = transaction_runtime::get(matches)

--- a/src/transaction/put.rs
+++ b/src/transaction/put.rs
@@ -9,9 +9,6 @@ use super::creation_common::{activate_bid, add_bid, add_reservations, cancel_res
 
 use crate::{command::ClientCommand, Success, common};
 
-// TODO: Remove this constant and use the chainspec instead.
-const MINIMUM_BID_AMOUNT: u64 = 10_000_000_000_000u64;
-
 #[derive(PartialEq, Eq, Serialize, Deserialize, Debug)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
@@ -204,6 +201,19 @@ async fn put_withdraw_bid_transaction(matches: &ArgMatches) -> Result<Success, C
     let (transaction_builder_params, transaction_str_params) = withdraw_bid::run(matches)?;
 
     if let TransactionBuilderParams::WithdrawBid {  public_key, amount, min_bid_override } = &transaction_builder_params {
+
+        let chainspec_bytes =  casper_client::cli::get_chainspec("", node_address, verbosity_level).await?
+            .result
+            .chainspec_bytes;
+
+        let chainspec_as_str = std::str::from_utf8(chainspec_bytes.chainspec_bytes()).unwrap();
+        let toml_chainspec: TomlChainspec = toml::from_str(chainspec_as_str)
+            .unwrap();
+
+        let minimum_validator_bid = toml_chainspec
+            .core
+            .minimum_bid_amount;
+
         match casper_client::cli::get_auction_info("", node_address, verbosity_level, "")
             .await?
             .result
@@ -213,10 +223,12 @@ async fn put_withdraw_bid_transaction(matches: &ArgMatches) -> Result<Success, C
             Some((_, bid)) => {
                 let staked_amount = *bid.staked_amount();
                 let remainder = staked_amount.saturating_sub(*amount);
-                if remainder < U512::from(MINIMUM_BID_AMOUNT) && !min_bid_override {
-                    return Err(CliError::ReducedStakeBelowMinAmount)
-                } else {
-                    println!("amount will cause unbonding of all stake")
+                if remainder < U512::from(minimum_validator_bid) {
+                    if !min_bid_override {
+                        return Err(CliError::ReducedStakeBelowMinAmount)
+                    } else {
+                        println!("amount will cause unbonding of all stake")
+                    }
                 }
             },
             None => {

--- a/src/transaction/put.rs
+++ b/src/transaction/put.rs
@@ -1,17 +1,14 @@
 use async_trait::async_trait;
+use casper_types::bytesrepr::{FromBytes};
+use casper_types::{Chainspec, U512};
 use clap::{ArgMatches, Command};
 
-use casper_client::cli::CliError;
 
-use super::creation_common::{
-    activate_bid, add_bid, add_reservations, cancel_reservations, change_bid_public_key, delegate,
-    invocable_entity, invocable_entity_alias, package, package_alias, redelegate, session,
-    transfer, undelegate, withdraw_bid,
-};
+use casper_client::cli::{CliError, TransactionBuilderParams};
 
-use crate::{
-    command::ClientCommand, transaction::creation_common::parse_rpc_args_and_run, Success,
-};
+use super::creation_common::{activate_bid, add_bid, add_reservations, cancel_reservations, change_bid_public_key, delegate, invocable_entity, invocable_entity_alias, package, package_alias, public_key, redelegate, session, transfer, undelegate, withdraw_bid, withdraw_bid_all};
+
+use crate::{command::ClientCommand, Success, common};
 
 pub struct PutTransaction;
 const ALIAS: &str = "put-txn";
@@ -28,6 +25,7 @@ impl ClientCommand for PutTransaction {
             .subcommand_required(true)
             .subcommand(add_bid::put_transaction_build())
             .subcommand(activate_bid::put_transaction_build())
+            .subcommand(withdraw_bid_all::put_transaction_build())
             .subcommand(withdraw_bid::put_transaction_build())
             .subcommand(delegate::put_transaction_build())
             .subcommand(undelegate::put_transaction_build())
@@ -45,56 +43,380 @@ impl ClientCommand for PutTransaction {
     }
 
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
-        if let Some((subcommand, matches)) = matches.subcommand() {
-            let (
-                transaction_builder_params,
-                transaction_str_params,
-                node_address,
-                rpc_id,
-                verbosity_level,
-            ) = match subcommand {
-                add_bid::NAME => parse_rpc_args_and_run(matches, add_bid::run)?,
-                activate_bid::NAME => parse_rpc_args_and_run(matches, activate_bid::run)?,
-                withdraw_bid::NAME => parse_rpc_args_and_run(matches, withdraw_bid::run)?,
-                delegate::NAME => parse_rpc_args_and_run(matches, delegate::run)?,
-                undelegate::NAME => parse_rpc_args_and_run(matches, undelegate::run)?,
-                redelegate::NAME => parse_rpc_args_and_run(matches, redelegate::run)?,
-                change_bid_public_key::NAME => {
-                    parse_rpc_args_and_run(matches, change_bid_public_key::run)?
+        match matches.subcommand() {
+            None => {
+                Err(CliError::InvalidArgument {
+                    context: "Make Transaction",
+                    error: "failure to provide recognized subcommand".to_string(),
+                })
+            }
+            Some((subcommand, arg_matches)) => {
+                match subcommand {
+                    add_bid::NAME => put_add_bid_transaction(arg_matches).await,
+                    activate_bid::NAME => put_activate_bid_transaction(arg_matches).await,
+                    withdraw_bid_all::NAME => put_withdraw_all_transaction(arg_matches).await,
+                    withdraw_bid::NAME => put_withdraw_bid_transaction(arg_matches).await,
+                    delegate::NAME => put_delegate_transaction(arg_matches).await,
+                    undelegate::NAME => put_undelegate_transaction(arg_matches).await,
+                    redelegate::NAME => put_redelegate_transaction(arg_matches).await,
+                    change_bid_public_key::NAME => {
+                        put_change_public_key_transaction(arg_matches).await
+                    }
+                    add_reservations::NAME => put_add_reservations_transaction(arg_matches).await,
+                    cancel_reservations::NAME => {
+                        put_cancel_reservations_transaction(arg_matches).await
+                    }
+                    invocable_entity::NAME => put_entity_by_hash_transaction(arg_matches).await,
+                    invocable_entity_alias::NAME => {
+                        put_entity_by_name_transaction(arg_matches).await
+                    }
+                    package::NAME => put_by_package_hash_transaction(arg_matches).await,
+                    package_alias::NAME => put_package_by_name_transaction(arg_matches).await,
+                    session::NAME => put_session_transaction(arg_matches).await,
+                    transfer::NAME => put_transfer_transaction(arg_matches).await,
+                    _ => {
+                        return Err(CliError::InvalidArgument {
+                            context: "Make Transaction",
+                            error: "failure to provide recognized subcommand".to_string(),
+                        })
+                    }
                 }
-                add_reservations::NAME => parse_rpc_args_and_run(matches, add_reservations::run)?,
-                cancel_reservations::NAME => {
-                    parse_rpc_args_and_run(matches, cancel_reservations::run)?
-                }
-                invocable_entity::NAME => parse_rpc_args_and_run(matches, invocable_entity::run)?,
-                invocable_entity_alias::NAME => {
-                    parse_rpc_args_and_run(matches, invocable_entity_alias::run)?
-                }
-                package::NAME => parse_rpc_args_and_run(matches, package::run)?,
-                package_alias::NAME => parse_rpc_args_and_run(matches, package_alias::run)?,
-                session::NAME => parse_rpc_args_and_run(matches, session::run)?,
-                transfer::NAME => parse_rpc_args_and_run(matches, transfer::run)?,
-                _ => {
-                    return Err(CliError::InvalidArgument {
-                        context: "Make Transaction",
-                        error: "failure to provide recognized subcommand".to_string(),
-                    })
-                }
-            };
-            casper_client::cli::put_transaction(
-                rpc_id,
-                node_address,
-                verbosity_level,
-                transaction_builder_params,
-                transaction_str_params,
-            )
-            .await
-            .map(Success::from)
-        } else {
-            return Err(CliError::InvalidArgument {
-                context: "Put Transaction",
-                error: "Failure to supply subcommand".to_string(),
-            });
+            }
         }
     }
+}
+
+
+async fn put_add_bid_transaction(matches: &ArgMatches) -> Result<Success, CliError> {
+    let node_address = common::node_address::get(matches);
+    let rpc_id = common::rpc_id::get(matches);
+    let verbosity_level = common::verbose::get(matches);
+
+    let (transaction_builder_params, transaction_str_params) = add_bid::run(matches)?;
+    casper_client::cli::put_transaction(
+        rpc_id,
+        node_address,
+        verbosity_level,
+        transaction_builder_params,
+        transaction_str_params,
+    )
+        .await
+        .map(Success::from)
+}
+
+
+
+async fn put_activate_bid_transaction(matches: &ArgMatches) -> Result<Success, CliError> {
+    let node_address = common::node_address::get(matches);
+    let rpc_id = common::rpc_id::get(matches);
+    let verbosity_level = common::verbose::get(matches);
+
+    let (transaction_builder_params, transaction_str_params) = activate_bid::run(matches)?;
+    casper_client::cli::put_transaction(
+        rpc_id,
+        node_address,
+        verbosity_level,
+        transaction_builder_params,
+        transaction_str_params,
+    )
+        .await
+        .map(Success::from)
+
+}
+
+async fn put_withdraw_all_transaction(matches: &ArgMatches) -> Result<Success, CliError> {
+    let node_address = common::node_address::get(matches);
+    let rpc_id = common::rpc_id::get(matches);
+    let verbosity_level = common::verbose::get(matches);
+
+    let public_key_str = public_key::get(matches)?;
+    let public_key = public_key::parse_public_key(&public_key_str)?;
+
+    let (transaction_builder_params, transaction_str_params) = match casper_client::cli::get_auction_info("", node_address, verbosity_level, "")
+        .await?
+        .result
+        .auction_state
+        .bids()
+        .find(|(bid_key, _bid)| **bid_key == public_key) {
+        Some((_, bid)) => {
+            let staked_amount = *bid.staked_amount();
+            withdraw_bid_all::run(matches, staked_amount)?
+
+        },
+        None => {
+            return Err(CliError::FailedToGetAuctionState)
+        }
+    };
+
+    casper_client::cli::put_transaction(
+        rpc_id,
+        node_address,
+        verbosity_level,
+        transaction_builder_params,
+        transaction_str_params,
+    )
+        .await
+        .map(Success::from)
+}
+
+
+async fn put_withdraw_bid_transaction(matches: &ArgMatches) -> Result<Success, CliError> {
+    let node_address = common::node_address::get(matches);
+    let rpc_id = common::rpc_id::get(matches);
+    let verbosity_level = common::verbose::get(matches);
+
+    let (transaction_builder_params, transaction_str_params) = withdraw_bid::run(matches)?;
+
+    if let TransactionBuilderParams::WithdrawBid {  public_key, amount, min_bid_override } = &transaction_builder_params {
+        let chainspec_bytes = casper_client::cli::get_chainspec("", node_address, verbosity_level)
+            .await?
+            .result
+            .chainspec_bytes;
+
+        let chainspec = match Chainspec::from_bytes(chainspec_bytes.chainspec_bytes())  {
+            Ok((chainspec, _)) => { chainspec}
+            Err(_) => {
+                return Err(CliError::UnexpectedTransactionArgsVariant)
+            }
+        };
+
+        let min_validator_bid_amount = chainspec
+            .core_config
+            .minimum_bid_amount;
+
+        match casper_client::cli::get_auction_info("", node_address, verbosity_level, "")
+            .await?
+            .result
+            .auction_state
+            .bids()
+            .find(|(bid_key, _bid)| **bid_key == *public_key) {
+            Some((_, bid)) => {
+                let staked_amount = *bid.staked_amount();
+                let remainder = staked_amount.saturating_sub(*amount);
+                if remainder < U512::from(min_validator_bid_amount) && !min_bid_override {
+                    return Err(CliError::ReducedStakeBelowMinAmount)
+                } else {
+                    println!("amount will cause unbonding of all stake")
+                }
+            },
+            None => {
+                return Err(CliError::FailedToGetAuctionState)
+            }
+        };
+    }
+
+
+    casper_client::cli::put_transaction(
+        rpc_id,
+        node_address,
+        verbosity_level,
+        transaction_builder_params,
+        transaction_str_params,
+    )
+        .await
+        .map(Success::from)
+
+}
+
+async fn put_delegate_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
+    let node_address = common::node_address::get(arg_matches);
+    let rpc_id = common::rpc_id::get(arg_matches);
+    let verbosity_level = common::verbose::get(arg_matches);
+
+    let (transaction_builder_params, transaction_str_params) = delegate::run(arg_matches)?;
+    casper_client::cli::put_transaction(
+        rpc_id,
+        node_address,
+        verbosity_level,
+        transaction_builder_params,
+        transaction_str_params,
+    )
+        .await
+        .map(Success::from)
+}
+
+async fn put_undelegate_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
+    let node_address = common::node_address::get(arg_matches);
+    let rpc_id = common::rpc_id::get(arg_matches);
+    let verbosity_level = common::verbose::get(arg_matches);
+
+    let (transaction_builder_params, transaction_str_params) = undelegate::run(arg_matches)?;
+    casper_client::cli::put_transaction(
+        rpc_id,
+        node_address,
+        verbosity_level,
+        transaction_builder_params,
+        transaction_str_params,
+    )
+        .await
+        .map(Success::from)
+}
+
+async fn put_redelegate_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
+    let node_address = common::node_address::get(arg_matches);
+    let rpc_id = common::rpc_id::get(arg_matches);
+    let verbosity_level = common::verbose::get(arg_matches);
+
+    let (transaction_builder_params, transaction_str_params) = redelegate::run(arg_matches)?;
+    casper_client::cli::put_transaction(
+        rpc_id,
+        node_address,
+        verbosity_level,
+        transaction_builder_params,
+        transaction_str_params,
+    )
+        .await
+        .map(Success::from)
+}
+
+async fn put_change_public_key_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
+    let node_address = common::node_address::get(arg_matches);
+    let rpc_id = common::rpc_id::get(arg_matches);
+    let verbosity_level = common::verbose::get(arg_matches);
+
+    let (transaction_builder_params, transaction_str_params) = change_bid_public_key::run(arg_matches)?;
+    casper_client::cli::put_transaction(
+        rpc_id,
+        node_address,
+        verbosity_level,
+        transaction_builder_params,
+        transaction_str_params,
+    )
+        .await
+        .map(Success::from)
+}
+
+async fn put_add_reservations_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
+    let node_address = common::node_address::get(arg_matches);
+    let rpc_id = common::rpc_id::get(arg_matches);
+    let verbosity_level = common::verbose::get(arg_matches);
+
+    let (transaction_builder_params, transaction_str_params) = add_reservations::run(arg_matches)?;
+    casper_client::cli::put_transaction(
+        rpc_id,
+        node_address,
+        verbosity_level,
+        transaction_builder_params,
+        transaction_str_params,
+    )
+        .await
+        .map(Success::from)
+}
+async fn put_cancel_reservations_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
+    let node_address = common::node_address::get(arg_matches);
+    let rpc_id = common::rpc_id::get(arg_matches);
+    let verbosity_level = common::verbose::get(arg_matches);
+
+    let (transaction_builder_params, transaction_str_params) = cancel_reservations::run(arg_matches)?;
+    casper_client::cli::put_transaction(
+        rpc_id,
+        node_address,
+        verbosity_level,
+        transaction_builder_params,
+        transaction_str_params,
+    )
+        .await
+        .map(Success::from)
+}
+
+async fn put_entity_by_hash_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
+    let node_address = common::node_address::get(arg_matches);
+    let rpc_id = common::rpc_id::get(arg_matches);
+    let verbosity_level = common::verbose::get(arg_matches);
+
+    let (transaction_builder_params, transaction_str_params) = invocable_entity::run(arg_matches)?;
+    casper_client::cli::put_transaction(
+        rpc_id,
+        node_address,
+        verbosity_level,
+        transaction_builder_params,
+        transaction_str_params,
+    )
+        .await
+        .map(Success::from)
+}
+
+async fn put_entity_by_name_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
+    let node_address = common::node_address::get(arg_matches);
+    let rpc_id = common::rpc_id::get(arg_matches);
+    let verbosity_level = common::verbose::get(arg_matches);
+
+    let (transaction_builder_params, transaction_str_params) = invocable_entity_alias::run(arg_matches)?;
+    casper_client::cli::put_transaction(
+        rpc_id,
+        node_address,
+        verbosity_level,
+        transaction_builder_params,
+        transaction_str_params,
+    )
+        .await
+        .map(Success::from)
+}
+
+async fn put_by_package_hash_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
+    let node_address = common::node_address::get(arg_matches);
+    let rpc_id = common::rpc_id::get(arg_matches);
+    let verbosity_level = common::verbose::get(arg_matches);
+
+    let (transaction_builder_params, transaction_str_params) = package::run(arg_matches)?;
+    casper_client::cli::put_transaction(
+        rpc_id,
+        node_address,
+        verbosity_level,
+        transaction_builder_params,
+        transaction_str_params,
+    )
+        .await
+        .map(Success::from)
+}
+
+async fn put_package_by_name_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
+    let node_address = common::node_address::get(arg_matches);
+    let rpc_id = common::rpc_id::get(arg_matches);
+    let verbosity_level = common::verbose::get(arg_matches);
+
+    let (transaction_builder_params, transaction_str_params) = package_alias::run(arg_matches)?;
+    casper_client::cli::put_transaction(
+        rpc_id,
+        node_address,
+        verbosity_level,
+        transaction_builder_params,
+        transaction_str_params,
+    )
+        .await
+        .map(Success::from)
+}
+
+async fn put_session_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
+    let node_address = common::node_address::get(arg_matches);
+    let rpc_id = common::rpc_id::get(arg_matches);
+    let verbosity_level = common::verbose::get(arg_matches);
+
+    let (transaction_builder_params, transaction_str_params) = session::run(arg_matches)?;
+    casper_client::cli::put_transaction(
+        rpc_id,
+        node_address,
+        verbosity_level,
+        transaction_builder_params,
+        transaction_str_params,
+    )
+        .await
+        .map(Success::from)
+}
+
+async fn put_transfer_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
+    let node_address = common::node_address::get(arg_matches);
+    let rpc_id = common::rpc_id::get(arg_matches);
+    let verbosity_level = common::verbose::get(arg_matches);
+
+    let (transaction_builder_params, transaction_str_params) = transfer::run(arg_matches)?;
+    casper_client::cli::put_transaction(
+        rpc_id,
+        node_address,
+        verbosity_level,
+        transaction_builder_params,
+        transaction_str_params,
+    )
+        .await
+        .map(Success::from)
 }

--- a/src/transaction/put.rs
+++ b/src/transaction/put.rs
@@ -1,14 +1,47 @@
 use async_trait::async_trait;
-use casper_types::bytesrepr::{FromBytes};
-use casper_types::{Chainspec, U512};
 use clap::{ArgMatches, Command};
-
+use serde::{Deserialize, Serialize};
 
 use casper_client::cli::{CliError, TransactionBuilderParams};
+use casper_types::{ActivationPoint, CoreConfig, HighwayConfig, ProtocolVersion, StorageCosts, SystemConfig, TransactionConfig, U512, VacancyConfig, WasmConfig};
 
 use super::creation_common::{activate_bid, add_bid, add_reservations, cancel_reservations, change_bid_public_key, delegate, invocable_entity, invocable_entity_alias, package, package_alias, public_key, redelegate, session, transfer, undelegate, withdraw_bid, withdraw_bid_all};
 
 use crate::{command::ClientCommand, Success, common};
+
+#[derive(PartialEq, Eq, Serialize, Deserialize, Debug)]
+// Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
+#[serde(deny_unknown_fields)]
+struct TomlNetwork {
+    name: String,
+    maximum_net_message_size: u32,
+}
+
+#[derive(PartialEq, Eq, Serialize, Deserialize, Debug)]
+// Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
+#[serde(deny_unknown_fields)]
+struct TomlProtocol {
+    version: ProtocolVersion,
+    hard_reset: bool,
+    activation_point: ActivationPoint,
+}
+
+/// A chainspec configuration as laid out in the TOML-encoded configuration file.
+#[derive(PartialEq, Eq, Serialize, Deserialize, Debug)]
+// Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
+#[serde(deny_unknown_fields)]
+pub(super) struct TomlChainspec {
+    protocol: TomlProtocol,
+    network: TomlNetwork,
+    core: CoreConfig,
+    transactions: TransactionConfig,
+    highway: HighwayConfig,
+    wasm: WasmConfig,
+    system_costs: SystemConfig,
+    vacancy: VacancyConfig,
+    storage_costs: StorageCosts,
+}
+
 
 pub struct PutTransaction;
 const ALIAS: &str = "put-txn";
@@ -173,15 +206,12 @@ async fn put_withdraw_bid_transaction(matches: &ArgMatches) -> Result<Success, C
             .result
             .chainspec_bytes;
 
-        let chainspec = match Chainspec::from_bytes(chainspec_bytes.chainspec_bytes())  {
-            Ok((chainspec, _)) => { chainspec}
-            Err(_) => {
-                return Err(CliError::UnexpectedTransactionArgsVariant)
-            }
-        };
+        let toml_chainspec: TomlChainspec =
+            toml::from_str(std::str::from_utf8(&chainspec_bytes.chainspec_bytes()).unwrap())
+                .map_err(|_| CliError::FailedToParseChainspecBytes)?;
 
-        let min_validator_bid_amount = chainspec
-            .core_config
+        let min_validator_bid_amount = toml_chainspec
+            .core
             .minimum_bid_amount;
 
         match casper_client::cli::get_auction_info("", node_address, verbosity_level, "")

--- a/src/transaction/put.rs
+++ b/src/transaction/put.rs
@@ -3,11 +3,18 @@ use clap::{ArgMatches, Command};
 use serde::{Deserialize, Serialize};
 
 use casper_client::cli::{CliError, TransactionBuilderParams};
-use casper_types::{ActivationPoint, CoreConfig, HighwayConfig, ProtocolVersion, StorageCosts, SystemConfig, TransactionConfig, U512, VacancyConfig, WasmConfig};
+use casper_types::{
+    ActivationPoint, CoreConfig, HighwayConfig, ProtocolVersion, StorageCosts, SystemConfig,
+    TransactionConfig, VacancyConfig, WasmConfig, U512,
+};
 
-use super::creation_common::{activate_bid, add_bid, add_reservations, cancel_reservations, change_bid_public_key, delegate, invocable_entity, invocable_entity_alias, package, package_alias, public_key, redelegate, session, transfer, undelegate, withdraw_bid, withdraw_bid_all};
+use super::creation_common::{
+    activate_bid, add_bid, add_reservations, cancel_reservations, change_bid_public_key, delegate,
+    invocable_entity, invocable_entity_alias, package, package_alias, public_key, redelegate,
+    session, transfer, undelegate, withdraw_bid, withdraw_bid_all,
+};
 
-use crate::{command::ClientCommand, Success, common};
+use crate::{command::ClientCommand, common, Success};
 
 #[derive(PartialEq, Eq, Serialize, Deserialize, Debug)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
@@ -41,7 +48,6 @@ pub(super) struct TomlChainspec {
     vacancy: VacancyConfig,
     storage_costs: StorageCosts,
 }
-
 
 pub struct PutTransaction;
 const ALIAS: &str = "put-txn";
@@ -77,48 +83,37 @@ impl ClientCommand for PutTransaction {
 
     async fn run(matches: &ArgMatches) -> Result<Success, CliError> {
         match matches.subcommand() {
-            None => {
-                Err(CliError::InvalidArgument {
-                    context: "Make Transaction",
-                    error: "failure to provide recognized subcommand".to_string(),
-                })
-            }
-            Some((subcommand, arg_matches)) => {
-                match subcommand {
-                    add_bid::NAME => put_add_bid_transaction(arg_matches).await,
-                    activate_bid::NAME => put_activate_bid_transaction(arg_matches).await,
-                    withdraw_bid_all::NAME => put_withdraw_all_transaction(arg_matches).await,
-                    withdraw_bid::NAME => put_withdraw_bid_transaction(arg_matches).await,
-                    delegate::NAME => put_delegate_transaction(arg_matches).await,
-                    undelegate::NAME => put_undelegate_transaction(arg_matches).await,
-                    redelegate::NAME => put_redelegate_transaction(arg_matches).await,
-                    change_bid_public_key::NAME => {
-                        put_change_public_key_transaction(arg_matches).await
-                    }
-                    add_reservations::NAME => put_add_reservations_transaction(arg_matches).await,
-                    cancel_reservations::NAME => {
-                        put_cancel_reservations_transaction(arg_matches).await
-                    }
-                    invocable_entity::NAME => put_entity_by_hash_transaction(arg_matches).await,
-                    invocable_entity_alias::NAME => {
-                        put_entity_by_name_transaction(arg_matches).await
-                    }
-                    package::NAME => put_by_package_hash_transaction(arg_matches).await,
-                    package_alias::NAME => put_package_by_name_transaction(arg_matches).await,
-                    session::NAME => put_session_transaction(arg_matches).await,
-                    transfer::NAME => put_transfer_transaction(arg_matches).await,
-                    _ => {
-                        return Err(CliError::InvalidArgument {
-                            context: "Make Transaction",
-                            error: "failure to provide recognized subcommand".to_string(),
-                        })
-                    }
+            None => Err(CliError::InvalidArgument {
+                context: "Make Transaction",
+                error: "failure to provide recognized subcommand".to_string(),
+            }),
+            Some((subcommand, arg_matches)) => match subcommand {
+                add_bid::NAME => put_add_bid_transaction(arg_matches).await,
+                activate_bid::NAME => put_activate_bid_transaction(arg_matches).await,
+                withdraw_bid_all::NAME => put_withdraw_all_transaction(arg_matches).await,
+                withdraw_bid::NAME => put_withdraw_bid_transaction(arg_matches).await,
+                delegate::NAME => put_delegate_transaction(arg_matches).await,
+                undelegate::NAME => put_undelegate_transaction(arg_matches).await,
+                redelegate::NAME => put_redelegate_transaction(arg_matches).await,
+                change_bid_public_key::NAME => put_change_public_key_transaction(arg_matches).await,
+                add_reservations::NAME => put_add_reservations_transaction(arg_matches).await,
+                cancel_reservations::NAME => put_cancel_reservations_transaction(arg_matches).await,
+                invocable_entity::NAME => put_entity_by_hash_transaction(arg_matches).await,
+                invocable_entity_alias::NAME => put_entity_by_name_transaction(arg_matches).await,
+                package::NAME => put_by_package_hash_transaction(arg_matches).await,
+                package_alias::NAME => put_package_by_name_transaction(arg_matches).await,
+                session::NAME => put_session_transaction(arg_matches).await,
+                transfer::NAME => put_transfer_transaction(arg_matches).await,
+                _ => {
+                    return Err(CliError::InvalidArgument {
+                        context: "Make Transaction",
+                        error: "failure to provide recognized subcommand".to_string(),
+                    })
                 }
-            }
+            },
         }
     }
 }
-
 
 async fn put_add_bid_transaction(matches: &ArgMatches) -> Result<Success, CliError> {
     let node_address = common::node_address::get(matches);
@@ -133,11 +128,9 @@ async fn put_add_bid_transaction(matches: &ArgMatches) -> Result<Success, CliErr
         transaction_builder_params,
         transaction_str_params,
     )
-        .await
-        .map(Success::from)
+    .await
+    .map(Success::from)
 }
-
-
 
 async fn put_activate_bid_transaction(matches: &ArgMatches) -> Result<Success, CliError> {
     let node_address = common::node_address::get(matches);
@@ -152,9 +145,8 @@ async fn put_activate_bid_transaction(matches: &ArgMatches) -> Result<Success, C
         transaction_builder_params,
         transaction_str_params,
     )
-        .await
-        .map(Success::from)
-
+    .await
+    .map(Success::from)
 }
 
 async fn put_withdraw_all_transaction(matches: &ArgMatches) -> Result<Success, CliError> {
@@ -165,21 +157,20 @@ async fn put_withdraw_all_transaction(matches: &ArgMatches) -> Result<Success, C
     let public_key_str = public_key::get(matches)?;
     let public_key = public_key::parse_public_key(&public_key_str)?;
 
-    let (transaction_builder_params, transaction_str_params) = match casper_client::cli::get_auction_info("", node_address, verbosity_level, "")
-        .await?
-        .result
-        .auction_state
-        .bids()
-        .find(|(bid_key, _bid)| **bid_key == public_key) {
-        Some((_, bid)) => {
-            let staked_amount = *bid.staked_amount();
-            withdraw_bid_all::run(matches, staked_amount)?
-
-        },
-        None => {
-            return Err(CliError::FailedToGetAuctionState)
-        }
-    };
+    let (transaction_builder_params, transaction_str_params) =
+        match casper_client::cli::get_auction_info("", node_address, verbosity_level, "")
+            .await?
+            .result
+            .auction_state
+            .bids()
+            .find(|(bid_key, _bid)| **bid_key == public_key)
+        {
+            Some((_, bid)) => {
+                let staked_amount = *bid.staked_amount();
+                withdraw_bid_all::run(matches, staked_amount)?
+            }
+            None => return Err(CliError::FailedToGetAuctionState),
+        };
 
     casper_client::cli::put_transaction(
         rpc_id,
@@ -188,10 +179,9 @@ async fn put_withdraw_all_transaction(matches: &ArgMatches) -> Result<Success, C
         transaction_builder_params,
         transaction_str_params,
     )
-        .await
-        .map(Success::from)
+    .await
+    .map(Success::from)
 }
-
 
 async fn put_withdraw_bid_transaction(matches: &ArgMatches) -> Result<Success, CliError> {
     let node_address = common::node_address::get(matches);
@@ -200,43 +190,43 @@ async fn put_withdraw_bid_transaction(matches: &ArgMatches) -> Result<Success, C
 
     let (transaction_builder_params, transaction_str_params) = withdraw_bid::run(matches)?;
 
-    if let TransactionBuilderParams::WithdrawBid {  public_key, amount, min_bid_override } = &transaction_builder_params {
-
-        let chainspec_bytes =  casper_client::cli::get_chainspec("", node_address, verbosity_level).await?
+    if let TransactionBuilderParams::WithdrawBid {
+        public_key,
+        amount,
+        min_bid_override,
+    } = &transaction_builder_params
+    {
+        let chainspec_bytes = casper_client::cli::get_chainspec("", node_address, verbosity_level)
+            .await?
             .result
             .chainspec_bytes;
 
         let chainspec_as_str = std::str::from_utf8(chainspec_bytes.chainspec_bytes()).unwrap();
-        let toml_chainspec: TomlChainspec = toml::from_str(chainspec_as_str)
-            .unwrap();
+        let toml_chainspec: TomlChainspec = toml::from_str(chainspec_as_str).unwrap();
 
-        let minimum_validator_bid = toml_chainspec
-            .core
-            .minimum_bid_amount;
+        let minimum_validator_bid = toml_chainspec.core.minimum_bid_amount;
 
         match casper_client::cli::get_auction_info("", node_address, verbosity_level, "")
             .await?
             .result
             .auction_state
             .bids()
-            .find(|(bid_key, _bid)| **bid_key == *public_key) {
+            .find(|(bid_key, _bid)| **bid_key == *public_key)
+        {
             Some((_, bid)) => {
                 let staked_amount = *bid.staked_amount();
                 let remainder = staked_amount.saturating_sub(*amount);
                 if remainder < U512::from(minimum_validator_bid) {
                     if !min_bid_override {
-                        return Err(CliError::ReducedStakeBelowMinAmount)
+                        return Err(CliError::ReducedStakeBelowMinAmount);
                     } else {
                         println!("[WARN] Execution of this withdraw bid will result in unbonding of all stake")
                     }
                 }
-            },
-            None => {
-                return Err(CliError::FailedToGetAuctionState)
             }
+            None => return Err(CliError::FailedToGetAuctionState),
         };
     }
-
 
     casper_client::cli::put_transaction(
         rpc_id,
@@ -245,9 +235,8 @@ async fn put_withdraw_bid_transaction(matches: &ArgMatches) -> Result<Success, C
         transaction_builder_params,
         transaction_str_params,
     )
-        .await
-        .map(Success::from)
-
+    .await
+    .map(Success::from)
 }
 
 async fn put_delegate_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
@@ -263,8 +252,8 @@ async fn put_delegate_transaction(arg_matches: &ArgMatches) -> Result<Success, C
         transaction_builder_params,
         transaction_str_params,
     )
-        .await
-        .map(Success::from)
+    .await
+    .map(Success::from)
 }
 
 async fn put_undelegate_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
@@ -280,8 +269,8 @@ async fn put_undelegate_transaction(arg_matches: &ArgMatches) -> Result<Success,
         transaction_builder_params,
         transaction_str_params,
     )
-        .await
-        .map(Success::from)
+    .await
+    .map(Success::from)
 }
 
 async fn put_redelegate_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
@@ -297,8 +286,8 @@ async fn put_redelegate_transaction(arg_matches: &ArgMatches) -> Result<Success,
         transaction_builder_params,
         transaction_str_params,
     )
-        .await
-        .map(Success::from)
+    .await
+    .map(Success::from)
 }
 
 async fn put_change_public_key_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
@@ -306,7 +295,8 @@ async fn put_change_public_key_transaction(arg_matches: &ArgMatches) -> Result<S
     let rpc_id = common::rpc_id::get(arg_matches);
     let verbosity_level = common::verbose::get(arg_matches);
 
-    let (transaction_builder_params, transaction_str_params) = change_bid_public_key::run(arg_matches)?;
+    let (transaction_builder_params, transaction_str_params) =
+        change_bid_public_key::run(arg_matches)?;
     casper_client::cli::put_transaction(
         rpc_id,
         node_address,
@@ -314,8 +304,8 @@ async fn put_change_public_key_transaction(arg_matches: &ArgMatches) -> Result<S
         transaction_builder_params,
         transaction_str_params,
     )
-        .await
-        .map(Success::from)
+    .await
+    .map(Success::from)
 }
 
 async fn put_add_reservations_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
@@ -331,15 +321,18 @@ async fn put_add_reservations_transaction(arg_matches: &ArgMatches) -> Result<Su
         transaction_builder_params,
         transaction_str_params,
     )
-        .await
-        .map(Success::from)
+    .await
+    .map(Success::from)
 }
-async fn put_cancel_reservations_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
+async fn put_cancel_reservations_transaction(
+    arg_matches: &ArgMatches,
+) -> Result<Success, CliError> {
     let node_address = common::node_address::get(arg_matches);
     let rpc_id = common::rpc_id::get(arg_matches);
     let verbosity_level = common::verbose::get(arg_matches);
 
-    let (transaction_builder_params, transaction_str_params) = cancel_reservations::run(arg_matches)?;
+    let (transaction_builder_params, transaction_str_params) =
+        cancel_reservations::run(arg_matches)?;
     casper_client::cli::put_transaction(
         rpc_id,
         node_address,
@@ -347,8 +340,8 @@ async fn put_cancel_reservations_transaction(arg_matches: &ArgMatches) -> Result
         transaction_builder_params,
         transaction_str_params,
     )
-        .await
-        .map(Success::from)
+    .await
+    .map(Success::from)
 }
 
 async fn put_entity_by_hash_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
@@ -364,8 +357,8 @@ async fn put_entity_by_hash_transaction(arg_matches: &ArgMatches) -> Result<Succ
         transaction_builder_params,
         transaction_str_params,
     )
-        .await
-        .map(Success::from)
+    .await
+    .map(Success::from)
 }
 
 async fn put_entity_by_name_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
@@ -373,7 +366,8 @@ async fn put_entity_by_name_transaction(arg_matches: &ArgMatches) -> Result<Succ
     let rpc_id = common::rpc_id::get(arg_matches);
     let verbosity_level = common::verbose::get(arg_matches);
 
-    let (transaction_builder_params, transaction_str_params) = invocable_entity_alias::run(arg_matches)?;
+    let (transaction_builder_params, transaction_str_params) =
+        invocable_entity_alias::run(arg_matches)?;
     casper_client::cli::put_transaction(
         rpc_id,
         node_address,
@@ -381,8 +375,8 @@ async fn put_entity_by_name_transaction(arg_matches: &ArgMatches) -> Result<Succ
         transaction_builder_params,
         transaction_str_params,
     )
-        .await
-        .map(Success::from)
+    .await
+    .map(Success::from)
 }
 
 async fn put_by_package_hash_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
@@ -398,8 +392,8 @@ async fn put_by_package_hash_transaction(arg_matches: &ArgMatches) -> Result<Suc
         transaction_builder_params,
         transaction_str_params,
     )
-        .await
-        .map(Success::from)
+    .await
+    .map(Success::from)
 }
 
 async fn put_package_by_name_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
@@ -415,8 +409,8 @@ async fn put_package_by_name_transaction(arg_matches: &ArgMatches) -> Result<Suc
         transaction_builder_params,
         transaction_str_params,
     )
-        .await
-        .map(Success::from)
+    .await
+    .map(Success::from)
 }
 
 async fn put_session_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
@@ -432,8 +426,8 @@ async fn put_session_transaction(arg_matches: &ArgMatches) -> Result<Success, Cl
         transaction_builder_params,
         transaction_str_params,
     )
-        .await
-        .map(Success::from)
+    .await
+    .map(Success::from)
 }
 
 async fn put_transfer_transaction(arg_matches: &ArgMatches) -> Result<Success, CliError> {
@@ -449,6 +443,6 @@ async fn put_transfer_transaction(arg_matches: &ArgMatches) -> Result<Success, C
         transaction_builder_params,
         transaction_str_params,
     )
-        .await
-        .map(Success::from)
+    .await
+    .map(Success::from)
 }

--- a/src/transaction/put.rs
+++ b/src/transaction/put.rs
@@ -227,7 +227,7 @@ async fn put_withdraw_bid_transaction(matches: &ArgMatches) -> Result<Success, C
                     if !min_bid_override {
                         return Err(CliError::ReducedStakeBelowMinAmount)
                     } else {
-                        println!("amount will cause unbonding of all stake")
+                        println!("[WARN] Execution of this withdraw bid will result in unbonding of all stake")
                     }
                 }
             },

--- a/src/transaction/put.rs
+++ b/src/transaction/put.rs
@@ -9,6 +9,9 @@ use super::creation_common::{activate_bid, add_bid, add_reservations, cancel_res
 
 use crate::{command::ClientCommand, Success, common};
 
+// TODO: Remove this constant and use the chainspec instead.
+const MINIMUM_BID_AMOUNT: u64 = 10_000_000_000_000u64;
+
 #[derive(PartialEq, Eq, Serialize, Deserialize, Debug)]
 // Disallow unknown fields to ensure config files and command-line overrides contain valid keys.
 #[serde(deny_unknown_fields)]
@@ -201,19 +204,6 @@ async fn put_withdraw_bid_transaction(matches: &ArgMatches) -> Result<Success, C
     let (transaction_builder_params, transaction_str_params) = withdraw_bid::run(matches)?;
 
     if let TransactionBuilderParams::WithdrawBid {  public_key, amount, min_bid_override } = &transaction_builder_params {
-        let chainspec_bytes = casper_client::cli::get_chainspec("", node_address, verbosity_level)
-            .await?
-            .result
-            .chainspec_bytes;
-
-        let toml_chainspec: TomlChainspec =
-            toml::from_str(std::str::from_utf8(&chainspec_bytes.chainspec_bytes()).unwrap())
-                .map_err(|_| CliError::FailedToParseChainspecBytes)?;
-
-        let min_validator_bid_amount = toml_chainspec
-            .core
-            .minimum_bid_amount;
-
         match casper_client::cli::get_auction_info("", node_address, verbosity_level, "")
             .await?
             .result
@@ -223,7 +213,7 @@ async fn put_withdraw_bid_transaction(matches: &ArgMatches) -> Result<Success, C
             Some((_, bid)) => {
                 let staked_amount = *bid.staked_amount();
                 let remainder = staked_amount.saturating_sub(*amount);
-                if remainder < U512::from(min_validator_bid_amount) && !min_bid_override {
+                if remainder < U512::from(MINIMUM_BID_AMOUNT) && !min_bid_override {
                     return Err(CliError::ReducedStakeBelowMinAmount)
                 } else {
                     println!("amount will cause unbonding of all stake")


### PR DESCRIPTION
CHANGLEOG

- Adds a new subcommand `withdraw-bid-all` which takes in a public-key for a validator and produces a withdraw bid transaction which completely unstakes the validator
- Modified `withdraw-bid` to check that withdraw bid does not result in a validator's stake dropping below a validator minimum bid threshold
- Added an override flag to `withdraw-bid` to simply log the warning to stdout and produce/send the withdraw bid transaction