### PR TITLE
Remove defaulting of override flag

### DIFF
--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -341,7 +341,13 @@ pub async fn put_deploy_with_min_bid_override(
     let rpc_id = parse::rpc_id(maybe_rpc_id);
     let verbosity = parse::verbosity(verbosity_level);
     let deploy = with_payment_and_session(deploy_params, payment_params, session_params, false)?;
-    do_deploy_checks(node_address, min_bid_override, &deploy).await?;
+    if let Err(err) = do_deploy_checks(node_address, min_bid_override, &deploy).await {
+        if !min_bid_override {
+            return Err(err)
+        } else {
+            println!("[WARN]: Skipping withdraw bid amount checks: {}", err)
+        }
+    };
     #[allow(deprecated)]
     crate::put_deploy(rpc_id, node_address, verbosity, deploy)
         .await

--- a/lib/cli/deploy.rs
+++ b/lib/cli/deploy.rs
@@ -343,7 +343,7 @@ pub async fn put_deploy_with_min_bid_override(
     let deploy = with_payment_and_session(deploy_params, payment_params, session_params, false)?;
     if let Err(err) = do_deploy_checks(node_address, min_bid_override, &deploy).await {
         if !min_bid_override {
-            return Err(err)
+            return Err(err);
         } else {
             println!("[WARN]: Skipping withdraw bid amount checks: {}", err)
         }

--- a/lib/cli/transaction.rs
+++ b/lib/cli/transaction.rs
@@ -157,11 +157,13 @@ pub async fn put_transaction(
     let verbosity_level = parse::verbosity(verbosity_level);
     let min_bid_override = transaction_params.min_bid_override;
     let transaction = create_transaction(builder_params, transaction_params, false)?;
-    if let Err(err) = check_auction_state_for_withdraw(node_address, 0, min_bid_override, &transaction).await {
+    if let Err(err) =
+        check_auction_state_for_withdraw(node_address, 0, min_bid_override, &transaction).await
+    {
         if !min_bid_override {
-            return Err(err)
+            return Err(err);
         } else {
-            println!("[WARN] Skipping withdraw amount checks {}",err)
+            println!("[WARN] Skipping withdraw amount checks {}", err)
         }
     };
     put_transaction_rpc_handler(rpc_id, node_address, verbosity_level, transaction)

--- a/lib/cli/transaction.rs
+++ b/lib/cli/transaction.rs
@@ -157,7 +157,13 @@ pub async fn put_transaction(
     let verbosity_level = parse::verbosity(verbosity_level);
     let min_bid_override = transaction_params.min_bid_override;
     let transaction = create_transaction(builder_params, transaction_params, false)?;
-    check_auction_state_for_withdraw(node_address, 0, min_bid_override, &transaction).await?;
+    if let Err(err) = check_auction_state_for_withdraw(node_address, 0, min_bid_override, &transaction).await {
+        if !min_bid_override {
+            return Err(err)
+        } else {
+            println!("[WARN] Skipping withdraw amount checks {}",err)
+        }
+    };
     put_transaction_rpc_handler(rpc_id, node_address, verbosity_level, transaction)
         .await
         .map_err(CliError::from)

--- a/src/transaction/creation_common.rs
+++ b/src/transaction/creation_common.rs
@@ -1835,7 +1835,6 @@ pub(super) mod withdraw_bid {
     fn add_args(withdraw_bid_subcommand: Command) -> Command {
         withdraw_bid_subcommand
             .arg(public_key::arg(DisplayOrder::PublicKey as usize))
-            .arg(min_bid_override::arg())
             .arg(transaction_amount::arg())
     }
 }
@@ -2192,7 +2191,6 @@ pub(super) mod invocable_entity {
             .arg(transaction_runtime::arg())
             .arg(transferred_value::arg())
             .arg(chunked_args::arg())
-            .arg(min_bid_override::arg())
     }
 }
 
@@ -2241,7 +2239,6 @@ pub(super) mod invocable_entity_alias {
         invocable_entity_alias_subcommand
             .arg(entity_alias_arg::arg())
             .arg(session_entry_point::arg())
-            .arg(min_bid_override::arg())
             .arg(transaction_runtime::arg())
             .arg(transferred_value::arg())
             .arg(chunked_args::arg())
@@ -2312,7 +2309,6 @@ pub(super) mod package {
             .arg(chunked_args::arg())
             .arg(major_version::arg())
             .arg(session_entry_point::arg())
-            .arg(min_bid_override::arg())
     }
 }
 
@@ -2373,7 +2369,6 @@ pub(super) mod package_alias {
             .arg(chunked_args::arg())
             .arg(major_version::arg())
             .arg(session_entry_point::arg())
-            .arg(min_bid_override::arg())
     }
 }
 
@@ -2667,6 +2662,7 @@ pub(super) fn build_transaction_str_params(
             additional_computation_factor,
             receipt,
             standard_payment,
+            min_bid_override,
             ..Default::default()
         }
     }
@@ -2705,12 +2701,16 @@ fn get_transaction_runtime(matches: &ArgMatches) -> Result<TransactionRuntimePar
 
 #[cfg(test)]
 mod tests {
-    use super::is_install_upgrade;
+    use super::{is_install_upgrade, min_bid_override};
     use clap::Command;
 
     // Helper function to build a command with `is_install_upgrade` argument
     fn build_app() -> Command {
         Command::new("put-transaction session").arg(is_install_upgrade::arg(1))
+    }
+
+    fn build_withdraw() -> Command {
+        Command::new("put-transaction withdraw-bid").arg(min_bid_override::arg())
     }
 
     #[test]
@@ -2733,5 +2733,16 @@ mod tests {
 
         // Assert that `get` returns false when the flag is absent
         assert!(!is_install_upgrade::get(&matches));
+    }
+
+    #[test]
+    fn test_is_min_bid_override_accepted() {
+        // Simulate running with the `--install-upgrade` flag
+        let matches = build_withdraw()
+            .try_get_matches_from(vec!["put-transaction withdraw-bid", "--min-bid-override"])
+            .unwrap();
+
+        // Assert that `get` returns true when the flag is present
+        assert!(min_bid_override::get(&matches));
     }
 }


### PR DESCRIPTION
Fixes an issue in the `put-transaction` flow which would skip checking the amount checks for withdraw bid
Fixes an issue which would cause the `min-bid-override` flag to be ignored