### PR TITLE
Optimistically deserialize toml chainspec

### DIFF
--- a/src/transaction/put.rs
+++ b/src/transaction/put.rs
@@ -196,49 +196,27 @@ async fn put_withdraw_bid_transaction(matches: &ArgMatches) -> Result<Success, C
         min_bid_override,
     } = &transaction_builder_params
     {
+        if *min_bid_override {
+            return casper_client::cli::put_transaction(
+                rpc_id,
+                node_address,
+                verbosity_level,
+                transaction_builder_params,
+                transaction_str_params,
+            )
+            .await
+            .map(Success::from);
+        }
+
         let chainspec_bytes = casper_client::cli::get_chainspec("", node_address, verbosity_level)
             .await?
             .result
             .chainspec_bytes;
 
-        let chainspec_as_str = match std::str::from_utf8(chainspec_bytes.chainspec_bytes()) {
-            Ok(chainspec_as_str) => chainspec_as_str,
-            Err(_) => {
-                return if *min_bid_override {
-                    println!("Unable to decode chainspec bytes, skipping withdraw bid checks");
-                    casper_client::cli::put_transaction(
-                        rpc_id,
-                        node_address,
-                        verbosity_level,
-                        transaction_builder_params,
-                        transaction_str_params,
-                    )
-                    .await
-                    .map(Success::from)
-                } else {
-                    Err(CliError::FailedToParseChainspecBytes)
-                }
-            }
-        };
-        let toml_chainspec: TomlChainspec = match toml::from_str(chainspec_as_str) {
-            Ok(toml_chainspec) => toml_chainspec,
-            Err(_) => {
-                return if *min_bid_override {
-                    println!("Unable to deserialize chainspec skipping withdraw bid checks");
-                    casper_client::cli::put_transaction(
-                        rpc_id,
-                        node_address,
-                        verbosity_level,
-                        transaction_builder_params,
-                        transaction_str_params,
-                    )
-                    .await
-                    .map(Success::from)
-                } else {
-                    Err(CliError::FailedToParseChainspecBytes)
-                }
-            }
-        };
+        let chainspec_as_str = std::str::from_utf8(chainspec_bytes.chainspec_bytes())
+            .map_err(|_| CliError::FailedToParseChainspecBytes)?;
+        let toml_chainspec: TomlChainspec =
+            toml::from_str(chainspec_as_str).map_err(|_| CliError::FailedToParseChainspecBytes)?;
 
         let minimum_validator_bid = toml_chainspec.core.minimum_bid_amount;
 

--- a/src/transaction/put.rs
+++ b/src/transaction/put.rs
@@ -201,8 +201,36 @@ async fn put_withdraw_bid_transaction(matches: &ArgMatches) -> Result<Success, C
             .result
             .chainspec_bytes;
 
-        let chainspec_as_str = std::str::from_utf8(chainspec_bytes.chainspec_bytes()).unwrap();
-        let toml_chainspec: TomlChainspec = toml::from_str(chainspec_as_str).unwrap();
+        let chainspec_as_str = match std::str::from_utf8(chainspec_bytes.chainspec_bytes()) {
+            Ok(chainspec_as_str) => chainspec_as_str,
+            Err(_) => {
+                println!("Unable to decode chainspec bytes, skipping withdraw bid checks");
+                return casper_client::cli::put_transaction(
+                    rpc_id,
+                    node_address,
+                    verbosity_level,
+                    transaction_builder_params,
+                    transaction_str_params,
+                )
+                    .await
+                    .map(Success::from)
+            }
+        };
+        let toml_chainspec: TomlChainspec = match toml::from_str(chainspec_as_str) {
+            Ok(toml_chainspec) => toml_chainspec,
+            Err(_) => {
+                println!("Unable to deserialize chainspec skipping withdraw bid checks");
+                return casper_client::cli::put_transaction(
+                    rpc_id,
+                    node_address,
+                    verbosity_level,
+                    transaction_builder_params,
+                    transaction_str_params,
+                )
+                    .await
+                    .map(Success::from)
+            }
+        };
 
         let minimum_validator_bid = toml_chainspec.core.minimum_bid_amount;
 

--- a/src/transaction/put.rs
+++ b/src/transaction/put.rs
@@ -204,31 +204,39 @@ async fn put_withdraw_bid_transaction(matches: &ArgMatches) -> Result<Success, C
         let chainspec_as_str = match std::str::from_utf8(chainspec_bytes.chainspec_bytes()) {
             Ok(chainspec_as_str) => chainspec_as_str,
             Err(_) => {
-                println!("Unable to decode chainspec bytes, skipping withdraw bid checks");
-                return casper_client::cli::put_transaction(
-                    rpc_id,
-                    node_address,
-                    verbosity_level,
-                    transaction_builder_params,
-                    transaction_str_params,
-                )
-                .await
-                .map(Success::from);
+                return if min_bid_override {
+                    println!("Unable to decode chainspec bytes, skipping withdraw bid checks");
+                    casper_client::cli::put_transaction(
+                        rpc_id,
+                        node_address,
+                        verbosity_level,
+                        transaction_builder_params,
+                        transaction_str_params,
+                    )
+                    .await
+                    .map(Success::from)
+                } else {
+                    Err(CliError::FailedToParseChainspecBytes)
+                }
             }
         };
         let toml_chainspec: TomlChainspec = match toml::from_str(chainspec_as_str) {
             Ok(toml_chainspec) => toml_chainspec,
             Err(_) => {
-                println!("Unable to deserialize chainspec skipping withdraw bid checks");
-                return casper_client::cli::put_transaction(
-                    rpc_id,
-                    node_address,
-                    verbosity_level,
-                    transaction_builder_params,
-                    transaction_str_params,
-                )
-                .await
-                .map(Success::from);
+                return if min_bid_override {
+                    println!("Unable to deserialize chainspec skipping withdraw bid checks");
+                    casper_client::cli::put_transaction(
+                        rpc_id,
+                        node_address,
+                        verbosity_level,
+                        transaction_builder_params,
+                        transaction_str_params,
+                    )
+                    .await
+                    .map(Success::from)
+                } else {
+                    Err(CliError::FailedToParseChainspecBytes)
+                }
             }
         };
 

--- a/src/transaction/put.rs
+++ b/src/transaction/put.rs
@@ -204,7 +204,7 @@ async fn put_withdraw_bid_transaction(matches: &ArgMatches) -> Result<Success, C
         let chainspec_as_str = match std::str::from_utf8(chainspec_bytes.chainspec_bytes()) {
             Ok(chainspec_as_str) => chainspec_as_str,
             Err(_) => {
-                return if min_bid_override {
+                return if *min_bid_override {
                     println!("Unable to decode chainspec bytes, skipping withdraw bid checks");
                     casper_client::cli::put_transaction(
                         rpc_id,
@@ -223,7 +223,7 @@ async fn put_withdraw_bid_transaction(matches: &ArgMatches) -> Result<Success, C
         let toml_chainspec: TomlChainspec = match toml::from_str(chainspec_as_str) {
             Ok(toml_chainspec) => toml_chainspec,
             Err(_) => {
-                return if min_bid_override {
+                return if *min_bid_override {
                     println!("Unable to deserialize chainspec skipping withdraw bid checks");
                     casper_client::cli::put_transaction(
                         rpc_id,

--- a/src/transaction/put.rs
+++ b/src/transaction/put.rs
@@ -212,8 +212,8 @@ async fn put_withdraw_bid_transaction(matches: &ArgMatches) -> Result<Success, C
                     transaction_builder_params,
                     transaction_str_params,
                 )
-                    .await
-                    .map(Success::from)
+                .await
+                .map(Success::from);
             }
         };
         let toml_chainspec: TomlChainspec = match toml::from_str(chainspec_as_str) {
@@ -227,8 +227,8 @@ async fn put_withdraw_bid_transaction(matches: &ArgMatches) -> Result<Success, C
                     transaction_builder_params,
                     transaction_str_params,
                 )
-                    .await
-                    .map(Success::from)
+                .await
+                .map(Success::from);
             }
         };
 


### PR DESCRIPTION
CHANGELOG:

- When attempting to deserialize the chainspec skip the minimum amount checks on failure instead of panicking